### PR TITLE
fix(npm): derive expected release tag from package.json in platform test

### DIFF
--- a/packages/yarr-mcp/test/platform.test.js
+++ b/packages/yarr-mcp/test/platform.test.js
@@ -7,6 +7,7 @@ const {
   releaseVersion,
   targetFor,
 } = require("../lib/platform");
+const { version: packageVersion } = require("../package.json");
 
 test("maps supported platforms to release assets", () => {
   assert.deepEqual(targetFor("linux", "x64"), {
@@ -24,7 +25,7 @@ test("rejects unsupported platforms", () => {
 });
 
 test("uses npm package version as the binary tag by default", () => {
-  assert.equal(releaseVersion({}), "v0.4.0");
+  assert.equal(releaseVersion({}), `v${packageVersion}`);
 });
 
 test("allows release tag override", () => {


### PR DESCRIPTION
## Summary
- `packages/yarr-mcp/test/platform.test.js` hardcoded the expected binary-tag literal (`v0.4.0`) instead of deriving it from `package.json`, so it silently breaks CI on every version bump.
- This first surfaced on the release-please 0.5.0 PR (#34) as an "NPM Package" failure. Fixing it only there wasn't durable — release-please force-regenerates that branch from `main` on every update, so the bug would resurface on the next bump if `main` itself isn't fixed.

## Test plan
- [x] \`npm test --prefix packages/yarr-mcp\` (4/4 pass at current 0.4.0)
- [x] Verified the same fix passes at 0.5.0 on the release-please branch

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the platform test in `packages/yarr-mcp` to read the expected binary tag from `package.json` instead of a hardcoded `v0.4.0`. This prevents CI failures on version bumps and keeps `release-please` branches stable.

<sup>Written for commit 33391877b80aa9dbb800aa213e23287f7f1317e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/yarr-mcp/pull/43?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

