### PR TITLE
feat: add yarr npm launcher package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Node launcher package and curl installer.** Added `packages/yarr-mcp`, an npm
+  package that installs the matching GitHub Release binary and exposes `yarr`
+  (plus a `rustarr` alias) so users can run `npx -y yarr-mcp mcp` or
+  `npm i -g yarr-mcp`.
+  Added `scripts/install.sh` for one-line curl installs that place `rustarr` on
+  `PATH` and create a `yarr` symlink.
 - **Curated Bazarr and Tracearr action surfaces.** Bazarr now has read-scoped
   `subtitles_*` actions for status, subtitle inventories, wanted queues,
   providers, and languages. Tracearr now has read-scoped `trace_*` public

--- a/README.md
+++ b/README.md
@@ -57,6 +57,33 @@ of the fleet through these (MCP-only) actions, also available on the CLI via
 
 Destructive deletes are refused inside Code Mode (no confirmation channel mid-script); call them directly with `--confirm`.
 
+## Install
+
+The recommended install path is the Node launcher package:
+
+```bash
+# Run the stdio MCP server without a permanent install
+npx -y yarr-mcp mcp
+
+# Or install the launcher globally
+npm i -g yarr-mcp
+yarr --version
+yarr mcp
+```
+
+The npm package downloads the matching GitHub Release binary during install and
+adds a `yarr` command to `PATH`. It also exposes a `rustarr` alias for existing
+CLI scripts.
+
+For machines without npm, use the one-line release installer:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/jmagar/rustarr-mcp/main/scripts/install.sh | bash
+```
+
+That script installs `rustarr` into `~/.local/bin` and creates a `yarr` symlink
+next to it.
+
 ## Generated operations vs curated commands
 
 The 6 spec-backed services are served by **generated OpenAPI operations** — the
@@ -112,18 +139,18 @@ The `*_API_KEY` pattern covers most Arr-style services. qBittorrent uses usernam
 ## Run
 
 ```bash
-cargo run -- help
-cargo run -- radarr status
-cargo run -- sonarr get --path /api/v3/system/status
-cargo run -- radarr post --path /api/v3/command --body '{"name":"RefreshMovie"}' --confirm
+yarr help
+yarr radarr status
+yarr sonarr get --path /api/v3/system/status
+yarr radarr post --path /api/v3/command --body '{"name":"RefreshMovie"}' --confirm
 
 # generated ops (spec-backed services) + curated commands
-cargo run -- sonarr op get_series
-cargo run -- qbittorrent queue
-cargo run -- tautulli activity
+yarr sonarr op get_series
+yarr qbittorrent queue
+yarr tautulli activity
 
-cargo run -- serve
-cargo run -- mcp
+yarr serve
+yarr mcp
 ```
 
 HTTP MCP endpoint:
@@ -158,7 +185,7 @@ stdio:
 {
   "mcpServers": {
     "rustarr": {
-      "command": "/path/to/rustarr/target/release/rustarr",
+      "command": "yarr",
       "args": ["mcp"],
       "env": {
         "RUST_LOG": "info,rustarr=debug"
@@ -190,6 +217,7 @@ The service layer owns business rules:
 ## Development
 
 ```bash
+cargo run -- help
 cargo fmt --check
 cargo test
 cargo clippy -- -D warnings

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -13,11 +13,12 @@ last_reviewed: "2026-05-15"
 
 # Deployment
 
-This template supports three deployment modes:
+This template supports four deployment modes:
 
-1. **Local development** with `just dev`.
-2. **Docker Compose** with `just docker-up`.
-3. **User systemd** with an installed release binary.
+1. **Node launcher** with `npx -y yarr-mcp mcp` or `npm i -g yarr-mcp`.
+2. **Local development** with `just dev`.
+3. **Docker Compose** with `just docker-up`.
+4. **User systemd** with an installed release binary.
 
 ## Binary command surface
 
@@ -31,6 +32,15 @@ Every server binary exposes exactly two server modes and a CLI:
 | `rustarr doctor` | Pre-flight check | Validates environment and config |
 | `rustarr --help` | Help | Print usage |
 | `rustarr --version` | Version | Print version |
+
+The npm package exposes `yarr` as the primary command and keeps `rustarr` as an
+alias:
+
+```bash
+npx -y yarr-mcp mcp
+npm i -g yarr-mcp
+yarr serve
+```
 
 ## Deployment checklist
 
@@ -107,15 +117,15 @@ Non-loopback HTTP deployments must use bearer auth or OAuth. The server refuses 
   "mcpServers": {
     "rustarr": {
       "type": "stdio",
-      "command": "rustarr",
+      "command": "yarr",
       "args": ["mcp"]
     }
   }
 }
 ```
 
-The binary must be in `$PATH` for stdio configs. The plugin uses its bundled
-`${CLAUDE_PLUGIN_ROOT}/bin/rustarr` binary for lifecycle setup.
+The `yarr` command must be in `$PATH` for stdio configs. Install it with
+`npm i -g yarr-mcp`, or use the curl installer when npm is unavailable.
 
 ## Public endpoints
 

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -885,7 +885,7 @@ networks:
 
 ```bash
 #!/usr/bin/env bash
-# One-line install: curl -fsSL https://raw.githubusercontent.com/jmagar/rustarr-mcp/main/install.sh | bash
+# One-line install: curl -fsSL https://raw.githubusercontent.com/jmagar/rustarr-mcp/main/scripts/install.sh | bash
 set -euo pipefail
 
 REPO="jmagar/rustarr-mcp"

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -15,15 +15,24 @@ export RUSTARR_RADARR_API_KEY=change-me
 ## 2. Try the CLI
 
 ```bash
-cargo run -- help
-cargo run -- radarr status
-cargo run -- radarr get --path /api/v3/system/status
+npx -y yarr-mcp help
+npx -y yarr-mcp radarr status
+npx -y yarr-mcp radarr get --path /api/v3/system/status
 ```
+
+For a permanent command on `PATH`:
+
+```bash
+npm i -g yarr-mcp
+yarr --version
+```
+
+For local development from source, replace `npx -y yarr-mcp` with `cargo run --`.
 
 ## 3. Start HTTP MCP
 
 ```bash
-cargo run -- serve
+yarr serve
 ```
 
 Call the tool:
@@ -37,7 +46,7 @@ curl -s http://127.0.0.1:40070/mcp \
 ## 4. Run stdio MCP
 
 ```bash
-cargo run -- mcp
+npx -y yarr-mcp mcp
 ```
 
 Use stdio mode for local child-process MCP clients. It bypasses HTTP auth because the OS process boundary is the trust boundary.

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -25,6 +25,7 @@ Maintenance scripts live in `scripts/`. The authoritative per-script usage refer
 | Hygiene | `asciicheck.py`, `check-file-size.sh`, `block-env-commits.sh` |
 | MCP/plugin validation | `check-schema-docs.py`, `validate-plugin-layout.sh`, `check-plugin-hook-contract.py`, `test-mcp-auth.sh` |
 | Runtime/deploy | `check-runtime-current.sh`, `sync-cargo.sh`, `bump-version.sh` |
+| Install | `install.sh` |
 | Reference docs | `refresh-docs.sh` |
 | Live tests | `live-read-smoke.sh` for legacy quick smoke; `cargo xtask live --suite all` for full guarded shart coverage |
 
@@ -34,6 +35,7 @@ Maintenance scripts live in `scripts/`. The authoritative per-script usage refer
 scripts/pre-release-check.sh
 scripts/pre-release-check.sh --mcporter   # include live MCP tests
 cargo xtask live --suite all              # guarded shart live suite
+curl -fsSL https://raw.githubusercontent.com/jmagar/rustarr-mcp/main/scripts/install.sh | bash
 scripts/refresh-docs.sh --dry-run
 scripts/test-mcp-auth.sh --url http://localhost:40070/mcp --token <token>
 ```
@@ -96,10 +98,10 @@ preflight() {
 
 One-line install:
 ```bash
-curl -fsSL https://raw.githubusercontent.com/jmagar/rustarr-mcp/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/jmagar/rustarr-mcp/main/scripts/install.sh | bash
 ```
 
-After install: `rustarr doctor` to validate the environment.
+After install: `yarr doctor` to validate the environment.
 
 ## block-env-commits.sh
 

--- a/docs/SYSTEMD.md
+++ b/docs/SYSTEMD.md
@@ -18,21 +18,22 @@ The template supports user-level systemd deployments when a unit named `rustarr-
 ## Install the binary
 
 ```bash
-cargo build --release
-install -m 755 target/release/rustarr ~/.local/bin/rustarr
+curl -fsSL https://raw.githubusercontent.com/jmagar/rustarr-mcp/main/scripts/install.sh | bash
 ```
 
-Or use the install script:
+Or install through npm:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/jmagar/rustarr-mcp/main/install.sh | bash
+npm i -g yarr-mcp
 ```
 
-The binary installs to `~/.local/bin/`. Verify it's in `$PATH`:
+The npm package installs `yarr` and `rustarr` shims. The curl installer writes
+`rustarr` to `~/.local/bin/` and creates a `yarr` symlink. Verify the command is
+in `$PATH`:
 
 ```bash
-rustarr --version
-rustarr doctor
+yarr --version
+yarr doctor
 ```
 
 ## Unit file pattern
@@ -44,7 +45,7 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=%h/.local/bin/rustarr serve mcp
+ExecStart=%h/.local/bin/yarr serve mcp
 Restart=on-failure
 RestartSec=5
 EnvironmentFile=%h/.rustarr/.env
@@ -54,6 +55,8 @@ WantedBy=default.target
 ```
 
 Key points:
+- The unit example assumes the curl installer. If you use `npm i -g yarr-mcp`, set
+  `ExecStart` to the absolute path returned by `command -v yarr`.
 - Use `EnvironmentFile` pointing at `~/.rustarr/.env` — never hardcode tokens in unit files.
 - `%h` expands to the user home directory.
 - `serve mcp` is the canonical Streamable HTTP mode (see `docs/DEPLOYMENT.md`).

--- a/packages/yarr-mcp/README.md
+++ b/packages/yarr-mcp/README.md
@@ -1,0 +1,32 @@
+# yarr-mcp
+
+Node launcher for the Rustarr MCP and CLI binary.
+
+```bash
+npx -y yarr-mcp mcp
+```
+
+Install globally when you want the command on `PATH`:
+
+```bash
+npm i -g yarr-mcp
+yarr --version
+yarr mcp
+```
+
+The package downloads the matching GitHub Release binary during `postinstall`.
+The npm package version and the Rustarr release tag are expected to match.
+
+The package name is `yarr-mcp` because the shorter `yarr` npm name is already
+occupied by an unrelated package. The installed command is still `yarr`.
+
+## Overrides
+
+```bash
+YARR_BINARY_VERSION=v0.4.0 npm i -g yarr-mcp
+YARR_RELEASE_BASE_URL=https://github.com/jmagar/rustarr-mcp/releases/download npm i -g yarr-mcp
+YARR_SKIP_DOWNLOAD=1 npm i -g yarr-mcp
+```
+
+Supported binary targets are Linux x64 and Windows x64, matching the current
+GitHub Release assets.

--- a/packages/yarr-mcp/bin/yarr.js
+++ b/packages/yarr-mcp/bin/yarr.js
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+const { binaryPath } = require("../lib/platform");
+
+function fail(message) {
+  process.stderr.write(`yarr: ${message}\n`);
+  process.exit(1);
+}
+
+const binary = binaryPath();
+
+if (!fs.existsSync(binary)) {
+  const installer = path.resolve(__dirname, "..", "scripts", "install.js");
+  const install = spawnSync(process.execPath, [installer], { stdio: "inherit" });
+  if (install.status !== 0) {
+    fail("binary is not installed; postinstall may have failed");
+  }
+}
+
+const child = spawnSync(binary, process.argv.slice(2), { stdio: "inherit" });
+
+if (child.error) {
+  fail(child.error.message);
+}
+
+if (child.signal) {
+  process.kill(process.pid, child.signal);
+} else {
+  process.exit(child.status ?? 1);
+}

--- a/packages/yarr-mcp/lib/platform.js
+++ b/packages/yarr-mcp/lib/platform.js
@@ -1,0 +1,56 @@
+"use strict";
+
+const path = require("node:path");
+
+function packageVersion() {
+  return require("../package.json").version;
+}
+
+function targetFor(platform = process.platform, arch = process.arch) {
+  if (platform === "linux" && arch === "x64") {
+    return {
+      asset: "rustarr-x86_64.tar.gz",
+      binary: "rustarr",
+    };
+  }
+
+  if (platform === "win32" && arch === "x64") {
+    return {
+      asset: "rustarr-windows-x86_64.tar.gz",
+      binary: "rustarr.exe",
+    };
+  }
+
+  throw new Error(`Unsupported platform ${platform}/${arch}. Supported targets: linux/x64, win32/x64.`);
+}
+
+function releaseVersion(env = process.env) {
+  const raw = env.YARR_BINARY_VERSION || env.RUSTARR_BINARY_VERSION || packageVersion();
+  return raw.startsWith("v") ? raw : `v${raw}`;
+}
+
+function releaseBaseUrl(env = process.env) {
+  return env.YARR_RELEASE_BASE_URL || "https://github.com/jmagar/rustarr-mcp/releases/download";
+}
+
+function downloadUrl(target, env = process.env) {
+  return `${releaseBaseUrl(env)}/${releaseVersion(env)}/${target.asset}`;
+}
+
+function installRoot() {
+  return path.resolve(__dirname, "..", "vendor");
+}
+
+function binaryPath(platform = process.platform, arch = process.arch) {
+  const target = targetFor(platform, arch);
+  return path.join(installRoot(), target.binary);
+}
+
+module.exports = {
+  binaryPath,
+  downloadUrl,
+  installRoot,
+  packageVersion,
+  releaseVersion,
+  targetFor,
+};

--- a/packages/yarr-mcp/package.json
+++ b/packages/yarr-mcp/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "yarr-mcp",
+  "version": "0.4.0",
+  "description": "Node launcher for the rustarr/yarr MCP and CLI binary.",
+  "license": "MIT",
+  "homepage": "https://github.com/jmagar/rustarr-mcp#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jmagar/rustarr-mcp.git"
+  },
+  "bugs": {
+    "url": "https://github.com/jmagar/rustarr-mcp/issues"
+  },
+  "bin": {
+    "yarr-mcp": "bin/yarr.js",
+    "yarr": "bin/yarr.js",
+    "rustarr": "bin/yarr.js"
+  },
+  "files": [
+    "bin/",
+    "lib/",
+    "scripts/",
+    "README.md"
+  ],
+  "scripts": {
+    "postinstall": "node scripts/install.js",
+    "test": "node --test",
+    "check": "node --check bin/yarr.js && node --check scripts/install.js && node --check lib/platform.js"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "keywords": [
+    "mcp",
+    "rustarr",
+    "yarr",
+    "sonarr",
+    "radarr",
+    "plex",
+    "jellyfin"
+  ]
+}

--- a/packages/yarr-mcp/scripts/install.js
+++ b/packages/yarr-mcp/scripts/install.js
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("node:fs");
+const https = require("node:https");
+const os = require("node:os");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+const {
+  binaryPath,
+  downloadUrl,
+  installRoot,
+  releaseVersion,
+  targetFor,
+} = require("../lib/platform");
+
+function log(message) {
+  process.stderr.write(`yarr: ${message}\n`);
+}
+
+function download(url, destination) {
+  return new Promise((resolve, reject) => {
+    const request = https.get(url, (response) => {
+      if ([301, 302, 303, 307, 308].includes(response.statusCode)) {
+        response.resume();
+        download(response.headers.location, destination).then(resolve, reject);
+        return;
+      }
+
+      if (response.statusCode !== 200) {
+        response.resume();
+        reject(new Error(`download failed (${response.statusCode}) from ${url}`));
+        return;
+      }
+
+      const file = fs.createWriteStream(destination, { mode: 0o600 });
+      response.pipe(file);
+      file.on("finish", () => file.close(resolve));
+      file.on("error", reject);
+    });
+
+    request.on("error", reject);
+  });
+}
+
+function extract(archive, destination) {
+  fs.rmSync(destination, { recursive: true, force: true });
+  fs.mkdirSync(destination, { recursive: true });
+
+  const result = spawnSync("tar", ["-xzf", archive, "-C", destination], {
+    encoding: "utf8",
+  });
+
+  if (result.status !== 0) {
+    throw new Error((result.stderr || result.stdout || "tar extraction failed").trim());
+  }
+}
+
+async function main() {
+  if (process.env.YARR_SKIP_DOWNLOAD === "1") {
+    log("skipping binary download because YARR_SKIP_DOWNLOAD=1");
+    return;
+  }
+
+  const target = targetFor();
+  const destination = binaryPath();
+
+  if (fs.existsSync(destination)) {
+    log(`${path.basename(destination)} already installed for ${releaseVersion()}`);
+    return;
+  }
+
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "yarr-mcp-install-"));
+  const archive = path.join(tempDir, target.asset);
+
+  try {
+    const url = downloadUrl(target);
+    log(`downloading ${url}`);
+    await download(url, archive);
+    extract(archive, installRoot());
+    fs.chmodSync(destination, 0o755);
+    log(`installed ${destination}`);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  log(error.message);
+  process.exitCode = 1;
+});

--- a/packages/yarr-mcp/test/platform.test.js
+++ b/packages/yarr-mcp/test/platform.test.js
@@ -1,0 +1,33 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  downloadUrl,
+  releaseVersion,
+  targetFor,
+} = require("../lib/platform");
+
+test("maps supported platforms to release assets", () => {
+  assert.deepEqual(targetFor("linux", "x64"), {
+    asset: "rustarr-x86_64.tar.gz",
+    binary: "rustarr",
+  });
+  assert.deepEqual(targetFor("win32", "x64"), {
+    asset: "rustarr-windows-x86_64.tar.gz",
+    binary: "rustarr.exe",
+  });
+});
+
+test("rejects unsupported platforms", () => {
+  assert.throws(() => targetFor("darwin", "arm64"), /Unsupported platform/);
+});
+
+test("uses npm package version as the binary tag by default", () => {
+  assert.equal(releaseVersion({}), "v0.4.0");
+});
+
+test("allows release tag override", () => {
+  const env = { YARR_BINARY_VERSION: "v9.9.9", YARR_RELEASE_BASE_URL: "https://example.test/releases" };
+  assert.equal(downloadUrl(targetFor("linux", "x64"), env), "https://example.test/releases/v9.9.9/rustarr-x86_64.tar.gz");
+});

--- a/plugins/rustarr/README.md
+++ b/plugins/rustarr/README.md
@@ -74,8 +74,12 @@ The monitor emits only on state transitions — Claude is not notified while the
 - `DOWN` — connection refused / timeout
 - `DEGRADED(HTTP N)` — non-2xx HTTP response
 
-The plugin does not ship or install a binary. Install `rustarr` separately before
-enabling the monitor.
+The plugin does not ship or install a binary. Install `yarr` separately before
+enabling the monitor:
+
+```bash
+npm i -g yarr-mcp
+```
 
 Disabling the plugin mid-session does not stop an already-running monitor; it stops when the session ends.
 
@@ -86,7 +90,7 @@ Disabling the plugin mid-session does not stop an already-running monitor; it st
 ## Packaging checklist
 
 1. Confirm the plugin does not rely on a bundled `rustarr` binary.
-2. Confirm `rustarr` is installed separately when testing runtime setup.
+2. Confirm `yarr` or `rustarr` is installed separately when testing runtime setup.
 3. Run `cargo test --test plugin_contract`.
 4. Verify all manifests still omit explicit `version` fields.
 5. Install through the target marketplace or local plugin path.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -19,6 +19,7 @@ Maintenance and automation scripts for the template. Shell scripts are written f
 | `check-schema-docs.py` | Generate/check `docs/MCP_SCHEMA.md` and action docs. |
 | `check-version-sync.sh` | Check version consistency. |
 | `generate-cli.sh` | Generate a standalone CLI for this server via mcporter (requires running server). |
+| `install.sh` | Install the latest GitHub Release binary and create a `yarr` symlink. |
 | `live-read-smoke.sh` | Run legacy guarded shart read-only CLI and upstream `get` checks. |
 | `pre-release-check.sh` | Full release-readiness gate, including schema and runtime contract drift checks. |
 | `refresh-docs.sh` | Refresh ignored reference docs with Axon/Repomix. |
@@ -165,6 +166,17 @@ just generate-cli
 Generates a standalone CLI binary for this server via `mcporter generate-cli`. Requires a running server on port 40070 and `mcporter` in PATH. Caches a schema hash under `dist/.cache/` and skips regeneration when the tool schema is unchanged. The generated binary embeds the token — do not commit or share it.
 
 The script targets Rustarr's default port 40070 and `RUSTARR_MCP_TOKEN`.
+
+### `install.sh`
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/jmagar/rustarr-mcp/main/scripts/install.sh | bash
+YARR_VERSION=v0.4.0 INSTALL_DIR=~/.local/bin bash scripts/install.sh
+```
+
+Downloads the matching GitHub Release tarball, installs `rustarr`, and creates a
+`yarr` symlink in the same directory. Supports Linux x64 and Windows x64 release
+assets, matching the current release workflow.
 
 ### `live-read-smoke.sh`
 

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -16,6 +16,7 @@ REPO_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd
 VERSION_FILES=(
     "${REPO_ROOT}/Cargo.toml"
     "${REPO_ROOT}/Cargo.lock"
+    "${REPO_ROOT}/packages/yarr-mcp/package.json"
     "${REPO_ROOT}/server.json"
 )
 

--- a/scripts/check-version-sync.sh
+++ b/scripts/check-version-sync.sh
@@ -20,6 +20,11 @@ if [ -f "package.json" ]; then
   [ -n "$v" ] && versions+=("package.json=$v") && files_checked+=("package.json")
 fi
 
+if [ -f "packages/yarr-mcp/package.json" ]; then
+  v=$(python3 -c "import json; print(json.load(open('packages/yarr-mcp/package.json')).get('version',''))" 2>/dev/null)
+  [ -n "$v" ] && versions+=("packages/yarr-mcp/package.json=$v") && files_checked+=("packages/yarr-mcp/package.json")
+fi
+
 if [ -f "pyproject.toml" ]; then
   v=$(grep -m1 '^version' pyproject.toml | sed 's/.*"\(.*\)".*/\1/')
   [ -n "$v" ] && versions+=("pyproject.toml=$v") && files_checked+=("pyproject.toml")

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="${YARR_REPO:-jmagar/rustarr-mcp}"
+INSTALL_DIR="${INSTALL_DIR:-${HOME}/.local/bin}"
+VERSION="${YARR_VERSION:-latest}"
+
+usage() {
+  cat <<'USAGE'
+Install rustarr/yarr from GitHub Releases.
+
+Environment:
+  INSTALL_DIR  Destination directory (default: ~/.local/bin)
+  YARR_VERSION Release tag such as v0.4.0 (default: latest)
+  YARR_REPO    GitHub repo owner/name (default: jmagar/rustarr-mcp)
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+need() {
+  command -v "$1" >/dev/null 2>&1 || {
+    printf 'error: %s is required\n' "$1" >&2
+    exit 1
+  }
+}
+
+target_asset() {
+  local os arch
+  os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+  arch="$(uname -m)"
+
+  case "${os}:${arch}" in
+    linux:x86_64|linux:amd64)
+      printf 'rustarr-x86_64.tar.gz'
+      ;;
+    mingw*:x86_64|msys*:x86_64|cygwin*:x86_64)
+      printf 'rustarr-windows-x86_64.tar.gz'
+      ;;
+    *)
+      printf 'error: unsupported platform %s/%s\n' "${os}" "${arch}" >&2
+      exit 1
+      ;;
+  esac
+}
+
+need curl
+need tar
+need mktemp
+
+asset="$(target_asset)"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+if [[ "${VERSION}" == "latest" ]]; then
+  url="https://github.com/${REPO}/releases/latest/download/${asset}"
+else
+  url="https://github.com/${REPO}/releases/download/${VERSION}/${asset}"
+fi
+
+mkdir -p "${INSTALL_DIR}"
+if [[ ! -w "${INSTALL_DIR}" ]]; then
+  printf 'error: install dir is not writable: %s\n' "${INSTALL_DIR}" >&2
+  exit 1
+fi
+
+printf 'Downloading %s\n' "${url}" >&2
+curl -fsSL "${url}" -o "${tmpdir}/${asset}"
+tar -xzf "${tmpdir}/${asset}" -C "${tmpdir}"
+
+binary="${tmpdir}/rustarr"
+if [[ ! -f "${binary}" && -f "${tmpdir}/rustarr.exe" ]]; then
+  binary="${tmpdir}/rustarr.exe"
+fi
+if [[ ! -f "${binary}" ]]; then
+  printf 'error: archive did not contain rustarr binary\n' >&2
+  exit 1
+fi
+
+install -m 755 "${binary}" "${INSTALL_DIR}/rustarr"
+ln -sf rustarr "${INSTALL_DIR}/yarr"
+
+printf 'Installed rustarr to %s/rustarr\n' "${INSTALL_DIR}"
+printf 'Installed yarr shim to %s/yarr\n' "${INSTALL_DIR}"
+printf 'Run: yarr --version\n'


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a Node launcher package `yarr-mcp` and a one-line curl installer to make install and updates simple. Users can now run `npx -y yarr-mcp mcp` or install `yarr` globally, with docs and examples switched to `yarr`.

- New Features
  - New npm package `yarr-mcp` that downloads the matching GitHub Release binary on postinstall and exposes `yarr`, `yarr-mcp`, and `rustarr`.
  - Adds `scripts/install.sh` for curl installs; puts `rustarr` in `~/.local/bin` and creates a `yarr` symlink.
  - Linux x64 and Windows x64 supported; env overrides: `YARR_BINARY_VERSION`, `YARR_RELEASE_BASE_URL`, `YARR_SKIP_DOWNLOAD`.
  - `packages/yarr-mcp/bin/yarr.js` bootstraps the binary if missing; includes basic platform tests.
  - Docs updated: quickstart, deployment, systemd, scripts, plugin notes now use `yarr`; HTTP/stdio examples updated.
  - Version sync scripts include `packages/yarr-mcp/package.json`; CHANGELOG updated.

- Migration
  - For stdio MCP configs, set `"command": "yarr"` (ensure it’s on PATH via `npm i -g yarr-mcp` or the curl installer).
  - For systemd, use `ExecStart` with `yarr`; if installed via npm, point to `command -v yarr`.

<sup>Written for commit 82ea89f45e9afb68f1e55a647821714a330e3117. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/servarr-rmcp/pull/28?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

