### PR TITLE
fix(ci): align codeql-action/analyze to v4.36.3

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -50,6 +50,6 @@ jobs:
         run: cargo build --release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/analyze@8533807ff379ac610d2b2c389c47e7c629d31d13 # v4.36.3
         with:
           category: "/language:${{ matrix.language }}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,9 +473,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Summary
- Dependabot bumped `github/codeql-action/init` (#36) and `.../upload-sarif` (#37) to v4.36.3, but `.../analyze` in `codeql.yml` was left at v4.36.2.
- CodeQL requires all `codeql-action` steps to run the same version; the skew broke the CodeQL run on every push to main with "Loaded a configuration file for version '4.36.3', but running version '4.36.2'".

## Test plan
- [x] `actionlint .github/workflows/codeql.yml` — clean
- [ ] CodeQL passes on this PR / after merge to main

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align `github/codeql-action/analyze` to v4.36.3 to match `init` and `upload-sarif`, fixing the version mismatch and unblocking CodeQL scans in CI. Also bump `crossbeam-epoch` to 0.9.20 to address RUSTSEC-2026-0204 and pass `cargo-deny`.

<sup>Written for commit 47ef606aef99abfd6201c927db0ac1b104d3ea7e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/yarr-mcp/pull/44?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

