### PR TITLE
fix(ci): couple plugin manifest launcher pins to release version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,9 @@ jobs:
       - name: npm run check
         run: npm run check --prefix packages/yarr-mcp
 
+      - name: Plugin manifest launcher pins are in sync
+        run: node scripts/sync-plugin-manifests.js --check
+
       - name: npm pack dry run
         run: npm pack --dry-run --json ./packages/yarr-mcp
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -46,3 +46,35 @@ jobs:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      # release-please bumps JSON scalar version fields (package.json, server.json)
+      # but cannot template the version embedded in launcher-arg strings such as
+      # `["-y", "yarr-mcp@1.1.1", "mcp"]`. Re-couple those pins on the open release
+      # PR so its CI (coupled-version contract, plugin_contract) stays green.
+      - name: Check out release PR branch
+        if: ${{ steps.release.outputs.pr }}
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        if: ${{ steps.release.outputs.pr }}
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+
+      - name: Sync plugin manifest launcher pins
+        if: ${{ steps.release.outputs.pr }}
+        run: |
+          set -euo pipefail
+          node scripts/sync-plugin-manifests.js
+          if git diff --quiet; then
+            echo "Plugin manifest launcher pins already in sync."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit --all --message "chore: sync plugin manifest launcher pins to release version"
+          git push

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -26,6 +26,7 @@ Maintenance and automation scripts for the template. Shell scripts are written f
 | `repair.sh` | Stop, rebuild, and restart the service via systemd or Docker Compose. |
 | `run-ascii-check.sh` | Collect tracked files and run `asciicheck.py`; pass `--fix` to rewrite in place. |
 | `sync-cargo.sh` | Sync `Cargo.lock` into plugin data directories. |
+| `sync-plugin-manifests.js` | Couple every `yarr-mcp@<version>` launcher pin to `packages/yarr-mcp/package.json`; `--check` fails on drift. |
 | `test-mcp-auth.sh` | Smoke-test HTTP MCP bearer auth. |
 | `test-template-features.sh` | Fast template invariant smoke tests. |
 | `validate-plugin-layout.sh` | Validate Claude/Codex/Gemini plugin package layout. |
@@ -285,6 +286,15 @@ bash scripts/sync-cargo.sh
 ```
 
 Copies `Cargo.lock` from `CLAUDE_PLUGIN_ROOT` to `CLAUDE_PLUGIN_DATA` when needed. Falls back to `cargo fetch` if the copy cannot be completed.
+
+### `sync-plugin-manifests.js`
+
+```bash
+node scripts/sync-plugin-manifests.js          # rewrite pins in place
+node scripts/sync-plugin-manifests.js --check   # fail (non-zero) on drift
+```
+
+Rewrites every hard-coded `yarr-mcp@<version>` npm launcher pin (in `plugins/yarr/.mcp.json`, `plugins/yarr/gemini-extension.json`, `scripts/validate-plugin-layout.sh`, `server.json`, and the plugin docs) plus `server.json`'s `_meta.buildInfo.version` to match `packages/yarr-mcp/package.json` — the single version release-please bumps. release-please cannot template a version embedded inside a launcher-arg string, so the release workflow runs this on the release PR and CI runs `--check` to block drift on `main`.
 
 ### `test-mcp-auth.sh`
 

--- a/scripts/sync-plugin-manifests.js
+++ b/scripts/sync-plugin-manifests.js
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+"use strict";
+
+// sync-plugin-manifests.js — keep every hard-coded `yarr-mcp@<version>` launcher
+// pin coupled to packages/yarr-mcp/package.json, the single version release-please
+// bumps on a release. release-please can update JSON scalar fields (server.json
+// $.version, package.json $.version) but cannot template a version embedded inside
+// a launcher-arg string such as `["-y", "yarr-mcp@1.1.1", "mcp"]`, so those pins
+// drift on every release and break the coupled-version contract checks.
+//
+// Usage:
+//   node scripts/sync-plugin-manifests.js          # rewrite pins in place
+//   node scripts/sync-plugin-manifests.js --check   # fail (non-zero) on drift
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const root = path.resolve(__dirname, "..");
+const check = process.argv.includes("--check");
+
+const packageJson = JSON.parse(
+  fs.readFileSync(path.join(root, "packages/yarr-mcp/package.json"), "utf8"),
+);
+const { name, version } = packageJson;
+const spec = `${name}@${version}`; // e.g. yarr-mcp@2.0.0
+
+// Files that pin the npm launcher spec `yarr-mcp@<semver>`. Listed explicitly so
+// an unrelated match can never be rewritten by accident.
+const pinnedLauncherFiles = [
+  "plugins/yarr/.mcp.json",
+  "plugins/yarr/gemini-extension.json",
+  "scripts/validate-plugin-layout.sh",
+  "server.json",
+  "docs/PLUGINS.md",
+  "plugins/README.md",
+  "plugins/yarr/README.md",
+  "plugins/yarr/CLAUDE.md",
+];
+
+const launcherPin = new RegExp(`${name}@\\d+\\.\\d+\\.\\d+`, "g");
+// server.json _meta.buildInfo.version travels with the launcher pin (release-please
+// only owns the top-level and packages[] version scalars, not this metadata block).
+const buildInfoVersion = /("buildInfo"\s*:\s*\{\s*"version"\s*:\s*")\d+\.\d+\.\d+(")/;
+
+const drift = new Set();
+
+function apply(relative, transform) {
+  const file = path.join(root, relative);
+  const before = fs.readFileSync(file, "utf8");
+  const after = transform(before);
+  if (before === after) return;
+  drift.add(relative);
+  if (!check) fs.writeFileSync(file, after);
+}
+
+for (const relative of pinnedLauncherFiles) {
+  apply(relative, (text) => text.replace(launcherPin, spec));
+}
+apply("server.json", (text) => text.replace(buildInfoVersion, `$1${version}$2`));
+
+if (drift.size === 0) {
+  console.log(`plugin manifest launcher pins already at ${spec}`);
+  process.exit(0);
+}
+
+const list = [...drift].map((f) => "  " + f).join("\n");
+
+if (check) {
+  console.error(
+    `plugin manifest launcher pins are out of sync with ${spec}:\n${list}\n\n` +
+      "Run: node scripts/sync-plugin-manifests.js",
+  );
+  process.exit(1);
+}
+
+console.log(`synced ${drift.size} file(s) to ${spec}:\n${list}`);


### PR DESCRIPTION
## Problem

The release-please PR (#60, release 2.0.0) fails CI on the **Test** and **NPM Package** jobs:

```
left:  ["-y", "yarr-mcp@1.1.1", "mcp"]
right: ["-y", "yarr-mcp@2.0.0", "mcp"]
```

release-please bumps JSON *scalar* version fields (`package.json` `$.version`, `server.json` `$.version` / `$.packages[].version`) but **cannot template a version embedded inside a launcher-arg string** like `["-y", "yarr-mcp@1.1.1", "mcp"]`. Those pins are duplicated across several files and stay at the old version on every release, breaking:

- the coupled-version contract (`scripts/check-dist-contract.js`, lines 100–106)
- the `plugin_contract` manifest tests (`.mcp.json`, `gemini-extension.json`)
- `scripts/validate-plugin-layout.sh`, which *also* hard-codes the pin and would break the moment the manifests are bumped without it

Since #60 is a release-please–owned branch that is regenerated on every run, the durable fix has to live on `main` and re-couple the pins automatically.

## Changes

- **`scripts/sync-plugin-manifests.js`** (new) — rewrites every `yarr-mcp@<semver>` launcher pin (plus `server.json` `_meta.buildInfo.version`) to match `packages/yarr-mcp/package.json`. Covers `.mcp.json`, `gemini-extension.json`, `validate-plugin-layout.sh`, `server.json`, and the docs. `--check` mode exits non-zero on drift.
- **`.github/workflows/release-please.yml`** — after the release PR is opened/updated, check out the release branch, run the sync, and push a fixup commit so the PR's CI re-couples and goes green. Self-heals on every future release.
- **`.github/workflows/ci.yml`** — run the sync in `--check` mode in the NPM Package job so a manual edit can never desync the pins on `main`.

## Verification

Simulated the full 2.0.0 release bump locally (all coupled version files → 2.0.0, then ran the sync):

- `scripts/check-dist-contract.js` → `dist contract ok: yarr 2.0.0`
- `scripts/validate-plugin-layout.sh plugins/yarr` → **61/61 passed**
- `cargo test --test plugin_contract` → **13 passed; 0 failed**
- `actionlint` on both edited workflows → clean
- On the restored `1.1.1` tree the sync is a no-op and `--check` passes.

## Note on #60

#60's branch is regenerated by release-please, so it cannot be fixed by pushing to it directly. Once this merges to `main`, the next release-please run (on merge, or via `workflow_dispatch` on the release-please workflow) will bump #60's package version **and** run the new sync step, turning #60 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBt5HQEGS79gnHnpm93SGR)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically sync all `yarr-mcp@<semver>` launcher pins to the package release version to keep CI and plugin contract tests green. Adds a script and CI steps that self-heal release branches and prevent drift on `main`.

- **Bug Fixes**
  - Added `scripts/sync-plugin-manifests.js` to rewrite launcher pins and `server.json` `_meta.buildInfo.version` to match `packages/yarr-mcp/package.json`; supports `--check`.
  - CI: in release workflow, run the sync on the release PR branch and push a fixup; in `ci.yml`, run `--check` in the NPM Package job.
  - Docs: documented the script and usage in `scripts/README.md` to satisfy repo contracts.

<sup>Written for commit f46f6597b365a7cc15a1810ea342bfaa4b94c4f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/yarr/pull/65?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

