### PR TITLE
chore(deps): upgrade rmcp from 1.7.0 to 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Upgraded `rmcp` from 1.7.0 to 2.1.0.** Adopted the 2.0 model-type
+  realignment to the MCP 2025-11-25 spec: `Content`/`RawResource` are replaced
+  by the flat `ContentBlock` enum and `Resource::new(uri, name)` builder, and
+  `PromptMessageRole` is replaced by `Role`. No behavior change.
 - **Rebranded the application to Yarr.** The CLI binary, plugin package,
   configuration namespace, MCP metadata, live harness, and active docs now use
   Yarr naming. The MCP tool remains `yarr`; upstream service names such as

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2569,9 +2569,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.7.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
+checksum = "f00a32c3b81b7b254076a65abd5ab2551209146713ba38f73818657e865e9433"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2601,9 +2601,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.7.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
+checksum = "2ee70afb7956da9f30d5348a2539b5eb90d9038f834463657ab717076ac3b1ad"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ tokio = { version = "1", features = [
 
 # HTTP / MCP transport
 axum = "0.8"
-rmcp = { version = "1.7.0", default-features = false, features = [
+rmcp = { version = "2.1.0", default-features = false, features = [
   "server",
   "macros",
   "transport-streamable-http-server",
@@ -103,7 +103,7 @@ test-support = []
 yarr = { path = ".", features = ["test-support"] }
 tempfile = "3"
 tower = { version = "0.5", features = ["util"] }
-rmcp = { version = "1.7.0", default-features = false, features = [
+rmcp = { version = "2.1.0", default-features = false, features = [
   "client",
   "transport-child-process",
 ] }

--- a/src/mcp/prompts.rs
+++ b/src/mcp/prompts.rs
@@ -7,8 +7,7 @@
 //! worth exposing directly to MCP clients.
 
 use rmcp::model::{
-    GetPromptRequestParams, GetPromptResult, ListPromptsResult, Prompt, PromptMessage,
-    PromptMessageRole,
+    GetPromptRequestParams, GetPromptResult, ListPromptsResult, Prompt, PromptMessage, Role,
 };
 
 pub(super) fn list_prompts() -> ListPromptsResult {
@@ -28,7 +27,7 @@ pub(super) fn list_prompts() -> ListPromptsResult {
 pub(super) fn get_prompt(request: GetPromptRequestParams) -> anyhow::Result<GetPromptResult> {
     match request.name.as_str() {
         "quick_start" => Ok(GetPromptResult::new(vec![PromptMessage::new_text(
-            PromptMessageRole::User,
+            Role::User,
             "Call the `yarr` tool with a Code Mode script. Inside it, use \
              codemode.search('status') to find a service's status callable, then invoke it \
              (e.g. `await sonarr.service_status()`) and return the result. The service is baked \

--- a/src/mcp/rmcp_server.rs
+++ b/src/mcp/rmcp_server.rs
@@ -14,10 +14,10 @@ use lab_auth::AuthContext;
 use rmcp::{
     ErrorData, RoleServer, ServerHandler,
     model::{
-        CallToolRequestParams, CallToolResult, Content, GetPromptRequestParams, GetPromptResult,
-        Implementation, ListPromptsResult, ListResourcesResult, ListToolsResult,
-        PaginatedRequestParams, RawResource, ReadResourceRequestParams, ReadResourceResult,
-        Resource, ResourceContents, ServerCapabilities, ServerInfo, Tool,
+        CallToolRequestParams, CallToolResult, ContentBlock, GetPromptRequestParams,
+        GetPromptResult, Implementation, ListPromptsResult, ListResourcesResult, ListToolsResult,
+        PaginatedRequestParams, ReadResourceRequestParams, ReadResourceResult, Resource,
+        ResourceContents, ServerCapabilities, ServerInfo, Tool,
     },
     service::{Peer, RequestContext},
 };
@@ -268,12 +268,9 @@ impl ServerHandler for YarrRmcpServer {
 const SCHEMA_RESOURCE_URI: &str = "yarr://schema/mcp-tool";
 
 fn schema_resource() -> Resource {
-    Resource::new(
-        RawResource::new(SCHEMA_RESOURCE_URI, "yarr service tool schema")
-            .with_description("JSON schema for the yarr MCP tool and its Code Mode parameters")
-            .with_mime_type("application/json"),
-        None,
-    )
+    Resource::new(SCHEMA_RESOURCE_URI, "yarr service tool schema")
+        .with_description("JSON schema for the yarr MCP tool and its Code Mode parameters")
+        .with_mime_type("application/json")
 }
 
 // ── tool definition conversion ────────────────────────────────────────────────
@@ -336,7 +333,7 @@ fn tool_result_from_json(value: Value) -> Result<CallToolResult, ErrorData> {
             "MCP tool response truncated to fit token budget"
         );
     }
-    Ok(CallToolResult::success(vec![Content::text(text)]))
+    Ok(CallToolResult::success(vec![ContentBlock::text(text)]))
 }
 
 /// Inject `confirm=true` into the tool arguments once a destructive action has

--- a/src/mcp/rmcp_server_tests.rs
+++ b/src/mcp/rmcp_server_tests.rs
@@ -95,7 +95,6 @@ fn tool_result_from_json_applies_response_cap() {
     }))
     .expect("tool result should serialize");
     let text = result.content[0]
-        .raw
         .as_text()
         .expect("tool result should contain text")
         .text
@@ -132,7 +131,6 @@ fn inject_confirm_is_noop_on_non_object() {
 fn declined_result_reports_declined_and_nothing_changed() {
     let result = declined_result("delete").expect("declined result builds");
     let text = result.content[0]
-        .raw
         .as_text()
         .expect("declined result should contain text")
         .text


### PR DESCRIPTION
## Summary
- Upgrades `rmcp` 1.7.0 → 2.1.0 (supersedes dependabot #23, which had real CI failures because it bumped the version without adapting to the breaking model-type changes).
- Adopts the 2.0 model realignment to the MCP 2025-11-25 spec: `Content`/`RawResource` are gone, replaced by the flat `ContentBlock` enum + `Resource::new(uri, name)` builder; `PromptMessageRole` is replaced by `Role`.
- No behavior change — purely a mechanical API adaptation in `src/mcp/prompts.rs` and `src/mcp/rmcp_server.rs` (+ one test file).

## Test plan
- [x] `cargo build --all-targets`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test` (557+ unit tests, all integration suites) — all pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgraded `rmcp` to 2.1.0 and aligned our MCP model types with the 2.0 spec. No behavior changes.

- **Dependencies**
  - Bumped `rmcp` 1.7.0 → 2.1.0.

- **Refactors**
  - Replaced `Content` with `ContentBlock` and used `ContentBlock::text` for tool responses.
  - Switched to `Resource::new(uri, name)`; removed `RawResource` and updated the schema resource builder.
  - Replaced `PromptMessageRole` with `Role` in prompt messages.
  - Adjusted tests to stop accessing the removed `.raw` field.

<sup>Written for commit 765e3ceee16c5ba1808c65148fadea578c581e61. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/yarr-mcp/pull/40?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

