### PR TITLE
fix(docs): ASCII-hygiene fix for OpenWiki testing doc

### DIFF
--- a/openwiki/testing.md
+++ b/openwiki/testing.md
@@ -277,21 +277,21 @@ just ci
 
 ### What's tested
 
-- ✅ Config loading and env override
-- ✅ Action registry and curated commands
-- ✅ CLI parsing and dispatch
-- ✅ MCP tool dispatch
-- ✅ OpenAPI operation generation
-- ✅ Code Mode engine and built-ins
-- ✅ HTTP transport and auth
-- ✅ MCP ↔ CLI parity
-- ✅ Live upstream contracts
+- ✓ Config loading and env override
+- ✓ Action registry and curated commands
+- ✓ CLI parsing and dispatch
+- ✓ MCP tool dispatch
+- ✓ OpenAPI operation generation
+- ✓ Code Mode engine and built-ins
+- ✓ HTTP transport and auth
+- ✓ MCP ↔ CLI parity
+- ✓ Live upstream contracts
 
 ### What's NOT tested
 
-- ❌ Upstream service behavior (assume upstream works)
-- ❌ Full OAuth flow (requires real Google callback)
-- ❌ Cross-platform binary edge cases (assume Rust handles it)
+- ✗ Upstream service behavior (assume upstream works)
+- ✗ Full OAuth flow (requires real Google callback)
+- ✗ Cross-platform binary edge cases (assume Rust handles it)
 
 ## Adding tests
 


### PR DESCRIPTION
## Summary
- `openwiki/testing.md` (generated by OpenWiki init) used the emoji check/cross marks (U+2705 ✅ / U+274C ❌) instead of the plain marks (U+2713 ✓ / U+2717 ✗) this repo's ASCII-hygiene contract allows.
- This broke the "Repo Contracts" CI check on any PR merged against `main` (surfaced while investigating the failing release-please PR #34).

## Test plan
- [x] `bash scripts/test-template-features.sh` — 6 passed, 0 failed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced emoji check/cross (U+2705/U+274C) with plain marks (U+2713/U+2717) in `openwiki/testing.md` to meet the repo’s ASCII-hygiene contract and fix failing Repo Contracts CI.

<sup>Written for commit 99a3db326132b8b68dad3dfb5376ae5ec5b85a76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/yarr-mcp/pull/42?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

