### PR TITLE
ci: publish yarr-mcp package on release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,9 @@ jobs:
       - name: npm run check
         run: npm run check --prefix packages/yarr-mcp
 
+      - name: npm pack dry run
+        run: npm pack --dry-run --json ./packages/yarr-mcp
+
   # ── toml: taplo check ─────────────────────────────────────────────────────────
   toml:
     name: TOML Format

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,3 +136,45 @@ jobs:
           # GitHub generates release notes from merged commits and PRs.
           generate_release_notes: true
           files: artifacts/*
+
+  # ── Publish npm launcher ────────────────────────────────────────────────────
+  npm:
+    name: Publish npm package
+    needs: release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+
+      - name: Verify package version matches tag
+        run: |
+          package_version="$(node -p "require('./packages/yarr-mcp/package.json').version")"
+          tag_version="${GITHUB_REF_NAME#v}"
+          if [ "$package_version" != "$tag_version" ]; then
+            echo "packages/yarr-mcp/package.json version ${package_version} does not match tag ${GITHUB_REF_NAME}" >&2
+            exit 1
+          fi
+
+      - name: npm test
+        run: npm test --prefix packages/yarr-mcp
+
+      - name: npm run check
+        run: npm run check --prefix packages/yarr-mcp
+
+      - name: npm pack dry run
+        run: npm pack --dry-run --json ./packages/yarr-mcp
+
+      - name: Publish yarr-mcp
+        run: npm publish --provenance --access public ./packages/yarr-mcp
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/yarr-mcp/README.md
+++ b/packages/yarr-mcp/README.md
@@ -16,6 +16,8 @@ yarr mcp
 
 The package downloads the matching GitHub Release binary during `postinstall`.
 The npm package version and the yarr release tag are expected to match.
+Release automation publishes this package from the repository `v*` tag workflow;
+the GitHub repository must have an `NPM_TOKEN` secret with publish access.
 
 The package name is `yarr-mcp` because the shorter `yarr` npm name is already
 occupied by an unrelated package. The installed command is still `yarr`.


### PR DESCRIPTION
## Summary
- publish packages/yarr-mcp from the v* release workflow after GitHub Release creation
- verify package version matches the release tag before publishing
- add npm pack dry-run coverage in CI and document the required NPM_TOKEN secret

## Verification
- npm test --prefix packages/yarr-mcp
- npm run check --prefix packages/yarr-mcp
- npm pack --dry-run --json ./packages/yarr-mcp
- npm publish --dry-run --access public ./packages/yarr-mcp
- go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/release.yml .github/workflows/ci.yml
- bash scripts/check-version-sync.sh .

Refs: rustarr-mq7

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automates publishing the `yarr-mcp` package on GitHub Releases and guards against version/tag mismatches. Adds an `npm pack` dry run in CI, documents the `NPM_TOKEN` requirement, and addresses Linear rustarr-mq7.

- **New Features**
  - New release job publishes `packages/yarr-mcp` on `v*` tags after the GitHub Release.
  - Verifies `package.json` version matches the tag, runs tests/checks, dry-runs pack, then publishes with provenance.
  - CI runs `npm pack --dry-run --json` for `packages/yarr-mcp`; README notes the release flow and secret.

- **Migration**
  - Add an `NPM_TOKEN` repo secret with publish access to npm.

<sup>Written for commit bb7771a1b438d7da72d8ba9691afda2cd69a3735. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/yarr-mcp/pull/32?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

