### PR TITLE
fix: preserve Trivy severity gate in SARIF mode

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -168,6 +168,7 @@ jobs:
           format: sarif
           output: trivy-results.sarif
           severity: CRITICAL,HIGH
+          limit-severities-for-sarif: true
           exit-code: "1"
 
       - name: Upload Trivy results

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -303,7 +303,7 @@ bash scripts/test-template-features.sh
 just template-features
 ```
 
-Fast shell smoke tests for invariants that are awkward as Rust tests: `.env` blocking, agent docs symlinks, plugin layout, schema docs, and ASCII hygiene.
+Fast shell smoke tests for invariants that are awkward as Rust tests: `.env` blocking, agent docs symlinks, plugin layout, schema docs, the Trivy SARIF severity gate, and ASCII hygiene.
 
 ### `web-watch.sh`
 

--- a/scripts/test-template-features.sh
+++ b/scripts/test-template-features.sh
@@ -88,6 +88,10 @@ fi
 
 expect_ok "plugin layout validator passes" bash scripts/validate-plugin-layout.sh
 expect_ok "schema docs checker passes" python3 scripts/check-schema-docs.py --check
+expect_ok "Trivy SARIF keeps the HIGH/CRITICAL gate" bash -c '
+  grep -Eq "^[[:space:]]+severity: CRITICAL,HIGH$" .github/workflows/docker-publish.yml
+  grep -Eq "^[[:space:]]+limit-severities-for-sarif: true$" .github/workflows/docker-publish.yml
+'
 # shellcheck disable=SC2016 # The child shell expands its own positional args.
 expect_ok "ascii checker catches allowed repo glyphs cleanly" bash -c '
   set -euo pipefail

--- a/src/yarr/auth_tests.rs
+++ b/src/yarr/auth_tests.rs
@@ -129,7 +129,7 @@ async fn qbit_session_login_is_single_flight_and_cached() {
                     };
                     let _ = write!(
                         stream,
-                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n{extra}Content-Length: {}\r\n\r\n{body}",
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nConnection: close\r\n{extra}Content-Length: {}\r\n\r\n{body}",
                         body.len()
                     );
                     let _ = stream.flush();


### PR DESCRIPTION
Closes #62

## Summary

- keep the configured HIGH/CRITICAL filter when Trivy emits SARIF
- add a shell contract that prevents the action-specific input from regressing
- advertise Connection: close in the qBittorrent HTTP/1.1 mock to eliminate an observed retry-only test flake
- document the new workflow invariant

## Root cause

The pinned trivy-action unsets TRIVY_SEVERITY in SARIF mode unless limit-severities-for-sarif is true. The production job therefore failed on lower-severity findings even though its declared gate was HIGH/CRITICAL.

## Verification

- fresh Trivy 0.70.0 scan of immutable GHCR digest: 0 HIGH/CRITICAL SARIF results, exit 0 with exit-code 1
- qBittorrent single-flight test: 30/30 stress runs passed with retries disabled
- cargo xtask ci: 13/13 stages passed, 647/647 Rust tests
- feature contracts: 7/7 passed
- actionlint and coupled-file checks passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the Trivy severity gate (CRITICAL,HIGH) when generating SARIF so low-severity findings don’t fail the container scan. Also stabilize the qBittorrent auth test by closing the mock HTTP/1.1 connection.

- **Bug Fixes**
  - Set `limit-severities-for-sarif: true` alongside `severity: CRITICAL,HIGH` in the SARIF scan step.
  - Add a shell check to enforce this invariant and document it in `scripts/README.md`.
  - Send `Connection: close` in the qBittorrent mock response to remove a retry-only test flake.

<sup>Written for commit c126a4e8947bb3bf64f2a85841712824cc63cf3b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/yarr/pull/63?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

