### PR TITLE
chore: bump rustarr + xtask to Rust edition 2024

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Bumped to Rust edition 2024** (both the `rustarr` and `xtask` crates). Wrapped
+  the now-`unsafe` `std::env::set_var`/`remove_var` calls in `unsafe {}` blocks with
+  SAFETY justifications, collapsed nested `if let` into stabilized let-chains, and
+  reformatted the tree under the 2024 rustfmt style edition.
+
 ### Added
 
 - **Curated service-grouped command surface (epic).** rustarr moved from a single

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Hardened the `.env` loader against key injection.** `load_dotenv_defaults`
+  now only injects keys in rustarr's own namespace (`RUSTARR_*`) plus the
+  documented `RUST_LOG`; any other key in a `$RUSTARR_HOME/.env` is skipped with a
+  warning instead of being written into the process environment. This prevents a
+  writable `.env` from smuggling in process-wide variables such as `PATH`,
+  `LD_PRELOAD`, or `SSL_CERT_FILE`. Values containing a null byte are now rejected
+  instead of panicking `std::env::set_var`.
+
 ### Changed
 
 - **Bumped to Rust edition 2024** (both the `rustarr` and `xtask` crates). Wrapped

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ resolver = "2"
 [package]
 name = "rustarr"
 version = "0.4.0"
-edition = "2021"
+edition = "2024"
 rust-version = "1.90"
 description = "MCP and CLI server for media automation fleets"
 autobins = false

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -204,7 +204,7 @@ Zero validation, zero defaults, zero error message crafting in shims. All of tha
 ## Modern Rust requirements
 
 - No `mod.rs` files — use named module files (`mcp.rs` + `mcp/tools.rs`)
-- Rust 2021 edition minimum, target 2024 where possible
+- Rust 2024 edition
 - `thiserror` for structured error types in the service layer
 - `?` operator chains over nested `match`
 - Avoid `unwrap()`/`expect()` in production paths

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -2431,7 +2431,7 @@ fi
 
 ### Other modern Rust requirements
 
-- Rust 2021 edition minimum, target 2024 where possible
+- Rust 2024 edition
 - Use `async fn` in traits where the crate supports it (rmcp 1.6+ does)
 - Prefer `?` operator chains over nested `match`
 - `#[must_use]` on functions returning `Result` or important values

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -11,7 +11,7 @@ Maintenance and automation scripts for the template. Shell scripts are written f
 | `build-web.sh` | Build the Next.js web UI static export (`apps/web/out/`). |
 | `bump-version.sh` | Update version-bearing files from the `Cargo.toml` version. |
 | `check-blob-size.py` | Block unexpectedly large changed blobs. |
-| `check-coupled-files.sh` | Warn when files that normally change together drift. |
+| `check-coupled-files.sh` | Warn when files that normally change together drift. The `schemas.rs` ↔ `docs/MCP_SCHEMA.md` pair defers to `check-schema-docs.py --check`, so formatting-only edits do not false-positive. |
 | `check-dependency-updates.sh` | Report lockfile-compatible and latest dependency updates. |
 | `check-file-size.sh` | Pre-commit source file size budget. |
 | `check-plugin-hook-contract.py` | Audit plugin setup hook contract across Rust MCP servers. |

--- a/scripts/check-coupled-files.sh
+++ b/scripts/check-coupled-files.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 
 BASE="${1:-origin/main}"
 HEAD="${2:-HEAD}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 if ! git rev-parse --verify "$BASE" >/dev/null 2>&1; then
   BASE="HEAD~1"
@@ -35,7 +36,13 @@ if changed "scripts/*" && ! changed "scripts/README.md"; then
 fi
 
 if changed "src/mcp/schemas.rs" && ! changed "docs/MCP_SCHEMA.md"; then
-  issues+=("src/mcp/schemas.rs changed but docs/MCP_SCHEMA.md did not; run scripts/check-schema-docs.py --write.")
+  # docs/MCP_SCHEMA.md is generated from the action specs, so a formatting-only
+  # change to schemas.rs (e.g. import reordering) leaves it byte-identical. Defer
+  # to the authoritative generator check and only flag a genuine drift, so this
+  # coupling does not false-positive on cosmetic edits.
+  if ! python3 "$SCRIPT_DIR/check-schema-docs.py" --check >/dev/null 2>&1; then
+    issues+=("src/mcp/schemas.rs changed and docs/MCP_SCHEMA.md is stale; run scripts/check-schema-docs.py --write.")
+  fi
 fi
 
 if changed "plugins/rustarr/*" && ! changed "docs/PLUGINS.md"; then

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -26,16 +26,16 @@ pub mod registry;
 pub use dispatch::execute_service_action;
 pub use help::rest_help;
 pub use model::{
-    is_validation_error, scopes_satisfy, ActionSpec, ActionTransport, RustarrAction,
-    ValidationError, DENY_SCOPE, READ_SCOPE, WRITE_SCOPE,
+    ActionSpec, ActionTransport, DENY_SCOPE, READ_SCOPE, RustarrAction, ValidationError,
+    WRITE_SCOPE, is_validation_error, scopes_satisfy,
 };
 pub use parse::{bool_arg, optional_string, string_arg};
 pub use registry::{
-    action_allowed_for_kind, action_names, all_action_names, allowed_kind_names_for_action,
-    capability_digest, curated_command, curated_command_names, curated_commands,
-    curated_param_names, is_known_action, is_rest_action, mcp_only_action_names,
-    required_params_for_action, required_scope_for_action, rest_action_names,
-    valid_actions_for_kind, CommandDescriptor, CommandFuture, CommandHandler, ACTION_SPECS,
+    ACTION_SPECS, CommandDescriptor, CommandFuture, CommandHandler, action_allowed_for_kind,
+    action_names, all_action_names, allowed_kind_names_for_action, capability_digest,
+    curated_command, curated_command_names, curated_commands, curated_param_names, is_known_action,
+    is_rest_action, mcp_only_action_names, required_params_for_action, required_scope_for_action,
+    rest_action_names, valid_actions_for_kind,
 };
 
 #[cfg(test)]

--- a/src/actions/commands/arr.rs
+++ b/src/actions/commands/arr.rs
@@ -25,8 +25,7 @@ pub const ARR_COMMANDS: &[CommandDescriptor] = &[
     CommandDescriptor {
         name: "quality_profiles",
         capability: Capability::ArrManager,
-        description:
-            "list the configured quality profiles (id + name) for a sonarr/radarr service.",
+        description: "list the configured quality profiles (id + name) for a sonarr/radarr service.",
         required_scope: READ_SCOPE,
         required_params: &["service"],
         optional_params: &[],
@@ -128,8 +127,7 @@ pub const ARR_COMMANDS: &[CommandDescriptor] = &[
     CommandDescriptor {
         name: "refresh",
         capability: Capability::ArrManager,
-        description:
-            "start an ASYNC refresh/rescan job (POST /command). Fire-and-forget — does not \
+        description: "start an ASYNC refresh/rescan job (POST /command). Fire-and-forget — does not \
              poll. Confirm required.",
         required_scope: WRITE_SCOPE,
         required_params: &["service"],

--- a/src/actions/commands/indexer.rs
+++ b/src/actions/commands/indexer.rs
@@ -27,8 +27,7 @@ pub const INDEXER_COMMANDS: &[CommandDescriptor] = &[
     CommandDescriptor {
         name: "indexers",
         capability: Capability::Indexer,
-        description:
-            "list the configured indexers (id, name, enable, protocol, priority), slimmed.",
+        description: "list the configured indexers (id, name, enable, protocol, priority), slimmed.",
         required_scope: READ_SCOPE,
         required_params: &["service"],
         optional_params: &[],

--- a/src/actions/commands/requests_tests.rs
+++ b/src/actions/commands/requests_tests.rs
@@ -1,6 +1,6 @@
 use super::REQUEST_COMMANDS;
 use crate::actions::model::{READ_SCOPE, WRITE_SCOPE};
-use crate::actions::{curated_command, required_scope_for_action, RustarrAction};
+use crate::actions::{RustarrAction, curated_command, required_scope_for_action};
 use crate::capability::Capability;
 use serde_json::json;
 

--- a/src/actions/commands/stats_tests.rs
+++ b/src/actions/commands/stats_tests.rs
@@ -1,6 +1,6 @@
 use super::STATS_COMMANDS;
 use crate::actions::model::READ_SCOPE;
-use crate::actions::{curated_command, required_scope_for_action, RustarrAction};
+use crate::actions::{RustarrAction, curated_command, required_scope_for_action};
 use crate::capability::Capability;
 use serde_json::json;
 

--- a/src/actions/help.rs
+++ b/src/actions/help.rs
@@ -8,13 +8,13 @@
 //! than a static const that drifts) so curated commands appear automatically and
 //! a compact capability digest (AN-1/AN-3) aids first-try action selection.
 
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
+use super::WRITE_SCOPE;
 use super::registry::{
     all_action_names, capability_digest, curated_command, mcp_only_action_names,
     required_params_for_action, required_scope_for_action, rest_action_names,
 };
-use super::WRITE_SCOPE;
 
 pub fn rest_help() -> Value {
     json!({
@@ -36,12 +36,22 @@ pub fn rest_help() -> Value {
 /// carry their own `description` in their descriptor.
 fn generic_description(action: &str) -> &'static str {
     match action {
-        "integrations" => "list supported and configured integrations, with per-service capability and available actions.",
-        "service_status" => "call the default status endpoint for a configured service. Requires `service`.",
+        "integrations" => {
+            "list supported and configured integrations, with per-service capability and available actions."
+        }
+        "service_status" => {
+            "call the default status endpoint for a configured service. Requires `service`."
+        }
         "api_get" => "GET a safe relative path. Requires `service` and `path`.",
-        "api_post" => "POST JSON to a safe relative path. Requires `service`, `path`, and `confirm=true`; optional `body` defaults to `{}`.",
-        "api_put" => "PUT JSON to a safe relative path. Requires `service`, `path`, and `confirm=true`; optional `body` defaults to `{}`.",
-        "api_delete" => "DELETE a safe relative path. Requires `service`, `path`, and `confirm=true`; optional `body`. Query params go in `path`.",
+        "api_post" => {
+            "POST JSON to a safe relative path. Requires `service`, `path`, and `confirm=true`; optional `body` defaults to `{}`."
+        }
+        "api_put" => {
+            "PUT JSON to a safe relative path. Requires `service`, `path`, and `confirm=true`; optional `body` defaults to `{}`."
+        }
+        "api_delete" => {
+            "DELETE a safe relative path. Requires `service`, `path`, and `confirm=true`; optional `body`. Query params go in `path`."
+        }
         "help" => "return this help text.",
         _ => "",
     }

--- a/src/actions/parse.rs
+++ b/src/actions/parse.rs
@@ -2,7 +2,7 @@
 //! from MCP args / REST params.
 
 use anyhow::Result;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 use super::model::{ActionTransport, RustarrAction, ValidationError};
 use super::registry::{action_spec, curated_command};

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,11 +1,11 @@
 //! Business service layer.
 
-use anyhow::{anyhow, Result};
-use serde_json::{json, Value};
+use anyhow::{Result, anyhow};
+use serde_json::{Value, json};
 
 use crate::{
     config::{RustarrConfig, ServiceConfig, ServiceKind},
-    rustarr::{validate_safe_path, RustarrClient},
+    rustarr::{RustarrClient, validate_safe_path},
 };
 
 pub mod arr;

--- a/src/app/arr/editor.rs
+++ b/src/app/arr/editor.rs
@@ -3,8 +3,8 @@
 //! testable building blocks each stay well under the 500-LOC cap. Everything
 //! here is deterministic and unit-tested directly (see `write_tests.rs`).
 
-use anyhow::{anyhow, Result};
-use serde_json::{json, Map, Value};
+use anyhow::{Result, anyhow};
+use serde_json::{Map, Value, json};
 
 use crate::app::arr::read::arr_resource_noun;
 use crate::config::ServiceKind;
@@ -238,11 +238,11 @@ pub(crate) fn select_by_profile(rows: &[Value], from_id: i64) -> Selection {
     let mut ids = Vec::new();
     let mut titles = Vec::new();
     for row in rows {
-        if row.get("qualityProfileId").and_then(Value::as_i64) == Some(from_id) {
-            if let Some(id) = row_id(row) {
-                ids.push(id);
-                titles.push(row_title(row));
-            }
+        if row.get("qualityProfileId").and_then(Value::as_i64) == Some(from_id)
+            && let Some(id) = row_id(row)
+        {
+            ids.push(id);
+            titles.push(row_title(row));
         }
     }
     Selection { ids, titles }

--- a/src/app/arr/editor_tests.rs
+++ b/src/app/arr/editor_tests.rs
@@ -5,10 +5,10 @@
 //! so a mutation attempt would surface a transport error instead of a preview).
 
 use super::{
-    command_body_plural, command_body_single, editor_id_key, editor_monitor_body,
-    editor_quality_body, guard_count, kind_command_supports_plural_ids, refresh_command_name,
-    search_command_name, select_all, select_by_ids, select_by_profile, select_by_titles,
-    set_quality_preview, Selection, MAX_BULK,
+    MAX_BULK, Selection, command_body_plural, command_body_single, editor_id_key,
+    editor_monitor_body, editor_quality_body, guard_count, kind_command_supports_plural_ids,
+    refresh_command_name, search_command_name, select_all, select_by_ids, select_by_profile,
+    select_by_titles, set_quality_preview,
 };
 use crate::config::ServiceKind;
 use serde_json::json;

--- a/src/app/arr/read_tests.rs
+++ b/src/app/arr/read_tests.rs
@@ -1,7 +1,7 @@
-use super::{arr_path, arr_resource_noun, LIST_FIELDS};
+use super::{LIST_FIELDS, arr_path, arr_resource_noun};
 use crate::app::RustarrService;
 use crate::config::{RustarrConfig, ServiceConfig, ServiceKind};
-use crate::rustarr::{slim, RustarrClient};
+use crate::rustarr::{RustarrClient, slim};
 use serde_json::json;
 
 fn service_with(kinds: &[(&str, ServiceKind)]) -> RustarrService {

--- a/src/app/arr/resolve.rs
+++ b/src/app/arr/resolve.rs
@@ -5,7 +5,7 @@
 //! app layer (business logic) — never in a shim — and resolve a human-friendly
 //! name to the numeric id the upstream *arr API expects.
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use serde_json::Value;
 
 use crate::app::RustarrService;
@@ -46,10 +46,10 @@ pub(crate) fn match_quality_profile_id(profiles: &Value, name: &str) -> Result<i
     for profile in &items {
         let pname = profile.get("name").and_then(Value::as_str).unwrap_or("");
         available.push(pname.to_owned());
-        if pname.trim().to_ascii_lowercase() == needle {
-            if let Some(id) = profile.get("id").and_then(Value::as_i64) {
-                return Ok(id);
-            }
+        if pname.trim().to_ascii_lowercase() == needle
+            && let Some(id) = profile.get("id").and_then(Value::as_i64)
+        {
+            return Ok(id);
         }
     }
     Err(anyhow!(

--- a/src/app/arr/write.rs
+++ b/src/app/arr/write.rs
@@ -22,19 +22,19 @@
 //! `{seriesIds|movieIds, qualityProfileId}`; `/command` is async fire-and-forget
 //! with CASE-SENSITIVE command names; the editor id key is `{resource_noun}Ids`.
 
-use anyhow::{anyhow, Result};
-use serde_json::{json, Value};
+use anyhow::{Result, anyhow};
+use serde_json::{Value, json};
 
+use crate::app::RustarrService;
 use crate::app::arr::editor::{
-    build_add_body, command_body_plural, command_body_single, editor_apply_summary,
+    Selection, build_add_body, command_body_plural, command_body_single, editor_apply_summary,
     editor_id_key_singular, editor_monitor_body, editor_quality_body, guard_count,
     kind_command_supports_plural_ids, refresh_command_name, row_title, search_command_name,
     select_all, select_by_ids, select_by_profile, select_by_titles, set_quality_preview,
-    value_preview, value_shape, Selection,
+    value_preview, value_shape,
 };
 use crate::app::arr::read::{arr_path, arr_resource_noun};
 use crate::app::util::urlencode;
-use crate::app::RustarrService;
 use crate::capability::Capability;
 use crate::config::ServiceConfig;
 

--- a/src/app/arr/write_tests.rs
+++ b/src/app/arr/write_tests.rs
@@ -3,8 +3,8 @@
 //! assert the methods reject the wrong capability before any network call and
 //! that the headline `set_quality` request struct threads through unchanged.
 
-use crate::app::arr::write::SetQualityRequest;
 use crate::app::RustarrService;
+use crate::app::arr::write::SetQualityRequest;
 use crate::config::{RustarrConfig, ServiceConfig, ServiceKind};
 use crate::rustarr::RustarrClient;
 

--- a/src/app/download/qbit.rs
+++ b/src/app/download/qbit.rs
@@ -13,7 +13,7 @@
 //! module targets the v5 `stop`/`start` names.
 
 use anyhow::Result;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 use crate::app::RustarrService;
 use crate::config::ServiceConfig;

--- a/src/app/download/qbit_tests.rs
+++ b/src/app/download/qbit_tests.rs
@@ -1,9 +1,9 @@
 use crate::app::RustarrService;
 use crate::config::{RustarrConfig, ServiceConfig, ServiceKind};
-use crate::rustarr::{slim, RustarrClient};
+use crate::rustarr::{RustarrClient, slim};
 use serde_json::json;
 
-use super::{qbit_path, TORRENT_FIELDS};
+use super::{TORRENT_FIELDS, qbit_path};
 
 fn qbit_config() -> ServiceConfig {
     ServiceConfig {

--- a/src/app/download/sab.rs
+++ b/src/app/download/sab.rs
@@ -11,7 +11,7 @@
 //! removed `nzo_ids` are surfaced for the caller to verify.
 
 use anyhow::Result;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 use crate::app::RustarrService;
 use crate::config::ServiceConfig;

--- a/src/app/download/sab_tests.rs
+++ b/src/app/download/sab_tests.rs
@@ -1,6 +1,6 @@
 use crate::app::RustarrService;
 use crate::config::{RustarrConfig, ServiceConfig, ServiceKind};
-use crate::rustarr::{query_get, slim, RustarrClient};
+use crate::rustarr::{RustarrClient, query_get, slim};
 use serde_json::json;
 
 use super::{QUEUE_FIELDS, SAB_API};

--- a/src/app/indexer.rs
+++ b/src/app/indexer.rs
@@ -14,8 +14,8 @@
 use anyhow::Result;
 use serde_json::Value;
 
-use crate::app::util::urlencode;
 use crate::app::RustarrService;
+use crate::app::util::urlencode;
 use crate::capability::Capability;
 use crate::config::ServiceConfig;
 use crate::rustarr::slim;

--- a/src/app/indexer_tests.rs
+++ b/src/app/indexer_tests.rs
@@ -1,6 +1,6 @@
 use crate::app::RustarrService;
 use crate::config::{RustarrConfig, ServiceConfig, ServiceKind};
-use crate::rustarr::{slim, RustarrClient};
+use crate::rustarr::{RustarrClient, slim};
 use serde_json::json;
 
 use super::{INDEXER_FIELDS, STATS_FIELDS};

--- a/src/app/media_server/jellyfin.rs
+++ b/src/app/media_server/jellyfin.rs
@@ -16,7 +16,7 @@
 //! query parameter (S6).
 
 use anyhow::Result;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 use crate::app::RustarrService;
 use crate::config::ServiceConfig;

--- a/src/app/media_server/jellyfin_tests.rs
+++ b/src/app/media_server/jellyfin_tests.rs
@@ -1,6 +1,6 @@
 use crate::app::RustarrService;
 use crate::config::{RustarrConfig, ServiceConfig, ServiceKind};
-use crate::rustarr::{build_url, query_get, slim, RustarrClient};
+use crate::rustarr::{RustarrClient, build_url, query_get, slim};
 use serde_json::json;
 
 use super::{LIBRARY_FIELDS, SEARCH_FIELDS, SEARCH_ITEM_TYPES, SESSION_FIELDS};

--- a/src/app/media_server/plex.rs
+++ b/src/app/media_server/plex.rs
@@ -19,7 +19,7 @@
 //! for library sections) before field selection.
 
 use anyhow::Result;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 use crate::app::RustarrService;
 use crate::config::ServiceConfig;

--- a/src/app/media_server/plex_tests.rs
+++ b/src/app/media_server/plex_tests.rs
@@ -1,6 +1,6 @@
 use crate::app::RustarrService;
 use crate::config::{RustarrConfig, ServiceConfig, ServiceKind};
-use crate::rustarr::{build_url, query_get, slim, RustarrClient};
+use crate::rustarr::{RustarrClient, build_url, query_get, slim};
 use serde_json::json;
 
 use super::{LIBRARY_FIELDS, SEARCH_FIELDS, SESSION_FIELDS};

--- a/src/app/requests.rs
+++ b/src/app/requests.rs
@@ -16,10 +16,10 @@
 //! a user-scoped key returns 403. This is documented in the command help text.
 
 use anyhow::Result;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
-use crate::app::util::urlencode;
 use crate::app::RustarrService;
+use crate::app::util::urlencode;
 use crate::capability::Capability;
 use crate::config::ServiceConfig;
 use crate::rustarr::slim;

--- a/src/app/requests_tests.rs
+++ b/src/app/requests_tests.rs
@@ -1,6 +1,6 @@
 use crate::app::RustarrService;
 use crate::config::{RustarrConfig, ServiceConfig, ServiceKind};
-use crate::rustarr::{slim, RustarrClient};
+use crate::rustarr::{RustarrClient, slim};
 use serde_json::json;
 
 use super::{REQUEST_FIELDS, SEARCH_FIELDS};

--- a/src/app/stats.rs
+++ b/src/app/stats.rs
@@ -21,7 +21,7 @@
 //! decisions and live here, never in a shim.
 
 use anyhow::Result;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 use crate::app::RustarrService;
 use crate::capability::Capability;

--- a/src/app/stats_tests.rs
+++ b/src/app/stats_tests.rs
@@ -1,10 +1,10 @@
 use crate::app::RustarrService;
 use crate::config::{RustarrConfig, ServiceConfig, ServiceKind};
-use crate::rustarr::{query_get, slim, RustarrClient};
+use crate::rustarr::{RustarrClient, query_get, slim};
 use serde_json::json;
 
 use super::{
-    unwrap_tautulli, HISTORY_FIELDS, LIBRARY_FIELDS, SESSION_FIELDS, TAUTULLI_API, USER_FIELDS,
+    HISTORY_FIELDS, LIBRARY_FIELDS, SESSION_FIELDS, TAUTULLI_API, USER_FIELDS, unwrap_tautulli,
 };
 
 fn service_with(kinds: &[(&str, ServiceKind)]) -> RustarrService {

--- a/src/app_tests.rs
+++ b/src/app_tests.rs
@@ -28,9 +28,10 @@ fn integrations_omits_secret_values() {
 fn service_of_capability_matches_and_rejects() {
     let svc = service();
     // Sonarr is an ArrManager — resolving for that capability succeeds.
-    assert!(svc
-        .service_of_capability("sonarr", Capability::ArrManager)
-        .is_ok());
+    assert!(
+        svc.service_of_capability("sonarr", Capability::ArrManager)
+            .is_ok()
+    );
     // Resolving the same service for a mismatched capability fails closed.
     let err = svc
         .service_of_capability("sonarr", Capability::MediaServer)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -48,7 +48,7 @@ pub mod usage;
 pub mod watch;
 
 pub use command::Command;
-pub use setup::{apply_plugin_options, run_setup, SetupCommand};
+pub use setup::{SetupCommand, apply_plugin_options, run_setup};
 pub use usage::usage;
 
 /// Parse CLI arguments from `std::env::args()`.

--- a/src/cli/commands/arr.rs
+++ b/src/cli/commands/arr.rs
@@ -6,8 +6,8 @@
 //! business logic lives in `crate::app::arr`; validation/scope/dispatch flow
 //! through the shared `execute_service_action` path, exactly like the MCP shim.
 
-use anyhow::{anyhow, Result};
-use serde_json::{json, Map, Value};
+use anyhow::{Result, anyhow};
+use serde_json::{Map, Value, json};
 
 use crate::actions::curated_command;
 use crate::capability::Capability;

--- a/src/cli/commands/download.rs
+++ b/src/cli/commands/download.rs
@@ -9,8 +9,8 @@
 //! and dispatch flow through the shared `execute_service_action` path, exactly
 //! like the MCP shim.
 
-use anyhow::{anyhow, Result};
-use serde_json::{json, Map, Value};
+use anyhow::{Result, anyhow};
+use serde_json::{Map, Value, json};
 
 use crate::actions::curated_command;
 use crate::capability::Capability;

--- a/src/cli/commands/indexer.rs
+++ b/src/cli/commands/indexer.rs
@@ -8,8 +8,8 @@
 //! validation/scope/dispatch flow through the shared `execute_service_action`
 //! path, exactly like the MCP shim.
 
-use anyhow::{anyhow, Result};
-use serde_json::{json, Map, Value};
+use anyhow::{Result, anyhow};
+use serde_json::{Map, Value, json};
 
 use crate::actions::curated_command;
 use crate::capability::Capability;

--- a/src/cli/commands/media_server.rs
+++ b/src/cli/commands/media_server.rs
@@ -9,8 +9,8 @@
 //! `crate::app::media_server`; validation, scope, and dispatch flow through the
 //! shared `execute_service_action` path, exactly like the MCP shim.
 
-use anyhow::{anyhow, Result};
-use serde_json::{json, Map, Value};
+use anyhow::{Result, anyhow};
+use serde_json::{Map, Value, json};
 
 use crate::actions::curated_command;
 use crate::capability::Capability;

--- a/src/cli/commands/requests.rs
+++ b/src/cli/commands/requests.rs
@@ -10,8 +10,8 @@
 //! `crate::app::requests`; validation, scope, and dispatch flow through the shared
 //! `execute_service_action` path, exactly like the MCP shim.
 
-use anyhow::{anyhow, Result};
-use serde_json::{json, Map, Value};
+use anyhow::{Result, anyhow};
+use serde_json::{Map, Value, json};
 
 use crate::actions::curated_command;
 use crate::capability::Capability;

--- a/src/cli/commands/stats.rs
+++ b/src/cli/commands/stats.rs
@@ -10,8 +10,8 @@
 //! validation, scope, and dispatch flow through the shared `execute_service_action`
 //! path, exactly like the MCP shim.
 
-use anyhow::{anyhow, Result};
-use serde_json::{json, Map, Value};
+use anyhow::{Result, anyhow};
+use serde_json::{Map, Value, json};
 
 use crate::actions::curated_command;
 use crate::capability::Capability;

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -32,10 +32,10 @@ use checks::{
     check_port_available, check_required_var, check_upstream,
 };
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use serde::Serialize;
 
-use crate::config::{default_data_dir, Config};
+use crate::config::{Config, default_data_dir};
 use crate::{app::RustarrService, rustarr::RustarrClient};
 
 // ── Public entry point ────────────────────────────────────────────────────────

--- a/src/cli/doctor/checks.rs
+++ b/src/cli/doctor/checks.rs
@@ -19,7 +19,7 @@ use std::time::Instant;
 use crate::{
     app::RustarrService,
     config::Config,
-    server::{resolve_auth_policy_kind, AuthPolicyKind},
+    server::{AuthPolicyKind, resolve_auth_policy_kind},
 };
 
 use super::DoctorCheck;

--- a/src/cli/parse.rs
+++ b/src/cli/parse.rs
@@ -7,7 +7,7 @@
 //! reuse these helpers (notably the selector parsers `--from`/`--to`/`--title`/
 //! `--id`) when later beads add curated commands.
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 
 /// Error if any tokens remain — used by argument-less commands.
 pub fn reject_args(args: &[String], command: &str) -> Result<()> {

--- a/src/cli/parse_tests.rs
+++ b/src/cli/parse_tests.rs
@@ -1,6 +1,6 @@
 use super::{
-    parse_bool_flag, parse_passthrough_flags, parse_selectors, parse_watch_flags, reject_args,
-    Selectors,
+    Selectors, parse_bool_flag, parse_passthrough_flags, parse_selectors, parse_watch_flags,
+    reject_args,
 };
 
 #[test]

--- a/src/cli/router.rs
+++ b/src/cli/router.rs
@@ -21,7 +21,7 @@
 //! construction; `router_tests::infra_verbs_disjoint_from_service_kinds`
 //! asserts this so a future kind can never collide with an infra verb.
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 
 use super::command::Command;
 use super::parse::{parse_bool_flag, parse_passthrough_flags, parse_watch_flags, reject_args};

--- a/src/cli/router_tests.rs
+++ b/src/cli/router_tests.rs
@@ -1,4 +1,4 @@
-use super::{is_infra_verb, parse_capability_command, route, INFRA_VERBS};
+use super::{INFRA_VERBS, is_infra_verb, parse_capability_command, route};
 use crate::config::ServiceKind;
 
 /// Architecture F3-a invariant: the infra-verb set and the ServiceKind name set

--- a/src/cli/setup.rs
+++ b/src/cli/setup.rs
@@ -13,11 +13,11 @@ mod plugin;
 mod wizard;
 
 pub use plugin::apply_plugin_options;
-pub use wizard::{run_setup, SetupCommand};
+pub use wizard::{SetupCommand, run_setup};
 
 // Re-export internal items used by the colocated tests via `super::*`/`super::`.
 #[cfg(test)]
-pub(crate) use wizard::{dotenv_assignment, setup_check, setup_repair, SetupFailure, SetupReport};
+pub(crate) use wizard::{SetupFailure, SetupReport, dotenv_assignment, setup_check, setup_repair};
 
 #[cfg(test)]
 #[path = "setup_tests.rs"]

--- a/src/cli/setup/plugin.rs
+++ b/src/cli/setup/plugin.rs
@@ -95,9 +95,11 @@ pub fn apply_plugin_options() {
             eprintln!("rustarr setup: {option_var} must not contain newlines; skipping");
             continue;
         }
-        // SAFETY (edition 2021): set_var is not marked unsafe on this edition.
-        // This runs single-threaded before any worker threads are spawned.
-        std::env::set_var(rustarr_var, value);
+        // SAFETY: runs single-threaded before any worker threads are spawned,
+        // so there is no concurrent env access.
+        unsafe {
+            std::env::set_var(rustarr_var, value);
+        }
     }
 }
 

--- a/src/cli/setup/plugin.rs
+++ b/src/cli/setup/plugin.rs
@@ -95,8 +95,11 @@ pub fn apply_plugin_options() {
             eprintln!("rustarr setup: {option_var} must not contain newlines; skipping");
             continue;
         }
-        // SAFETY: runs single-threaded before any worker threads are spawned,
-        // so there is no concurrent env access.
+        // SAFETY: runs during early CLI startup, before `Config::load()` and
+        // before any task that reads the process environment is spawned onto the
+        // runtime, so there is no concurrent env access. (The tokio worker
+        // threads that exist at this point are parked and do not touch the
+        // environment.)
         unsafe {
             std::env::set_var(rustarr_var, value);
         }

--- a/src/cli/setup/wizard.rs
+++ b/src/cli/setup/wizard.rs
@@ -5,10 +5,10 @@ use std::net::TcpListener;
 use std::path::{Path, PathBuf};
 
 use crate::{
-    config::{default_data_dir, AuthMode, Config},
+    config::{AuthMode, Config, default_data_dir},
     server::resolve_auth_policy_kind,
 };
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 
 // ── public surface ────────────────────────────────────────────────────────────
 

--- a/src/cli/setup_tests.rs
+++ b/src/cli/setup_tests.rs
@@ -141,10 +141,12 @@ fn setup_check_reports_missing_env_as_advisory() {
 
     assert!(report.blocking_failures.is_empty());
     assert_eq!(report.exit_policy, "advisory_failure");
-    assert!(report
-        .advisory_failures
-        .iter()
-        .any(|failure| failure.code == "env_file_missing"));
+    assert!(
+        report
+            .advisory_failures
+            .iter()
+            .any(|failure| failure.code == "env_file_missing")
+    );
 }
 
 #[test]
@@ -179,10 +181,12 @@ fn setup_check_blocks_when_port_is_already_bound() {
 
     let report = with_plugin_data(dir.path(), || super::setup_check(&config, true));
 
-    assert!(report
-        .blocking_failures
-        .iter()
-        .any(|failure| failure.code == "mcp_port_in_use"));
+    assert!(
+        report
+            .blocking_failures
+            .iter()
+            .any(|failure| failure.code == "mcp_port_in_use")
+    );
 }
 
 #[test]

--- a/src/cli_tests.rs
+++ b/src/cli_tests.rs
@@ -1,4 +1,4 @@
-use super::{parse_args_from, usage, Command, SetupCommand};
+use super::{Command, SetupCommand, parse_args_from, usage};
 use serde_json::json;
 
 #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -199,8 +199,10 @@ fn load_dotenv_defaults() -> anyhow::Result<()> {
         if std::env::var_os(key).is_some() {
             continue;
         }
-        // SAFETY: runs single-threaded during startup config load, before any
-        // worker threads are spawned, so there is no concurrent env access.
+        // SAFETY: runs during early startup config load, before any task that
+        // reads the process environment is spawned onto the runtime, so there is
+        // no concurrent env access. (The tokio worker threads that exist at this
+        // point are parked and do not touch the environment.)
         unsafe {
             std::env::set_var(key, parse_dotenv_value(raw_value.trim())?);
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -193,21 +193,49 @@ fn load_dotenv_defaults() -> anyhow::Result<()> {
             anyhow::bail!("{}:{}: expected KEY=VALUE", path.display(), line_no + 1);
         };
         let key = key.trim();
-        if key.is_empty() || key.contains(char::is_whitespace) {
+        if key.is_empty() || key.contains(char::is_whitespace) || key.contains('\0') {
             anyhow::bail!("{}:{}: invalid env key", path.display(), line_no + 1);
+        }
+        // Only inject keys in rustarr's own namespace (plus the documented
+        // `RUST_LOG`). A `.env` lives in a writable appdata dir, so without this
+        // an attacker who can write it could smuggle in process-wide vars such as
+        // `PATH`, `LD_PRELOAD`, or `SSL_CERT_FILE`. Skip-and-warn rather than bail
+        // so an unexpected key never hard-fails startup.
+        if !is_injectable_env_key(key) {
+            tracing::warn!(
+                key,
+                file = %path.display(),
+                "ignoring non-RUSTARR key in .env; only RUSTARR_* and RUST_LOG are loaded"
+            );
+            continue;
         }
         if std::env::var_os(key).is_some() {
             continue;
+        }
+        let value = parse_dotenv_value(raw_value.trim())?;
+        if value.contains('\0') {
+            anyhow::bail!(
+                "{}:{}: env value contains a null byte",
+                path.display(),
+                line_no + 1
+            );
         }
         // SAFETY: runs during early startup config load, before any task that
         // reads the process environment is spawned onto the runtime, so there is
         // no concurrent env access. (The tokio worker threads that exist at this
         // point are parked and do not touch the environment.)
         unsafe {
-            std::env::set_var(key, parse_dotenv_value(raw_value.trim())?);
+            std::env::set_var(key, value);
         }
     }
     Ok(())
+}
+
+/// Keys a `.env` file is allowed to inject into the process environment:
+/// rustarr's own `RUSTARR_*` namespace, plus the documented `RUST_LOG`. Anything
+/// else is skipped so a writable `.env` cannot smuggle in process-wide variables.
+fn is_injectable_env_key(key: &str) -> bool {
+    key.starts_with("RUSTARR_") || key == "RUST_LOG"
 }
 
 fn parse_dotenv_value(raw: &str) -> anyhow::Result<String> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,12 +21,12 @@ pub mod services;
 // paths keep working unchanged.
 pub use auth::{AuthConfig, AuthMode};
 pub use mcp::McpConfig;
-pub use services::{default_data_dir, ServiceConfig, ServiceKind};
+pub use services::{ServiceConfig, ServiceKind, default_data_dir};
 
 // Bring the private env helpers into this module's scope. They are used by
 // `Config::load` below and exercised by the colocated tests via `super::*`.
 use mcp::{env_bool, env_list, env_opt_str, env_parse, env_str};
-use services::{load_services_from_env, SERVICE_HOME_DIRNAME};
+use services::{SERVICE_HOME_DIRNAME, load_services_from_env};
 
 /// Top-level config (maps to `config.toml` sections).
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -146,19 +146,19 @@ impl Config {
             "RUSTARR_MCP_AUTH_ALLOWED_CLIENT_REDIRECT_URIS",
             &mut config.mcp.auth.allowed_client_redirect_uris,
         );
-        if let Ok(v) = std::env::var("RUSTARR_MCP_AUTH_MODE") {
-            if !v.is_empty() {
-                config.mcp.auth.mode = match v.to_lowercase().as_str() {
-                    "oauth" => AuthMode::OAuth,
-                    "bearer" => AuthMode::Bearer,
-                    other => {
-                        return Err(anyhow::anyhow!(
-                            "invalid RUSTARR_MCP_AUTH_MODE {:?}: must be \"bearer\" or \"oauth\"",
-                            other
-                        ));
-                    }
-                };
-            }
+        if let Ok(v) = std::env::var("RUSTARR_MCP_AUTH_MODE")
+            && !v.is_empty()
+        {
+            config.mcp.auth.mode = match v.to_lowercase().as_str() {
+                "oauth" => AuthMode::OAuth,
+                "bearer" => AuthMode::Bearer,
+                other => {
+                    return Err(anyhow::anyhow!(
+                        "invalid RUSTARR_MCP_AUTH_MODE {:?}: must be \"bearer\" or \"oauth\"",
+                        other
+                    ));
+                }
+            };
         }
 
         load_services_from_env(&mut config.rustarr)?;
@@ -181,7 +181,7 @@ fn load_dotenv_defaults() -> anyhow::Result<()> {
             return Err(anyhow::anyhow!(
                 "Failed to read {}: {error}",
                 path.display()
-            ))
+            ));
         }
     };
     for (line_no, raw_line) in contents.lines().enumerate() {
@@ -199,7 +199,11 @@ fn load_dotenv_defaults() -> anyhow::Result<()> {
         if std::env::var_os(key).is_some() {
             continue;
         }
-        std::env::set_var(key, parse_dotenv_value(raw_value.trim())?);
+        // SAFETY: runs single-threaded during startup config load, before any
+        // worker threads are spawned, so there is no concurrent env access.
+        unsafe {
+            std::env::set_var(key, parse_dotenv_value(raw_value.trim())?);
+        }
     }
     Ok(())
 }

--- a/src/config/mcp.rs
+++ b/src/config/mcp.rs
@@ -98,28 +98,28 @@ impl Default for McpConfig {
 // ── env helpers ───────────────────────────────────────────────────────────────
 
 pub(super) fn env_str(key: &str, target: &mut String) {
-    if let Ok(v) = std::env::var(key) {
-        if !v.is_empty() {
-            *target = v;
-        }
+    if let Ok(v) = std::env::var(key)
+        && !v.is_empty()
+    {
+        *target = v;
     }
 }
 
 pub(super) fn env_opt_str(key: &str, target: &mut Option<String>) {
-    if let Ok(v) = std::env::var(key) {
-        if !v.is_empty() {
-            *target = Some(v);
-        }
+    if let Ok(v) = std::env::var(key)
+        && !v.is_empty()
+    {
+        *target = Some(v);
     }
 }
 
 pub(super) fn env_parse<T: std::str::FromStr>(key: &str, target: &mut T) -> anyhow::Result<()> {
-    if let Ok(v) = std::env::var(key) {
-        if !v.is_empty() {
-            *target = v
-                .parse()
-                .map_err(|_| anyhow::anyhow!("{key}: invalid value {v:?}"))?;
-        }
+    if let Ok(v) = std::env::var(key)
+        && !v.is_empty()
+    {
+        *target = v
+            .parse()
+            .map_err(|_| anyhow::anyhow!("{key}: invalid value {v:?}"))?;
     }
     Ok(())
 }

--- a/src/config_tests.rs
+++ b/src/config_tests.rs
@@ -73,10 +73,16 @@ fn is_loopback_subdomain_is_false() {
 // Each test uses a distinct key to avoid collisions with parallel test threads.
 
 fn call_env_bool(key: &str, raw: &str) -> anyhow::Result<bool> {
-    std::env::set_var(key, raw);
+    // SAFETY: each test uses a uniquely-named key, so no other thread reads or
+    // writes this env var concurrently.
+    unsafe {
+        std::env::set_var(key, raw);
+    }
     let mut target = false;
     let result = env_bool(key, &mut target);
-    std::env::remove_var(key);
+    unsafe {
+        std::env::remove_var(key);
+    }
     result.map(|_| target)
 }
 
@@ -119,10 +125,16 @@ fn env_bool_rejects_invalid() {
 // ── env_list helper ───────────────────────────────────────────────────────────
 
 fn call_env_list(key: &str, raw: &str) -> Vec<String> {
-    std::env::set_var(key, raw);
+    // SAFETY: each test uses a uniquely-named key, so no other thread reads or
+    // writes this env var concurrently.
+    unsafe {
+        std::env::set_var(key, raw);
+    }
     let mut target: Vec<String> = Vec::new();
     env_list(key, &mut target);
-    std::env::remove_var(key);
+    unsafe {
+        std::env::remove_var(key);
+    }
     target
 }
 
@@ -141,10 +153,15 @@ fn env_list_trims_spaces_around_commas() {
 #[test]
 fn env_list_empty_string_leaves_target_unchanged() {
     // An empty env var should not overwrite an existing target
-    std::env::set_var("TEST_ENV_LIST_EMPTY", "");
+    // SAFETY: this test owns the uniquely-named TEST_ENV_LIST_EMPTY key.
+    unsafe {
+        std::env::set_var("TEST_ENV_LIST_EMPTY", "");
+    }
     let mut target = vec!["existing".to_string()];
     env_list("TEST_ENV_LIST_EMPTY", &mut target);
-    std::env::remove_var("TEST_ENV_LIST_EMPTY");
+    unsafe {
+        std::env::remove_var("TEST_ENV_LIST_EMPTY");
+    }
     assert_eq!(
         target,
         vec!["existing"],
@@ -194,11 +211,15 @@ fn load_reads_dotenv_from_rustarr_home_without_overriding_process_env() {
     let old_url = std::env::var_os("RUSTARR_SONARR_URL");
     let old_key = std::env::var_os("RUSTARR_SONARR_API_KEY");
     let old_token = std::env::var_os("RUSTARR_MCP_TOKEN");
-    std::env::set_var("RUSTARR_HOME", dir.path());
-    std::env::remove_var("RUSTARR_SERVICES");
-    std::env::remove_var("RUSTARR_SONARR_URL");
-    std::env::set_var("RUSTARR_SONARR_API_KEY", "from-env");
-    std::env::remove_var("RUSTARR_MCP_TOKEN");
+    // SAFETY: `_guard` holds the process-wide ENV_LOCK, so no other test mutates
+    // or reads these shared keys concurrently.
+    unsafe {
+        std::env::set_var("RUSTARR_HOME", dir.path());
+        std::env::remove_var("RUSTARR_SERVICES");
+        std::env::remove_var("RUSTARR_SONARR_URL");
+        std::env::set_var("RUSTARR_SONARR_API_KEY", "from-env");
+        std::env::remove_var("RUSTARR_MCP_TOKEN");
+    }
 
     let loaded = Config::load().unwrap();
 
@@ -218,8 +239,12 @@ fn load_reads_dotenv_from_rustarr_home_without_overriding_process_env() {
 }
 
 fn restore_env(key: &str, value: Option<std::ffi::OsString>) {
-    match value {
-        Some(value) => std::env::set_var(key, value),
-        None => std::env::remove_var(key),
+    // SAFETY: callers invoke this only while holding the process-wide ENV_LOCK,
+    // so there is no concurrent env access to these shared keys.
+    unsafe {
+        match value {
+            Some(value) => std::env::set_var(key, value),
+            None => std::env::remove_var(key),
+        }
     }
 }

--- a/src/config_tests.rs
+++ b/src/config_tests.rs
@@ -248,3 +248,99 @@ fn restore_env(key: &str, value: Option<std::ffi::OsString>) {
         }
     }
 }
+
+// ── .env key-injection allowlist (security hardening) ─────────────────────────
+
+#[test]
+fn injectable_env_key_allows_rustarr_namespace_and_rust_log() {
+    assert!(is_injectable_env_key("RUSTARR_SERVICES"));
+    assert!(is_injectable_env_key("RUSTARR_SONARR_API_KEY"));
+    assert!(is_injectable_env_key("RUST_LOG"));
+}
+
+#[test]
+fn injectable_env_key_rejects_dangerous_process_vars() {
+    for key in [
+        "PATH",
+        "LD_PRELOAD",
+        "SSL_CERT_FILE",
+        "HOME",
+        "RUST_BACKTRACE",
+    ] {
+        assert!(
+            !is_injectable_env_key(key),
+            "{key} must not be injectable from .env"
+        );
+    }
+}
+
+#[test]
+fn load_dotenv_skips_non_rustarr_keys_but_injects_allowed_ones() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join(".env"),
+        "ZZINJECT_REVIEW_TEST=danger\nRUSTARR_REVIEW_INJECT_OK=safe\n",
+    )
+    .unwrap();
+
+    let old_home = std::env::var_os("RUSTARR_HOME");
+    let old_danger = std::env::var_os("ZZINJECT_REVIEW_TEST");
+    let old_ok = std::env::var_os("RUSTARR_REVIEW_INJECT_OK");
+    // SAFETY: `_guard` holds the process-wide ENV_LOCK, so no other test mutates
+    // or reads these keys concurrently. Clear the two test keys first so the
+    // `var_os` already-set guard does not mask the allowlist behaviour.
+    unsafe {
+        std::env::set_var("RUSTARR_HOME", dir.path());
+        std::env::remove_var("ZZINJECT_REVIEW_TEST");
+        std::env::remove_var("RUSTARR_REVIEW_INJECT_OK");
+    }
+
+    Config::load().unwrap();
+
+    let danger_after = std::env::var_os("ZZINJECT_REVIEW_TEST");
+    let ok_after = std::env::var("RUSTARR_REVIEW_INJECT_OK").ok();
+
+    restore_env("RUSTARR_HOME", old_home);
+    restore_env("ZZINJECT_REVIEW_TEST", old_danger);
+    restore_env("RUSTARR_REVIEW_INJECT_OK", old_ok);
+
+    assert!(
+        danger_after.is_none(),
+        "non-RUSTARR key must not be injected from .env"
+    );
+    assert_eq!(
+        ok_after.as_deref(),
+        Some("safe"),
+        "RUSTARR_* key should still be injected"
+    );
+}
+
+#[test]
+fn load_dotenv_rejects_null_byte_in_value() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join(".env"),
+        b"RUSTARR_REVIEW_NULL_TEST=ab\0cd\n".as_slice(),
+    )
+    .unwrap();
+
+    let old_home = std::env::var_os("RUSTARR_HOME");
+    let old_val = std::env::var_os("RUSTARR_REVIEW_NULL_TEST");
+    // SAFETY: `_guard` holds the process-wide ENV_LOCK.
+    unsafe {
+        std::env::set_var("RUSTARR_HOME", dir.path());
+        std::env::remove_var("RUSTARR_REVIEW_NULL_TEST");
+    }
+
+    let result = Config::load();
+
+    restore_env("RUSTARR_HOME", old_home);
+    restore_env("RUSTARR_REVIEW_NULL_TEST", old_val);
+
+    assert!(
+        result.is_err(),
+        "a null byte in a .env value must be rejected, not passed to set_var"
+    );
+}

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -55,7 +55,7 @@ use std::io::IsTerminal;
 use std::path::Path;
 
 use anyhow::{Context, Result};
-use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
+use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
 
 use formatter::AuroraFormatter;
 

--- a/src/logging/formatter/render.rs
+++ b/src/logging/formatter/render.rs
@@ -6,8 +6,8 @@ use std::fmt as stdfmt;
 use tracing::{Event, Subscriber};
 use tracing_subscriber::{
     fmt::{
-        format::{FormatEvent, FormatFields, Writer},
         FmtContext,
+        format::{FormatEvent, FormatFields, Writer},
     },
     registry::LookupSpan,
 };
@@ -15,8 +15,8 @@ use tracing_subscriber::{
 use crate::logging::aurora;
 
 use super::style::{
-    ansi256_bold, ansi_dim, format_field_value, sanitize_field_value, should_skip_field,
-    style_value, write_level, EventFieldCollector,
+    EventFieldCollector, ansi_dim, ansi256_bold, format_field_value, sanitize_field_value,
+    should_skip_field, style_value, write_level,
 };
 
 // ── AuroraFormatter ───────────────────────────────────────────────────────────

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,17 +15,17 @@
 use anyhow::Result;
 use std::sync::Arc;
 
-use rmcp::{transport::stdio, ServiceExt};
+use rmcp::{ServiceExt, transport::stdio};
 use rustarr::{
     app::RustarrService,
     cli,
     config::Config,
     mcp,
     rustarr::RustarrClient,
-    server::{self, resolve_auth_policy_kind, AppState, AuthPolicy, AuthPolicyKind},
+    server::{self, AppState, AuthPolicy, AuthPolicyKind, resolve_auth_policy_kind},
 };
 use tracing::info;
-use tracing_subscriber::{fmt, EnvFilter};
+use tracing_subscriber::{EnvFilter, fmt};
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -9,7 +9,7 @@ mod schemas;
 mod tools;
 mod transport;
 
-pub use rmcp_server::{rmcp_server, RustarrRmcpServer};
+pub use rmcp_server::{RustarrRmcpServer, rmcp_server};
 pub use transport::{allowed_origins, streamable_http_config, streamable_http_service};
 
 #[cfg(any(test, feature = "test-support"))]

--- a/src/mcp/rmcp_server.rs
+++ b/src/mcp/rmcp_server.rs
@@ -12,6 +12,7 @@ use std::{borrow::Cow, sync::Arc, time::Instant};
 
 use lab_auth::AuthContext;
 use rmcp::{
+    ErrorData, RoleServer, ServerHandler,
     model::{
         CallToolRequestParams, CallToolResult, Content, GetPromptRequestParams, GetPromptResult,
         Implementation, ListPromptsResult, ListResourcesResult, ListToolsResult,
@@ -19,12 +20,11 @@ use rmcp::{
         Resource, ResourceContents, ServerCapabilities, ServerInfo, Tool,
     },
     service::{Peer, RequestContext},
-    ErrorData, RoleServer, ServerHandler,
 };
 use serde_json::{Map, Value};
 
 use crate::{
-    actions::{is_known_action, required_scope_for_action, ValidationError},
+    actions::{ValidationError, is_known_action, required_scope_for_action},
     token_limit,
 };
 
@@ -108,10 +108,10 @@ impl ServerHandler for RustarrRmcpServer {
         }
         // Only scope-check when a known action is present; dispatch_rustarr will
         // return the validation error for a missing action below.
-        if let (Some(auth), Some(action_str)) = (auth, action_opt.as_deref()) {
-            if let Some(required_scope) = required_scope_for_action(action_str) {
-                check_scope(auth, required_scope, action_str)?;
-            }
+        if let (Some(auth), Some(action_str)) = (auth, action_opt.as_deref())
+            && let Some(required_scope) = required_scope_for_action(action_str)
+        {
+            check_scope(auth, required_scope, action_str)?;
         }
 
         let action: String = action_opt.unwrap_or_default();
@@ -189,11 +189,9 @@ impl ServerHandler for RustarrRmcpServer {
         let schema = tool_definitions();
         let text = serde_json::to_string_pretty(&schema)
             .map_err(|e| ErrorData::internal_error(format!("serialization error: {e}"), None))?;
-        Ok(ReadResourceResult::new(vec![ResourceContents::text(
-            text,
-            SCHEMA_RESOURCE_URI,
-        )
-        .with_mime_type("application/json")]))
+        Ok(ReadResourceResult::new(vec![
+            ResourceContents::text(text, SCHEMA_RESOURCE_URI).with_mime_type("application/json"),
+        ]))
     }
 
     // ── prompts ───────────────────────────────────────────────────────────────

--- a/src/mcp/rmcp_server_tests.rs
+++ b/src/mcp/rmcp_server_tests.rs
@@ -1,7 +1,7 @@
 use serde_json::json;
 
 use crate::{
-    actions::{required_scope_for_action, READ_SCOPE, WRITE_SCOPE},
+    actions::{READ_SCOPE, WRITE_SCOPE, required_scope_for_action},
     token_limit::MAX_RESPONSE_BYTES,
 };
 

--- a/src/mcp/schemas.rs
+++ b/src/mcp/schemas.rs
@@ -23,7 +23,7 @@ mod properties;
 
 use std::sync::OnceLock;
 
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 /// Cached JSON schema definitions (static data, built once at first call).
 static TOOL_DEFINITIONS: OnceLock<Vec<Value>> = OnceLock::new();

--- a/src/mcp/schemas/conditionals.rs
+++ b/src/mcp/schemas/conditionals.rs
@@ -11,7 +11,7 @@
 //! the shared dispatch guard (`crate::actions::dispatch::validate_action_for_service`),
 //! per the rmcp 1.7 guidance that most LLM clients reason poorly over `allOf`.
 
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 use crate::actions::{all_action_names, allowed_kind_names_for_action, required_params_for_action};
 

--- a/src/mcp/schemas/properties.rs
+++ b/src/mcp/schemas/properties.rs
@@ -7,7 +7,7 @@
 //! strict, so curated params must be declared here or calls would be rejected —
 //! generating them from the registry keeps that automatic.
 
-use serde_json::{json, Map, Value};
+use serde_json::{Map, Value, json};
 
 use crate::actions::{all_action_names, curated_param_names};
 

--- a/src/mcp/schemas/properties_tests.rs
+++ b/src/mcp/schemas/properties_tests.rs
@@ -1,4 +1,4 @@
-use super::{properties, property_count, BASE_PROPERTIES};
+use super::{BASE_PROPERTIES, properties, property_count};
 use crate::actions::{all_action_names, curated_param_names};
 
 #[test]

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1,9 +1,9 @@
 //! MCP tool dispatch — thin shims only.
 
-use rmcp::{service::Peer, RoleServer};
+use rmcp::{RoleServer, service::Peer};
 use serde_json::Value;
 
-use crate::actions::{execute_service_action, RustarrAction};
+use crate::actions::{RustarrAction, execute_service_action};
 use crate::server::AppState;
 
 pub(super) async fn execute_tool(

--- a/src/mcp/transport.rs
+++ b/src/mcp/transport.rs
@@ -11,12 +11,12 @@ mod tests;
 use std::net::Ipv6Addr;
 
 use rmcp::transport::streamable_http_server::{
-    session::local::LocalSessionManager, StreamableHttpServerConfig, StreamableHttpService,
+    StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
 };
 
 use crate::config::McpConfig;
 
-use super::rmcp_server::{rmcp_server as make_server, RustarrRmcpServer};
+use super::rmcp_server::{RustarrRmcpServer, rmcp_server as make_server};
 
 // ── Transport builders ────────────────────────────────────────────────────────
 
@@ -66,10 +66,10 @@ pub fn allowed_origins(config: &McpConfig) -> Vec<String> {
     for origin in &config.allowed_origins {
         push_configured_origin(&mut origins, origin);
     }
-    if let Some(public_url) = config.auth.public_url.as_deref() {
-        if let Some(origin) = extract_origin(public_url) {
-            origins.push(origin);
-        }
+    if let Some(public_url) = config.auth.public_url.as_deref()
+        && let Some(origin) = extract_origin(public_url)
+    {
+        origins.push(origin);
     }
     origins.sort();
     origins.dedup();

--- a/src/server/routes.rs
+++ b/src/server/routes.rs
@@ -9,16 +9,16 @@
 use std::sync::Arc;
 
 use axum::{
+    Router,
     http::{HeaderValue, Method, StatusCode},
     response::Json,
     routing::get,
-    Router,
 };
 use serde_json::json;
 use tower_http::{cors::CorsLayer, limit::RequestBodyLimitLayer};
 
 use crate::mcp::{allowed_origins, streamable_http_config, streamable_http_service};
-use crate::server::{build_auth_layer, AppState, AuthPolicy};
+use crate::server::{AppState, AuthPolicy, build_auth_layer};
 
 const MCP_BODY_LIMIT_BYTES: usize = 65_536;
 

--- a/src/server_tests.rs
+++ b/src/server_tests.rs
@@ -91,9 +91,11 @@ fn invalid_public_url_is_rejected() {
     let mut config = config("0.0.0.0");
     config.mcp.auth.public_url = Some("not a url".into());
     let error = resolve_auth_policy_kind(&config, true).unwrap_err();
-    assert!(error
-        .to_string()
-        .contains("RUSTARR_MCP_PUBLIC_URL is invalid"));
+    assert!(
+        error
+            .to_string()
+            .contains("RUSTARR_MCP_PUBLIC_URL is invalid")
+    );
 }
 
 #[test]
@@ -101,7 +103,9 @@ fn wildcard_public_url_is_rejected() {
     let mut config = config("0.0.0.0");
     config.mcp.auth.public_url = Some("https://*.rustarr.com".into());
     let error = resolve_auth_policy_kind(&config, true).unwrap_err();
-    assert!(error
-        .to_string()
-        .contains("RUSTARR_MCP_PUBLIC_URL must not contain wildcard hosts"));
+    assert!(
+        error
+            .to_string()
+            .contains("RUSTARR_MCP_PUBLIC_URL must not contain wildcard hosts")
+    );
 }

--- a/tests/cli_parse.rs
+++ b/tests/cli_parse.rs
@@ -1,4 +1,4 @@
-use rustarr::cli::{parse_args_from, Command, SetupCommand};
+use rustarr::cli::{Command, SetupCommand, parse_args_from};
 use serde_json::json;
 
 #[test]

--- a/tests/parity.rs
+++ b/tests/parity.rs
@@ -25,7 +25,7 @@
 use rustarr::actions::{all_action_names, curated_commands};
 use rustarr::capability::Capability;
 use rustarr::cli::commands::capability_verb_tables;
-use rustarr::cli::{parse_args_from, Command};
+use rustarr::cli::{Command, parse_args_from};
 use rustarr::config::ServiceKind;
 
 /// A representative service name for each capability, used to drive CLI parsing.

--- a/tests/plugin_contract.rs
+++ b/tests/plugin_contract.rs
@@ -40,18 +40,24 @@ fn plugin_manifests_share_identity_and_connection_settings() {
     assert_eq!(codex["name"], "rustarr-mcp");
     assert_eq!(gemini["name"], "rustarr-mcp");
 
-    assert!(claude["repository"]
-        .as_str()
-        .unwrap()
-        .ends_with("rustarr-mcp"));
-    assert!(codex["repository"]
-        .as_str()
-        .unwrap()
-        .ends_with("rustarr-mcp"));
-    assert!(gemini["repository"]
-        .as_str()
-        .unwrap()
-        .ends_with("rustarr-mcp"));
+    assert!(
+        claude["repository"]
+            .as_str()
+            .unwrap()
+            .ends_with("rustarr-mcp")
+    );
+    assert!(
+        codex["repository"]
+            .as_str()
+            .unwrap()
+            .ends_with("rustarr-mcp")
+    );
+    assert!(
+        gemini["repository"]
+            .as_str()
+            .unwrap()
+            .ends_with("rustarr-mcp")
+    );
 
     let user_config = claude["userConfig"].as_object().unwrap();
     for key in [
@@ -184,11 +190,13 @@ fn setup_plugin_hook_no_repair_emits_json_contract() {
     assert_eq!(json["ran_repair"], false);
     assert_eq!(json["no_repair"], true);
     assert!(json["blocking_failures"].as_array().unwrap().is_empty());
-    assert!(json["advisory_failures"]
-        .as_array()
-        .unwrap()
-        .iter()
-        .any(|failure| failure["code"] == "env_file_missing"));
+    assert!(
+        json["advisory_failures"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|failure| failure["code"] == "env_file_missing")
+    );
     assert!(!dir.path().join(".env").exists());
 }
 

--- a/tests/tool_dispatch.rs
+++ b/tests/tool_dispatch.rs
@@ -14,11 +14,13 @@ async fn call_mcp_action(args: serde_json::Value) -> serde_json::Value {
 async fn integrations_returns_supported_services() {
     let result = call_mcp_action(json!({ "action": "integrations" })).await;
     // `supported` is now a list of {kind, capability} objects (registry-derived).
-    assert!(result["supported"]
-        .as_array()
-        .unwrap()
-        .iter()
-        .any(|entry| entry["kind"] == "sonarr"));
+    assert!(
+        result["supported"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|entry| entry["kind"] == "sonarr")
+    );
 }
 
 #[test]
@@ -181,7 +183,7 @@ fn curated_list_rejected_for_non_arr_kind() {
 
 #[test]
 fn set_quality_requires_write_scope() {
-    use rustarr::actions::{required_scope_for_action, WRITE_SCOPE};
+    use rustarr::actions::{WRITE_SCOPE, required_scope_for_action};
     // Every C2 write command requires rustarr:write; read scope is insufficient.
     for action in [
         "set_quality",
@@ -267,7 +269,7 @@ fn indexer_commands_valid_only_for_prowlarr() {
 
 #[test]
 fn indexer_test_requires_write_scope_others_read() {
-    use rustarr::actions::{required_scope_for_action, READ_SCOPE, WRITE_SCOPE};
+    use rustarr::actions::{READ_SCOPE, WRITE_SCOPE, required_scope_for_action};
     assert_eq!(required_scope_for_action("indexers"), Some(READ_SCOPE));
     assert_eq!(
         required_scope_for_action("indexer_search"),
@@ -395,7 +397,7 @@ fn download_commands_valid_only_for_download_kinds() {
 
 #[test]
 fn download_scopes_queue_read_others_write() {
-    use rustarr::actions::{required_scope_for_action, READ_SCOPE, WRITE_SCOPE};
+    use rustarr::actions::{READ_SCOPE, WRITE_SCOPE, required_scope_for_action};
     assert_eq!(
         required_scope_for_action("download_queue"),
         Some(READ_SCOPE)

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -14,7 +14,7 @@
 [package]
 name = "xtask"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 # Exclude from crates.io — this is a private automation crate.
 publish = false
 

--- a/xtask/src/live.rs
+++ b/xtask/src/live.rs
@@ -1,5 +1,5 @@
-use anyhow::{bail, Result};
-use serde_json::{json, Value};
+use anyhow::{Result, bail};
+use serde_json::{Value, json};
 use std::collections::BTreeMap;
 use std::path::Path;
 use std::time::Duration;

--- a/xtask/src/live/assertions.rs
+++ b/xtask/src/live/assertions.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use serde_json::Value;
 
 use super::matrix::Expectation;
@@ -31,15 +31,15 @@ pub fn assert_value(value: &Value, expectation: &Expectation) -> Result<()> {
             bail!("expected type {expected_type}, got {node}");
         }
     }
-    if let Some(expected) = &expectation.equals {
-        if node != expected {
-            bail!("expected {expected}, got {node}");
-        }
+    if let Some(expected) = &expectation.equals
+        && node != expected
+    {
+        bail!("expected {expected}, got {node}");
     }
-    if let Some(expected_values) = &expectation.equals_any {
-        if !expected_values.iter().any(|expected| expected == node) {
-            bail!("expected one of {expected_values:?}, got {node}");
-        }
+    if let Some(expected_values) = &expectation.equals_any
+        && !expected_values.iter().any(|expected| expected == node)
+    {
+        bail!("expected one of {expected_values:?}, got {node}");
     }
     if let Some(needle) = &expectation.contains {
         let haystack = node.as_str().unwrap_or("");

--- a/xtask/src/live/guard.rs
+++ b/xtask/src/live/guard.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 

--- a/xtask/src/live/http.rs
+++ b/xtask/src/live/http.rs
@@ -1,5 +1,5 @@
-use anyhow::{bail, Result};
-use serde_json::{json, Value};
+use anyhow::{Result, bail};
+use serde_json::{Value, json};
 use ureq::Agent;
 
 /// Agent that surfaces non-2xx responses as `Ok` instead of `Error::StatusCode`,

--- a/xtask/src/live/process.rs
+++ b/xtask/src/live/process.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use std::collections::BTreeMap;
 use std::io::Write;
 use std::process::{Child, Command, Output, Stdio};
@@ -170,10 +170,10 @@ impl Server {
     pub fn wait_healthy(&mut self, base_url: &str) -> Result<()> {
         let deadline = Instant::now() + Duration::from_secs(20);
         while Instant::now() < deadline {
-            if let Ok(response) = ureq::get(format!("{base_url}/health")).call() {
-                if response.status().as_u16() == 200 {
-                    return Ok(());
-                }
+            if let Ok(response) = ureq::get(format!("{base_url}/health")).call()
+                && response.status().as_u16() == 200
+            {
+                return Ok(());
             }
             std::thread::sleep(Duration::from_millis(250));
         }

--- a/xtask/src/live/suites.rs
+++ b/xtask/src/live/suites.rs
@@ -1,10 +1,10 @@
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use serde_json::json;
 use std::collections::BTreeMap;
 
 use super::{
-    assertions, configured_service_names, http, live_base_url, matrix, process, report,
-    LIVE_AUTH_PORT, LIVE_OAUTH_PORT, LIVE_PORT,
+    LIVE_AUTH_PORT, LIVE_OAUTH_PORT, LIVE_PORT, assertions, configured_service_names, http,
+    live_base_url, matrix, process, report,
 };
 
 pub(super) fn run_rest(

--- a/xtask/src/live_tests.rs
+++ b/xtask/src/live_tests.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::fs;
 use std::path::Path;
 
-use crate::live::guard::{validate_env, SHART_HOME};
+use crate::live::guard::{SHART_HOME, validate_env};
 
 fn good_env() -> BTreeMap<String, String> {
     let mut env = BTreeMap::new();

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -18,7 +18,7 @@
 //! and use `std::process::Command` to shell out to existing tools rather than
 //! reimplementing them in Rust.
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use std::process::{Command, Stdio};
 use walkdir::WalkDir;
 

--- a/xtask/src/patterns.rs
+++ b/xtask/src/patterns.rs
@@ -6,7 +6,7 @@ mod reporter;
 mod surfaces;
 mod util;
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 
 use reporter::PatternReporter;
 


### PR DESCRIPTION
## Summary

`Cargo.toml` declared `edition = "2021"` while the project docs (and CLAUDE.md) claimed edition 2024 — and a SAFETY comment in `setup/plugin.rs` explicitly cited "edition 2021". This resolves the mismatch by bumping **both** workspace crates (`rustarr` and `xtask`) to edition 2024, then addresses everything surfaced by two rounds of multi-agent review.

## Changes

**Edition bump (commit 1)**
- `Cargo.toml` and `xtask/Cargo.toml` → `edition = "2024"`.
- Wrapped now-`unsafe` `std::env::set_var`/`remove_var` calls in `unsafe {}` blocks with SAFETY justifications (startup config load, plugin setup, `ENV_LOCK`-guarded test helpers).
- Collapsed 11 nested `if let` blocks into stabilized let-chains (clippy `collapsible_if`).
- Applied the 2024 rustfmt style edition across the tree.
- Updated `docs/ARCHITECTURE.md`, `docs/PATTERNS.md`, `CHANGELOG.md`.

**Review round 1 — pr-review-toolkit (commit 2)**
- Two agents flagged the production SAFETY comments claiming "before any worker threads are spawned" — false under the multi-threaded `#[tokio::main]` runtime (workers exist before `main`'s body). Reworded to state the true invariant: no env-reading task is spawned yet; the existing tokio workers are parked.

**Review round 2 — lavra-review (commit 3, security hardening)**
- `security-sentinel` surfaced that `load_dotenv_defaults` injected **any** key from `$RUSTARR_HOME/.env` via `set_var`. Since `.env` lives in a writable appdata dir, a writable `.env` could smuggle in `PATH`/`LD_PRELOAD`/`SSL_CERT_FILE`; a null byte in a value would also panic `set_var`.
  - Allowlisted injectable keys to `RUSTARR_*` + `RUST_LOG`; skip-and-warn on others (skip, not bail, so a stray key never hard-fails startup).
  - Reject null bytes in `.env` keys/values.
  - Added 4 colocated tests. The setup wizard only writes `RUSTARR_*` keys, so this is non-breaking.
- One informational finding (the startup env-mutation invariant is convention-dependent, not structurally enforced) filed as triage bead `rustarr-ozi`, not bundled here.

## Verification

- `cargo build --workspace` ✅
- `cargo fmt --all -- --check` ✅ clean
- `cargo clippy --workspace --all-targets -- -D warnings` ✅ clean
- `cargo test --workspace` ✅ 512 unit (+4 new) + integration/doc tests pass, 0 failures

bd: rustarr-1wh