### PR TITLE
fix(logging): wire up logging module, drop dead token_limit::truncate_if_needed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@
 # .github/workflows/ci.yml — Continuous Integration
 #
 # This workflow runs on every push and PR to main.
-# Jobs: fmt, clippy, test (nextest), toml, template checks, deny, gitleaks
+# Jobs: fmt, clippy, docs, test (nextest), toml, template checks, deny, gitleaks
 #
 # All jobs must pass before merging. Adjust the matrix rust-version to match
 # your Cargo.toml `rust-version` field.
@@ -71,6 +71,32 @@ jobs:
 
       - name: cargo clippy -- -D warnings
         run: cargo clippy --all-targets -- -D warnings
+
+  # ── docs: rustdoc with zero warnings (broken/ambiguous intra-doc links) ──────
+  docs:
+    name: Docs
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install Rust (stable)
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: Cache Cargo
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ github.repository }}-docs-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ github.repository }}-docs-
+
+      - name: cargo doc (deny warnings)
+        env:
+          RUSTDOCFLAGS: -D warnings
+        run: cargo doc --no-deps --document-private-items
 
   # ── test: cargo nextest run --profile ci ─────────────────────────────────────
   test:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Extracted launch-mode classification into a unit-tested `run_mode::RunMode`
   (`Serve` / `Stdio` / `Cli`) and centralised data-dir resolution behind
   `config::resolve_data_dir` (shared by `.env` loading and logging setup).
+- Fixed all 26 pre-existing `cargo doc` warnings (broken/private/ambiguous
+  intra-doc links, a bare URL, an unescaped `<service>`) and added a `docs` CI
+  job (`RUSTDOCFLAGS=-D warnings cargo doc`) so rustdoc warnings can't regress.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (pretty console on stderr + JSON-lines file under `{data_dir}/logs/rustarr.log`)
   via `logging::init` in HTTP-server mode; stdio/CLI modes stay on a stderr-only
   `warn` subscriber so the MCP JSON-RPC stream and CLI output are never corrupted.
-  The `logging` module was previously dead template scaffolding masked behind
-  `pub`; it is now `pub(crate)` with only `init` re-exported as
-  `crate::init_logging` for the binary.
+  File logging is **best-effort**: if the data dir or log file is unavailable
+  (read-only mount, permissions, no `HOME`), the server still starts with
+  stderr-only logging instead of aborting. The `logging` module was previously
+  dead template scaffolding masked behind `pub`; it is now `pub(crate)` with only
+  `init` re-exported as `crate::init_logging` for the binary.
+- Extracted launch-mode classification into a unit-tested `run_mode::RunMode`
+  (`Serve` / `Stdio` / `Cli`) and centralised data-dir resolution behind
+  `config::resolve_data_dir` (shared by `.env` loading and logging setup).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Wired up the `logging` module.** `main.rs` now initialises dual logging
+  (pretty console on stderr + JSON-lines file under `{data_dir}/logs/rustarr.log`)
+  via `logging::init` in HTTP-server mode; stdio/CLI modes stay on a stderr-only
+  `warn` subscriber so the MCP JSON-RPC stream and CLI output are never corrupted.
+  The `logging` module was previously dead template scaffolding masked behind
+  `pub`; it is now `pub(crate)` with only `init` re-exported as
+  `crate::init_logging` for the binary.
+
+### Removed
+
+- Dropped the unused `token_limit::truncate_if_needed` (and its tests); only
+  `serialize_with_limit` is used, by the MCP response path. `token_limit` is now
+  `pub(crate)`.
+
 ### Added
 
 - **Curated service-grouped command surface (epic).** rustarr moved from a single

--- a/src/actions/commands/download.rs
+++ b/src/actions/commands/download.rs
@@ -1,7 +1,7 @@
 //! DownloadClient (SABnzbd, qBittorrent) curated command descriptors (C5).
 //!
 //! The per-capability const slice the registry concatenates at its single
-//! extension point ([`crate::actions::registry::build_curated_commands`]). Each
+//! extension point (`build_curated_commands`). Each
 //! [`CommandDescriptor`] is the SSOT for one curated command — its scope, params,
 //! allowed kinds (via `capability` = [`Capability::DownloadClient`], so only
 //! SABnzbd + qBittorrent), schema fragment, help line, and handler.

--- a/src/actions/commands/indexer.rs
+++ b/src/actions/commands/indexer.rs
@@ -1,7 +1,7 @@
 //! Indexer (Prowlarr) curated command descriptors (C4).
 //!
 //! The per-capability const slice the registry concatenates at its single
-//! extension point ([`crate::actions::registry::build_curated_commands`]). Each
+//! extension point (`build_curated_commands`). Each
 //! [`CommandDescriptor`] is the SSOT for one curated command — its scope, params,
 //! allowed kinds (via `capability` = [`Capability::Indexer`], so only Prowlarr),
 //! schema fragment, help line, and handler.

--- a/src/actions/commands/media_server.rs
+++ b/src/actions/commands/media_server.rs
@@ -1,7 +1,7 @@
 //! MediaServer (Plex, Jellyfin) curated command descriptors (C6).
 //!
 //! The per-capability const slice the registry concatenates at its single
-//! extension point ([`crate::actions::registry::build_curated_commands`]). Each
+//! extension point (`build_curated_commands`). Each
 //! [`CommandDescriptor`] is the SSOT for one curated command — its scope, params,
 //! allowed kinds (via `capability` = [`Capability::MediaServer`], so only Plex +
 //! Jellyfin), schema fragment, help line, and handler.

--- a/src/actions/commands/requests.rs
+++ b/src/actions/commands/requests.rs
@@ -1,7 +1,7 @@
 //! Requests (Overseerr) curated command descriptors (C7).
 //!
 //! The per-capability const slice the registry concatenates at its single
-//! extension point ([`crate::actions::registry::build_curated_commands`]). Each
+//! extension point (`build_curated_commands`). Each
 //! [`CommandDescriptor`] is the SSOT for one curated command — its scope, params,
 //! allowed kinds (via `capability` = [`Capability::Requests`], so only Overseerr),
 //! schema fragment, help line, and handler.

--- a/src/actions/commands/stats.rs
+++ b/src/actions/commands/stats.rs
@@ -1,7 +1,7 @@
 //! Stats (Tautulli) curated command descriptors (C8).
 //!
 //! The per-capability const slice the registry concatenates at its single
-//! extension point ([`crate::actions::registry::build_curated_commands`]). Each
+//! extension point (`build_curated_commands`). Each
 //! [`CommandDescriptor`] is the SSOT for one curated command — its scope, params,
 //! allowed kinds (via `capability` = [`Capability::Stats`], so only Tautulli),
 //! schema fragment, help line, and handler.

--- a/src/actions/dispatch.rs
+++ b/src/actions/dispatch.rs
@@ -3,7 +3,7 @@
 //! This is the SHARED dispatch path for BOTH the CLI and MCP shims, so the
 //! action×kind validation guard lives here (LD4 / architecture F4-a) rather than
 //! in `mcp/rmcp_server.rs` — the CLI never touches that file. Every action that
-//! targets a service is checked against the resolved [`ServiceKind`] before it
+//! targets a service is checked against the resolved [`ServiceKind`](crate::config::ServiceKind) before it
 //! runs, so a curated command can never reach an incompatible kind regardless of
 //! which transport invoked it.
 
@@ -17,7 +17,7 @@ use crate::app::RustarrService;
 
 /// Validate that `action` (by name) may run against the service named `service_name`.
 ///
-/// Resolves the configured service's [`ServiceKind`] and calls
+/// Resolves the configured service's [`ServiceKind`](crate::config::ServiceKind) and calls
 /// [`action_allowed_for_kind`]. On mismatch it returns
 /// [`ValidationError::ActionNotValidForKind`], which carries the valid-action
 /// list so its `Display` teaches the agent what it *can* run (AN-2). Generic

--- a/src/actions/registry.rs
+++ b/src/actions/registry.rs
@@ -218,7 +218,7 @@ pub fn curated_param_names() -> Vec<&'static str> {
 
 /// Required params for an action: curated commands declare them in their
 /// descriptor; generic actions have their requirements encoded by
-/// [`generic_required_params`]. Returns an empty slice when the action takes no
+/// `generic_required_params`. Returns an empty slice when the action takes no
 /// required params (or is unknown).
 pub fn required_params_for_action(action: &str) -> Vec<&'static str> {
     if let Some(cmd) = curated_command(action) {

--- a/src/app/arr.rs
+++ b/src/app/arr.rs
@@ -9,7 +9,7 @@
 //!     by C2 write commands.
 //!   * [`editor`]  — pure (no self/network) body builders, selectors, count cap,
 //!     and dry-run preview for the C2 write commands; unit-tested directly.
-//!   * [`write`]   — WRITE/intent command methods (C2): set_quality, search,
+//!   * [`write`](mod@self::write)   — WRITE/intent command methods (C2): set_quality, search,
 //!     refresh, monitor/unmonitor, add, delete — confirm-gated + count-capped.
 //!
 //! The curated-command *descriptors* (registry table) live in

--- a/src/app/arr/read.rs
+++ b/src/app/arr/read.rs
@@ -62,7 +62,7 @@ impl RustarrService {
     }
 
     /// GET the primary resource collection (`series` for sonarr, `movie` for
-    /// radarr, …), slimmed to [`LIST_FIELDS`].
+    /// radarr, …), slimmed to `LIST_FIELDS`.
     pub async fn arr_list(&self, service: &str) -> Result<Value> {
         let config = self.arr_context(service)?;
         let path = arr_path(config.kind, arr_resource_noun(config.kind));

--- a/src/app/indexer.rs
+++ b/src/app/indexer.rs
@@ -53,7 +53,7 @@ impl RustarrService {
     }
 
     /// GET `{prefix}/indexer` — the configured indexers, slimmed to
-    /// [`INDEXER_FIELDS`].
+    /// `INDEXER_FIELDS`.
     pub async fn indexer_list(&self, service: &str) -> Result<Value> {
         let config = self.indexer_context(service)?;
         let path = Self::indexer_path(config, "indexer");
@@ -84,7 +84,7 @@ impl RustarrService {
     }
 
     /// GET `{prefix}/indexerstats` — per-indexer query/grab/failure counters,
-    /// slimmed to [`STATS_FIELDS`] (slims nested `indexers` rows in place).
+    /// slimmed to `STATS_FIELDS` (slims nested `indexers` rows in place).
     pub async fn indexer_stats(&self, service: &str) -> Result<Value> {
         let config = self.indexer_context(service)?;
         let path = Self::indexer_path(config, "indexerstats");

--- a/src/app/media_server.rs
+++ b/src/app/media_server.rs
@@ -10,7 +10,7 @@
 //! per-server split is **UNCONDITIONAL** — each public method on
 //! [`RustarrService`] resolves the service's
 //! [`KindDescriptor`](crate::capability::KindDescriptor) and dispatches to the
-//! [`plex`] or [`jellyfin`] impl by [`AuthStyle`](crate::capability::AuthStyle)
+//! [`plex`] or [`jellyfin`] impl by [`AuthStyle`]
 //! rather than matching the kind ad-hoc inside the method body.
 //!
 //! Scope split (locked in the bead): `sessions`, `libraries`, and `search` are

--- a/src/app/media_server/plex.rs
+++ b/src/app/media_server/plex.rs
@@ -3,7 +3,7 @@
 //! Plex is an HTTP API that returns **XML by default**; per the bead's FACT
 //! comment it requires `Accept: application/json` on EVERY call to negotiate a
 //! JSON body. That negotiation is a TRANSPORT concern, so each request here just
-//! passes [`ACCEPT_JSON`] as the `accept_mime` argument to
+//! passes `ACCEPT_JSON` as the `accept_mime` argument to
 //! [`send_get`](crate::rustarr::RustarrClient::send_get) — no XML parsing lives in
 //! this module (architecture decision C6-a).
 //!

--- a/src/app/requests.rs
+++ b/src/app/requests.rs
@@ -54,7 +54,7 @@ impl RustarrService {
     }
 
     /// GET `{prefix}/request?filter=&take=&skip=` — the request list, slimmed to
-    /// [`REQUEST_FIELDS`]. `filter` (e.g. `pending`/`approved`/`available`),
+    /// `REQUEST_FIELDS`. `filter` (e.g. `pending`/`approved`/`available`),
     /// `take`, and `skip` are optional pagination/selection knobs.
     pub async fn req_list(
         &self,
@@ -154,7 +154,7 @@ impl RustarrService {
     }
 
     /// GET `{prefix}/search?query=` — multi-search for titles to request, slimmed
-    /// to [`SEARCH_FIELDS`]. The `id` in each result is the TMDB id to pass into
+    /// to `SEARCH_FIELDS`. The `id` in each result is the TMDB id to pass into
     /// [`req_create`](Self::req_create). READ.
     pub async fn req_search(&self, service: &str, query: &str) -> Result<Value> {
         let config = self.requests_context(service)?;

--- a/src/app/stats.rs
+++ b/src/app/stats.rs
@@ -6,13 +6,13 @@
 //! REST resource surface. Each command therefore:
 //!   1. resolves a Stats service (capability-checked — a non-tautulli kind is
 //!      rejected before any request is built);
-//!   2. builds the request through [`query_get`](crate::rustarr::query_get), which
+//!   2. builds the request through [`query_get`], which
 //!      percent-encodes every param value (user text like `"x&cmd=delete"` cannot
 //!      inject a second `cmd`, S6) AND injects the `apikey` exactly once via the
 //!      shared query-auth path — so this module NEVER adds `apikey` itself (no
 //!      double key, and the key never appears in `cmd`/path strings, which Tautulli
 //!      logs to its access log);
-//!   3. unwraps the envelope ([`unwrap_tautulli`]) — surfacing the upstream
+//!   3. unwraps the envelope (`unwrap_tautulli`) — surfacing the upstream
 //!      `message` as an error when `result != "success"` — and slims the payload to
 //!      the fields agents need (AN-6 context budget).
 //!
@@ -115,7 +115,7 @@ impl RustarrService {
     }
 
     /// GET `?cmd=get_activity` → current streams. Slims to a stream count plus the
-    /// per-stream essentials ([`SESSION_FIELDS`]). READ.
+    /// per-stream essentials (`SESSION_FIELDS`). READ.
     pub async fn stats_activity(&self, service: &str) -> Result<Value> {
         let config = self.stats_context(service)?;
         let data = self.stats_cmd(config, "get_activity", &[]).await?;
@@ -131,7 +131,7 @@ impl RustarrService {
     }
 
     /// GET `?cmd=get_history[&start=&length=&user=]` → watch history, slimmed to
-    /// [`HISTORY_FIELDS`]. `start`/`length` are Tautulli's pagination knobs and
+    /// `HISTORY_FIELDS`. `start`/`length` are Tautulli's pagination knobs and
     /// `user` filters by username. READ.
     pub async fn stats_history(
         &self,
@@ -169,14 +169,14 @@ impl RustarrService {
         Ok(slimmed)
     }
 
-    /// GET `?cmd=get_users` → user list, slimmed to [`USER_FIELDS`]. READ.
+    /// GET `?cmd=get_users` → user list, slimmed to `USER_FIELDS`. READ.
     pub async fn stats_users(&self, service: &str) -> Result<Value> {
         let config = self.stats_context(service)?;
         let data = self.stats_cmd(config, "get_users", &[]).await?;
         Ok(slim(data, USER_FIELDS))
     }
 
-    /// GET `?cmd=get_libraries` → library list, slimmed to [`LIBRARY_FIELDS`]. READ.
+    /// GET `?cmd=get_libraries` → library list, slimmed to `LIBRARY_FIELDS`. READ.
     pub async fn stats_libraries(&self, service: &str) -> Result<Value> {
         let config = self.stats_context(service)?;
         let data = self.stats_cmd(config, "get_libraries", &[]).await?;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -26,7 +26,7 @@
 //!   - [`command`] — the parsed [`Command`] enum (pure data).
 //!   - [`router`]  — `token1` → infra verb OR service→kind→capability dispatch.
 //!   - [`parse`]   — shared flag parsers (path/body/confirm + selectors).
-//!   - [`usage`]   — USAGE generated from the action registry + capability map.
+//!   - [`usage`](mod@self::usage)   — USAGE generated from the action registry + capability map.
 //!   - [`doctor`] / [`setup`] / [`watch`] — infra-command implementations.
 //!
 //! Capability beads add curated commands as parse-only modules under

--- a/src/cli/router.rs
+++ b/src/cli/router.rs
@@ -149,7 +149,7 @@ fn parse_setup_command(rest: &[String]) -> Result<Command> {
 ///   2. **Generic passthrough fallback** — if no curated parser claimed the verb,
 ///      the generic surface common to every capability handles it: `status`,
 ///      `get`, `post`, `put`, `delete`. Any other verb yields a clear "unknown
-///      command for <service>" error.
+///      command for `<service>` error.
 pub fn parse_capability_command(
     kind: ServiceKind,
     capability: Capability,

--- a/src/cli/usage.rs
+++ b/src/cli/usage.rs
@@ -86,7 +86,7 @@ fn build_usage() -> String {
 }
 
 /// Append a per-capability section listing curated commands (empty until later
-/// beads populate [`curated_commands`](crate::actions::curated_commands)).
+/// beads populate [`curated_commands`]).
 fn append_curated_commands(out: &mut String) {
     if curated_commands().is_empty() {
         return;

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,7 +21,7 @@ pub mod services;
 // paths keep working unchanged.
 pub use auth::{AuthConfig, AuthMode};
 pub use mcp::McpConfig;
-pub use services::{default_data_dir, ServiceConfig, ServiceKind};
+pub use services::{default_data_dir, resolve_data_dir, ServiceConfig, ServiceKind};
 
 // Bring the private env helpers into this module's scope. They are used by
 // `Config::load` below and exercised by the colocated tests via `super::*`.
@@ -168,11 +168,7 @@ impl Config {
 }
 
 fn load_dotenv_defaults() -> anyhow::Result<()> {
-    let data_dir = if let Some(value) = std::env::var_os("RUSTARR_HOME") {
-        std::path::PathBuf::from(value)
-    } else {
-        default_data_dir()?
-    };
+    let data_dir = resolve_data_dir()?;
     let path = data_dir.join(".env");
     let contents = match std::fs::read_to_string(&path) {
         Ok(contents) => contents,

--- a/src/config/services.rs
+++ b/src/config/services.rs
@@ -163,6 +163,20 @@ pub fn default_data_dir() -> anyhow::Result<std::path::PathBuf> {
     Ok(home.join(SERVICE_HOME_DIRNAME))
 }
 
+/// Resolve the service data directory, honouring `RUSTARR_HOME` over the default.
+///
+/// `RUSTARR_HOME`, when set, takes precedence (used for tests, plugin installs,
+/// and custom deployments). Otherwise falls back to [`default_data_dir`]
+/// (`/data` in a container, `~/.rustarr` on bare metal). This is the single
+/// source of truth for "where does the data dir live" — both `.env` loading and
+/// the binary's logging setup go through it.
+pub fn resolve_data_dir() -> anyhow::Result<std::path::PathBuf> {
+    match std::env::var_os("RUSTARR_HOME") {
+        Some(value) => Ok(std::path::PathBuf::from(value)),
+        None => default_data_dir(),
+    }
+}
+
 // ── Service loading from env ────────────────────────────────────────────────────
 
 pub(super) fn load_services_from_env(config: &mut super::RustarrConfig) -> anyhow::Result<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,15 +17,17 @@ pub mod cli;
 pub mod config;
 pub(crate) mod logging;
 pub mod mcp;
+pub mod run_mode;
 pub mod rustarr;
 pub mod server;
 pub(crate) mod token_limit;
 
-/// Initialise dual logging (pretty console + JSON file) for the binary.
+/// Initialise dual logging for the binary: pretty colored output on stderr plus
+/// a JSON-lines file at `{data_dir}/logs/{service}.log` (truncated past 10MB at
+/// startup).
 ///
-/// Re-exported from the crate-private [`logging`] module so the binary can wire
-/// up logging without widening the whole module's visibility. See
-/// [`logging::init`] for behaviour.
+/// Re-exported from the crate-private `logging` module so the binary can wire up
+/// logging without widening the whole module's visibility.
 pub use logging::init as init_logging;
 
 /// Test helpers — available when `features = ["test-support"]` or in `cfg(test)`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,11 +15,18 @@ pub mod app;
 pub mod capability;
 pub mod cli;
 pub mod config;
-pub mod logging;
+pub(crate) mod logging;
 pub mod mcp;
 pub mod rustarr;
 pub mod server;
-pub mod token_limit;
+pub(crate) mod token_limit;
+
+/// Initialise dual logging (pretty console + JSON file) for the binary.
+///
+/// Re-exported from the crate-private [`logging`] module so the binary can wire
+/// up logging without widening the whole module's visibility. See
+/// [`logging::init`] for behaviour.
+pub use logging::init as init_logging;
 
 /// Test helpers — available when `features = ["test-support"]` or in `cfg(test)`.
 ///

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -16,24 +16,26 @@
 //! # Usage in main.rs
 //!
 //! This module is crate-private; the binary calls [`init`] via the
-//! [`crate::init_logging`] re-export. The wiring in `main.rs` is:
+//! [`crate::init_logging`] re-export. `main.rs` wires it up best-effort — file
+//! logging failures degrade to stderr rather than aborting startup:
 //!
 //! ```rust,ignore
-//! use rustarr::init_logging;
+//! use rustarr::{config::resolve_data_dir, init_logging};
 //!
 //! if serve_mode {
 //!     // HTTP server: dual logging (pretty console + JSON file under
-//!     // {data_dir}/logs/rustarr.log).
-//!     let data_dir = /* RUSTARR_HOME or default_data_dir() */;
-//!     init_logging(&data_dir, "rustarr")?;
-//! } else {
-//!     // stdio / CLI: stderr only at warn — a log file or stdout writes would
-//!     // corrupt the MCP JSON-RPC stream or CLI output.
-//!     tracing_subscriber::fmt()
-//!         .with_env_filter(EnvFilter::new("warn"))
-//!         .with_writer(std::io::stderr)
-//!         .init();
+//!     // {data_dir}/logs/rustarr.log). Falls back to the stderr-only subscriber
+//!     // below if the data dir / log file is unavailable.
+//!     if resolve_data_dir().and_then(|d| init_logging(&d, "rustarr")).is_ok() {
+//!         return;
+//!     }
 //! }
+//! // stdio / CLI (or serve fallback): stderr only — a log file or stdout writes
+//! // would corrupt the MCP JSON-RPC stream or CLI output.
+//! tracing_subscriber::fmt()
+//!     .with_env_filter(EnvFilter::new(if serve_mode { "info" } else { "warn" }))
+//!     .with_writer(std::io::stderr)
+//!     .init();
 //! ```
 //!
 //! # TEMPLATE: Log file location
@@ -41,9 +43,11 @@
 //! Logs are written to `{data_dir}/logs/{service}.log`.
 //! For the rustarr service this resolves to `~/.rustarr/logs/rustarr.log`.
 //!
-//! The file is truncated (not rotated) when it exceeds 10MB. This keeps
-//! disk usage predictable and eliminates the complexity of log rotation.
-//! For production deployments that need persistent logs, configure a log
+//! The file is truncated (not rotated) at **startup** if it exceeds 10MB — see
+//! [`truncate_log_if_needed`]. The cap is enforced only once per process, so a
+//! long-running server can grow the file past 10MB until the next restart; this
+//! keeps the implementation simple and avoids log rotation. For production
+//! deployments that need persistent or strictly-bounded logs, configure a log
 //! aggregator (e.g. Loki, Datadog, CloudWatch) to ship from stderr instead.
 
 pub mod aurora;
@@ -73,7 +77,7 @@ use formatter::AuroraFormatter;
 /// # TEMPLATE: EnvFilter precedence
 ///
 /// Log levels are controlled by `RUST_LOG`. If unset, defaults to `"info"`.
-/// Rustarrs:
+/// Examples:
 /// - `RUST_LOG=debug` — show all debug logs
 /// - `RUST_LOG=info,rmcp=warn` — info level, suppress rmcp crate noise
 /// - `RUST_LOG=rustarr=trace` — trace this crate only
@@ -174,11 +178,15 @@ const LOG_FILE_MAX_BYTES: u64 = 10 * 1024 * 1024; // 10 MiB
 /// Traditional log rotation creates `service.log.1`, `service.log.2`, etc.
 /// We truncate instead because:
 /// 1. Simpler — no need to manage multiple files or `logrotate` config
-/// 2. Predictable — disk usage is always ≤ 10MB, never grows unboundedly
+/// 2. Bounded at startup — the file is reset to 0 whenever a process starts and
+///    finds it over the cap, so it never accumulates across restarts. (It is
+///    *not* re-checked mid-run, so a single long-lived process can still grow
+///    the file past the cap until its next restart.)
 /// 3. Safe for agents — agents reading the log file always find a single file
 ///
-/// When the file is truncated, the server logs a WARN message so the operator
-/// knows why the log history starts from the current process.
+/// The check runs before the tracing subscriber is installed, so when it
+/// truncates it writes the WARN notice straight to stderr (see below) — the
+/// operator still sees why the log history starts from the current process.
 fn truncate_log_if_needed(path: &std::path::PathBuf) -> Result<()> {
     if !path.exists() {
         return Ok(());

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -217,7 +217,7 @@ fn truncate_log_if_needed(path: &std::path::PathBuf) -> Result<()> {
 ///
 /// Priority order (highest to lowest):
 ///
-/// 1. `NO_COLOR` env var set → **no color** (https://no-color.org convention)
+/// 1. `NO_COLOR` env var set → **no color** (<https://no-color.org> convention)
 /// 2. `FORCE_COLOR` env var set → **force color** (useful in Docker/CI)
 /// 3. `stderr` is a TTY → **color** (interactive terminal)
 /// 4. `stderr` is not a TTY → **no color** (piped/redirected)

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -13,28 +13,26 @@
 //! semantic colors, noise suppression. The file output preserves all fields
 //! for programmatic analysis (grep, jq, log aggregators, AI agents).
 //!
-//! # TEMPLATE: Usage in main.rs
+//! # Usage in main.rs
 //!
-//! Replace the existing `tracing_subscriber` setup in `main.rs` with:
-//!
-//! ```rust,ignore
-//! use rustarr::logging;
-//!
-//! let data_dir = config.data_dir(); // e.g. ~/.rustarr
-//! logging::init(&data_dir, "rustarr")?;
-//! ```
-//!
-//! In stdio mode, suppress all logs to avoid polluting the MCP JSON stream:
+//! This module is crate-private; the binary calls [`init`] via the
+//! [`crate::init_logging`] re-export. The wiring in `main.rs` is:
 //!
 //! ```rust,ignore
-//! if stdio_mode {
-//!     // Don't call logging::init() — tracing stays at warn level on stderr only
+//! use rustarr::init_logging;
+//!
+//! if serve_mode {
+//!     // HTTP server: dual logging (pretty console + JSON file under
+//!     // {data_dir}/logs/rustarr.log).
+//!     let data_dir = /* RUSTARR_HOME or default_data_dir() */;
+//!     init_logging(&data_dir, "rustarr")?;
+//! } else {
+//!     // stdio / CLI: stderr only at warn — a log file or stdout writes would
+//!     // corrupt the MCP JSON-RPC stream or CLI output.
 //!     tracing_subscriber::fmt()
 //!         .with_env_filter(EnvFilter::new("warn"))
 //!         .with_writer(std::io::stderr)
 //!         .init();
-//! } else {
-//!     logging::init(&data_dir, "rustarr")?;
 //! }
 //! ```
 //!

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,8 +19,8 @@ use rmcp::{transport::stdio, ServiceExt};
 use rustarr::{
     app::RustarrService,
     cli,
-    config::Config,
-    mcp,
+    config::{default_data_dir, Config},
+    init_logging, mcp,
     rustarr::RustarrClient,
     server::{self, resolve_auth_policy_kind, AppState, AuthPolicy, AuthPolicyKind},
 };
@@ -56,13 +56,26 @@ async fn main() -> Result<()> {
     } else {
         "info"
     };
-    fmt()
-        .with_env_filter(
-            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(log_level)),
-        )
-        .with_writer(std::io::stderr)
-        .with_target(true)
-        .init();
+    if serve_mode {
+        // HTTP server mode: dual logging — pretty console (stderr) + JSON lines
+        // file under `{data_dir}/logs/rustarr.log` for log aggregators / agents.
+        let data_dir = match std::env::var_os("RUSTARR_HOME") {
+            Some(value) => std::path::PathBuf::from(value),
+            None => default_data_dir()?,
+        };
+        init_logging(&data_dir, "rustarr")?;
+    } else {
+        // stdio / CLI mode: stderr only, never a log file. stdout carries the
+        // MCP JSON-RPC stream (stdio) or CLI output, so logs stay on stderr at
+        // warn to avoid corrupting either.
+        fmt()
+            .with_env_filter(
+                EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(log_level)),
+            )
+            .with_writer(std::io::stderr)
+            .with_target(true)
+            .init();
+    }
 
     if serve_mode {
         serve_mcp().await

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,8 +19,9 @@ use rmcp::{transport::stdio, ServiceExt};
 use rustarr::{
     app::RustarrService,
     cli,
-    config::{default_data_dir, Config},
+    config::{resolve_data_dir, Config},
     init_logging, mcp,
+    run_mode::RunMode,
     rustarr::RustarrClient,
     server::{self, resolve_auth_policy_kind, AppState, AuthPolicy, AuthPolicyKind},
 };
@@ -44,46 +45,47 @@ async fn main() -> Result<()> {
         _ => {}
     }
 
-    // Suppress logs in stdio/CLI mode — MCP clients communicate over stdio
-    // and cannot tolerate log lines mixed into the JSON stream.
-    let stdio_mode = matches!(args.as_slice(), [c] if c == "mcp");
-    let serve_mode = args.is_empty()
-        || matches!(args.as_slice(), [c] if c == "serve")
-        || matches!(args.as_slice(), [a, b] if a == "serve" && b == "mcp");
+    let mode = RunMode::classify(&args);
+    init_logging_for_mode(mode);
 
-    let log_level = if stdio_mode || !serve_mode {
-        "warn"
-    } else {
-        "info"
-    };
-    if serve_mode {
-        // HTTP server mode: dual logging — pretty console (stderr) + JSON lines
-        // file under `{data_dir}/logs/rustarr.log` for log aggregators / agents.
-        let data_dir = match std::env::var_os("RUSTARR_HOME") {
-            Some(value) => std::path::PathBuf::from(value),
-            None => default_data_dir()?,
-        };
-        init_logging(&data_dir, "rustarr")?;
-    } else {
-        // stdio / CLI mode: stderr only, never a log file. stdout carries the
-        // MCP JSON-RPC stream (stdio) or CLI output, so logs stay on stderr at
-        // warn to avoid corrupting either.
-        fmt()
-            .with_env_filter(
-                EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(log_level)),
-            )
-            .with_writer(std::io::stderr)
-            .with_target(true)
-            .init();
+    match mode {
+        RunMode::Serve => serve_mcp().await,
+        RunMode::Stdio => serve_stdio_mcp().await,
+        RunMode::Cli => run_cli().await,
+    }
+}
+
+/// Install the tracing subscriber appropriate for `mode`.
+///
+/// `Serve` gets dual logging — pretty console on stderr **plus** a JSON-lines
+/// file under `{data_dir}/logs/rustarr.log` for log aggregators / agents.
+/// `Stdio` and `Cli` get a stderr-only `warn` subscriber: stdout carries the MCP
+/// JSON-RPC stream or CLI output, so logs must never land there.
+///
+/// File logging is **best-effort**. If the data dir can't be resolved or the log
+/// file can't be opened (read-only mount, permissions, no `HOME`), the server
+/// still starts with stderr-only logging rather than aborting — its function
+/// doesn't depend on a writable log file. This is safe because every fallible
+/// step in `init_logging` runs *before* it installs the global subscriber, so
+/// the fallback below can't double-install.
+fn init_logging_for_mode(mode: RunMode) {
+    if mode.is_serve() {
+        match resolve_data_dir().and_then(|dir| init_logging(&dir, "rustarr")) {
+            Ok(()) => return,
+            Err(error) => eprintln!(
+                "WARN  file logging unavailable ({error:#}); continuing with stderr-only logs"
+            ),
+        }
     }
 
-    if serve_mode {
-        serve_mcp().await
-    } else if stdio_mode {
-        serve_stdio_mcp().await
-    } else {
-        run_cli().await
-    }
+    let log_level = if mode.is_serve() { "info" } else { "warn" };
+    fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(log_level)),
+        )
+        .with_writer(std::io::stderr)
+        .with_target(true)
+        .init();
 }
 
 // ── modes ─────────────────────────────────────────────────────────────────────

--- a/src/run_mode.rs
+++ b/src/run_mode.rs
@@ -1,0 +1,48 @@
+//! Binary launch-mode classification.
+//!
+//! A pure mapping from process arguments to the mode `main` dispatches on. It
+//! lives in the library crate (not `main.rs`) so the arg→mode rules — which are
+//! ordering-sensitive and easy to break — can be unit-tested without spawning
+//! the binary.
+
+/// The mode the binary runs in, derived from its CLI arguments.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RunMode {
+    /// HTTP MCP server — `rustarr`, `rustarr serve`, or `rustarr serve mcp`.
+    Serve,
+    /// Stdio MCP transport — `rustarr mcp`.
+    Stdio,
+    /// One-shot CLI command — anything else (`integrations`, `sonarr list`, …).
+    Cli,
+}
+
+impl RunMode {
+    /// Classify the process arguments (already stripped of `argv[0]`).
+    ///
+    /// `Serve` and `Stdio` only match their exact arg shapes; any extra or
+    /// unexpected argument falls through to `Cli`, where the CLI parser reports
+    /// a precise error.
+    #[must_use]
+    pub fn classify(args: &[String]) -> Self {
+        if args.is_empty()
+            || matches!(args, [c] if c == "serve")
+            || matches!(args, [a, b] if a == "serve" && b == "mcp")
+        {
+            RunMode::Serve
+        } else if matches!(args, [c] if c == "mcp") {
+            RunMode::Stdio
+        } else {
+            RunMode::Cli
+        }
+    }
+
+    /// Whether this mode runs the long-lived HTTP server.
+    #[must_use]
+    pub fn is_serve(self) -> bool {
+        matches!(self, RunMode::Serve)
+    }
+}
+
+#[cfg(test)]
+#[path = "run_mode_tests.rs"]
+mod tests;

--- a/src/run_mode_tests.rs
+++ b/src/run_mode_tests.rs
@@ -1,0 +1,38 @@
+use super::*;
+
+fn args(v: &[&str]) -> Vec<String> {
+    v.iter().map(|s| (*s).to_string()).collect()
+}
+
+#[test]
+fn empty_args_is_serve() {
+    assert_eq!(RunMode::classify(&args(&[])), RunMode::Serve);
+    assert!(RunMode::classify(&args(&[])).is_serve());
+}
+
+#[test]
+fn serve_and_serve_mcp_are_serve() {
+    assert_eq!(RunMode::classify(&args(&["serve"])), RunMode::Serve);
+    assert_eq!(RunMode::classify(&args(&["serve", "mcp"])), RunMode::Serve);
+}
+
+#[test]
+fn mcp_alone_is_stdio() {
+    assert_eq!(RunMode::classify(&args(&["mcp"])), RunMode::Stdio);
+    assert!(!RunMode::classify(&args(&["mcp"])).is_serve());
+}
+
+#[test]
+fn other_commands_are_cli() {
+    assert_eq!(RunMode::classify(&args(&["integrations"])), RunMode::Cli);
+    assert_eq!(RunMode::classify(&args(&["sonarr", "list"])), RunMode::Cli);
+    assert_eq!(RunMode::classify(&args(&["status"])), RunMode::Cli);
+}
+
+#[test]
+fn extra_args_fall_through_to_cli() {
+    // `mcp` is stdio only as a lone arg; with extras it's a CLI invocation.
+    assert_eq!(RunMode::classify(&args(&["mcp", "extra"])), RunMode::Cli);
+    // `serve` only pairs with `mcp`; any other second token is not serve.
+    assert_eq!(RunMode::classify(&args(&["serve", "http"])), RunMode::Cli);
+}

--- a/src/token_limit.rs
+++ b/src/token_limit.rs
@@ -62,8 +62,8 @@ pub const MAX_RESPONSE_BYTES: usize = 40_000;
 /// Serialize `value` for an MCP tool result, enforcing [`MAX_RESPONSE_BYTES`]
 /// with a *parseable* truncation marker.
 ///
-/// Unlike [`truncate_if_needed`], which appends a human notice that breaks JSON,
-/// this returns a string that is **always valid JSON**:
+/// Unlike a plain-text truncation notice (which would break JSON parsing), this
+/// returns a string that is **always valid JSON**:
 ///
 /// - Under the cap → the compact serialization of `value`.
 /// - Over the cap → a JSON object `{"truncated":true,"reason":...,"partial":"…"}`

--- a/src/token_limit.rs
+++ b/src/token_limit.rs
@@ -24,23 +24,17 @@
 //!
 //! ## Where to apply truncation
 //!
-//! Apply `truncate_if_needed()` in `mcp/tools.rs` AFTER the service call,
-//! BEFORE constructing the `CallToolResult`. Rustarr:
+//! Apply [`serialize_with_limit()`] in the MCP response path (see
+//! `mcp/rmcp_server.rs`) AFTER the service call, when serializing the result
+//! into the tool response. It returns a *parseable* JSON marker rather than a
+//! human notice, so the agent can detect truncation programmatically:
 //!
 //! ```rust,ignore
 //! use rustarr::token_limit;
 //!
 //! let result = state.service.list_things(limit, offset).await?;
-//! let text = serde_json::to_string_pretty(&result)?;
-//! let text = token_limit::truncate_if_needed(&text);
-//! Ok(json!({"result": text}))
-//! ```
-//!
-//! Or for the whole serialized response:
-//!
-//! ```rust,ignore
-//! let json = serde_json::to_string(&result)?;
-//! let json = token_limit::truncate_if_needed(&json);
+//! let (text, truncated) = token_limit::serialize_with_limit(&result);
+//! // `text` is bounded to MAX_RESPONSE_BYTES; `truncated` flags the cap.
 //! ```
 //!
 //! ## Truncation is a safety net, not the primary strategy
@@ -64,71 +58,6 @@
 /// Never exceed 100KB (25K tokens) — at that size, agents start losing
 /// context from earlier in the conversation.
 pub const MAX_RESPONSE_BYTES: usize = 40_000;
-
-/// Truncate `text` to [`MAX_RESPONSE_BYTES`] if it exceeds the cap.
-///
-/// When truncation occurs, appends a clear notice telling the agent:
-/// 1. That the response was truncated (not an error)
-/// 2. The exact token limit that was hit
-/// 3. How to get the full data (use pagination/filters)
-///
-/// # Truncation boundary
-///
-/// Truncation finds the last valid UTF-8 boundary within the content budget.
-/// The returned string, including the notice, never exceeds
-/// [`MAX_RESPONSE_BYTES`].
-///
-/// # TEMPLATE: Returning the raw truncated string
-///
-/// This function returns a `String`, not a `Value`. The caller wraps it
-/// as appropriate:
-///
-/// ```rust,ignore
-/// // In tools.rs:
-/// let raw = serde_json::to_string(&result)?;
-/// let output = token_limit::truncate_if_needed(&raw);
-/// // output is now a plain string — wrap it for the tool result:
-/// Ok(json!({ "data": output }))
-/// ```
-///
-/// Or embed the truncation check inside the serialized JSON directly:
-///
-/// ```rust,ignore
-/// let text = serde_json::to_string_pretty(&result)?;
-/// let text = token_limit::truncate_if_needed(&text);
-/// tool_text_result(text)  // helper that wraps in CallToolResult
-/// ```
-#[must_use]
-pub fn truncate_if_needed(text: &str) -> std::borrow::Cow<'_, str> {
-    if text.len() <= MAX_RESPONSE_BYTES {
-        return std::borrow::Cow::Borrowed(text);
-    }
-
-    let notice = format!(
-        "\n\n[TRUNCATED: response exceeded {MAX_RESPONSE_BYTES} bytes (~10K tokens).\n\
-        Use limit/offset parameters or more specific filters to get a smaller result.\n\
-        Rustarr: action=things, limit=20, offset=0]"
-    );
-    let content_budget = MAX_RESPONSE_BYTES.saturating_sub(notice.len());
-    debug_assert!(
-        notice.len() < MAX_RESPONSE_BYTES,
-        "truncation notice ({} bytes) must be smaller than MAX_RESPONSE_BYTES",
-        notice.len()
-    );
-
-    // Find the last valid UTF-8 char boundary at or before content_budget.
-    // Walks back at most 3 bytes (max UTF-8 char width is 4).
-    let boundary = {
-        let mut b = content_budget;
-        while !text.is_char_boundary(b) {
-            b -= 1;
-        }
-        b
-    };
-    let truncated = &text[..boundary];
-
-    std::borrow::Cow::Owned(format!("{truncated}{notice}"))
-}
 
 /// Serialize `value` for an MCP tool result, enforcing [`MAX_RESPONSE_BYTES`]
 /// with a *parseable* truncation marker.

--- a/src/token_limit_tests.rs
+++ b/src/token_limit_tests.rs
@@ -1,41 +1,6 @@
 use super::*;
 
 #[test]
-fn short_text_passes_through_unchanged() {
-    let text = "hello world";
-    assert_eq!(truncate_if_needed(text), text);
-}
-
-#[test]
-fn empty_string_passes_through() {
-    assert_eq!(truncate_if_needed(""), "");
-}
-
-#[test]
-fn text_at_exact_limit_passes_through() {
-    let text = "x".repeat(MAX_RESPONSE_BYTES);
-    let result = truncate_if_needed(&text);
-    assert!(!result.contains("[TRUNCATED"));
-    assert_eq!(result.len(), MAX_RESPONSE_BYTES);
-}
-
-#[test]
-fn text_over_limit_is_truncated() {
-    let text = "x".repeat(MAX_RESPONSE_BYTES + 100);
-    let result = truncate_if_needed(&text);
-    assert!(result.contains("[TRUNCATED"));
-    assert!(result.contains("limit/offset"));
-    assert!(result.len() <= MAX_RESPONSE_BYTES);
-}
-
-#[test]
-fn truncation_notice_mentions_token_limit() {
-    let text = "y".repeat(MAX_RESPONSE_BYTES + 1);
-    let result = truncate_if_needed(&text);
-    assert!(result.contains("10K tokens"));
-}
-
-#[test]
 fn serialize_with_limit_passes_small_payload_through() {
     let value = serde_json::json!({ "ok": true, "items": [1, 2, 3] });
     let (text, truncated) = serialize_with_limit(&value);
@@ -76,15 +41,4 @@ fn serialize_with_limit_holds_cap_for_escape_heavy_payload() {
     let parsed: serde_json::Value =
         serde_json::from_str(&text).expect("truncated output is valid JSON");
     assert_eq!(parsed["truncated"], true);
-}
-
-#[test]
-fn truncates_at_utf8_boundary() {
-    let mut text = "a".repeat(MAX_RESPONSE_BYTES - 1);
-    text.push('€');
-    let result = truncate_if_needed(&text);
-    let notice_start = result.find("[TRUNCATED").expect("notice should be present") - 2;
-    assert!(result[..notice_start].chars().all(|c| c == 'a'));
-    assert!(result.len() <= MAX_RESPONSE_BYTES);
-    assert!(result.contains("[TRUNCATED"));
 }


### PR DESCRIPTION
## Summary

The `src/logging/` module was dead code: `main.rs` built its tracing subscriber inline via `tracing_subscriber::{fmt, EnvFilter}` and never called `logging::init`. Keeping the module `pub` masked ~21 unused items. Separately, `token_limit::truncate_if_needed` was an unused `pub fn` (only `serialize_with_limit` is used, by `mcp/rmcp_server.rs`).

Per direction, the `logging` module is **wired up** (not deleted), and the unused `token_limit` function is removed.

## Changes

- **Wire `logging::init` into `main.rs`.** Serve mode now uses dual logging — `AuroraFormatter` console on stderr **+** JSON-lines file at `{data_dir}/logs/rustarr.log` (10 MB truncation, `NO_COLOR`/`FORCE_COLOR`/TTY detection). stdio/CLI modes keep the stderr-only `warn` subscriber so the MCP JSON-RPC stream and CLI output are never corrupted. `data_dir` resolves from `RUSTARR_HOME` or `config::default_data_dir()`.
- **Tighten visibility.** `logging` and `token_limit` are now `pub(crate)`. Because the binary is a separate crate, only `logging::init` is surfaced, re-exported as `crate::init_logging`.
- **Remove dead code.** Deleted `token_limit::truncate_if_needed` and its tests (confirmed not called by `serialize_with_limit`).
- Updated stale `logging.rs` docs + CHANGELOG.

## Behavioral note

Server mode now writes a JSON log file under the data dir (`~/.rustarr/logs/` by default) — the intended effect of wiring the module, and well-suited to the Cortex log-aggregation setup. stdio/CLI behavior is unchanged.

## Verification

- `cargo build` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test` — all suites pass (502 + others, 0 failures); doc-tests pass
- Runtime smoke test confirmed both sinks (JSON file + Aurora console).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wired up the logging module with best-effort dual logging in server mode (pretty stderr + JSON-lines file). Removed the dead `token_limit::truncate_if_needed`. Stdio/CLI remain stderr-only to keep MCP output clean.

- **Refactors**
  - Installed `init_logging` in `main.rs` for server mode with dual logging to `{data_dir}/logs/rustarr.log` (10 MB cap at startup), resolving `data_dir` via `config::resolve_data_dir`; falls back to stderr-only if file logging fails.
  - Added `run_mode::RunMode` (`Serve`/`Stdio`/`Cli`) and used it to install the right subscriber; stdio/CLI stay `warn` to stderr only. Tightened visibility (`logging`, `token_limit` are `pub(crate)`), re-exported `init_logging`, and removed `token_limit::truncate_if_needed` + its tests; `serialize_with_limit` remains.

- **Docs/CI**
  - Fixed rustdoc warnings and clarified the startup-only 10 MB cap.
  - Added a `docs` CI job (`cargo doc` with `-D warnings`).

<sup>Written for commit 20354d8cb33bf9ffb97631f39e69bb81d5e97a54. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/rustarr/pull/16?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

