### PR TITLE
fix(ci): derive plugin-layout pin from package.json; keep sync out of scripts/

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -294,7 +294,7 @@ node scripts/sync-plugin-manifests.js          # rewrite pins in place
 node scripts/sync-plugin-manifests.js --check   # fail (non-zero) on drift
 ```
 
-Rewrites every hard-coded `yarr-mcp@<version>` npm launcher pin (in `plugins/yarr/.mcp.json`, `plugins/yarr/gemini-extension.json`, `scripts/validate-plugin-layout.sh`, `server.json`, and the plugin docs) plus `server.json`'s `_meta.buildInfo.version` to match `packages/yarr-mcp/package.json` — the single version release-please bumps. release-please cannot template a version embedded inside a launcher-arg string, so the release workflow runs this on the release PR and CI runs `--check` to block drift on `main`.
+Rewrites every hard-coded `yarr-mcp@<version>` npm launcher pin (in `plugins/yarr/.mcp.json`, `plugins/yarr/gemini-extension.json`, `server.json`, and the plugin docs) plus `server.json`'s `_meta.buildInfo.version` to match `packages/yarr-mcp/package.json` — the single version release-please bumps. release-please cannot template a version embedded inside a launcher-arg string, so the release workflow runs this on the release PR and CI runs `--check` to block drift on `main`. `validate-plugin-layout.sh` derives the expected pin from `package.json` directly, so it is intentionally not rewritten here.
 
 ### `test-mcp-auth.sh`
 

--- a/scripts/sync-plugin-manifests.js
+++ b/scripts/sync-plugin-manifests.js
@@ -26,10 +26,13 @@ const spec = `${name}@${version}`; // e.g. yarr-mcp@2.0.0
 
 // Files that pin the npm launcher spec `yarr-mcp@<semver>`. Listed explicitly so
 // an unrelated match can never be rewritten by accident.
+// NB: deliberately excludes scripts/validate-plugin-layout.sh — that checker
+// derives the expected pin from package.json at runtime, so it never needs
+// rewriting (and rewriting it here would trip the scripts/ -> scripts/README.md
+// coupled-file guard on the release PR, where README does not also change).
 const pinnedLauncherFiles = [
   "plugins/yarr/.mcp.json",
   "plugins/yarr/gemini-extension.json",
-  "scripts/validate-plugin-layout.sh",
   "server.json",
   "docs/PLUGINS.md",
   "plugins/README.md",

--- a/scripts/validate-plugin-layout.sh
+++ b/scripts/validate-plugin-layout.sh
@@ -18,6 +18,12 @@ MCP_JSON="${PLUGIN_ROOT}/.mcp.json"
 HOOKS_JSON="${PLUGIN_ROOT}/hooks/hooks.json"
 SKILLS_DIR="${PLUGIN_ROOT}/skills"
 
+# The pinned npm launcher spec is derived from the released package version so it
+# stays coupled without being hand-edited (and without tripping the scripts/ ->
+# scripts/README.md coupled-file guard on the release PR).
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+EXPECTED_LAUNCHER="yarr-mcp@$(jq -r '.version' "${REPO_ROOT}/packages/yarr-mcp/package.json" 2>/dev/null)"
+
 check() {
   local test_name="$1"
   local test_cmd="$2"
@@ -68,7 +74,7 @@ check "Gemini extension name is yarr-mcp" "test \"\$(jq -er '.name' '${GEMINI_EX
 check "Gemini extension has no version field" "test \"\$(jq -er 'has(\"version\")' '${GEMINI_EXTENSION_JSON}')\" = 'false'"
 check "Gemini extension points to skills directory" "test \"\$(jq -er '.skills' '${GEMINI_EXTENSION_JSON}')\" = './skills'"
 if [[ "${PLUGIN_ROOT}" == "plugins/yarr" ]]; then
-  check "Gemini extension declares pinned npm stdio MCP server" "jq -er '.mcpServers.yarr.command == \"npx\" and .mcpServers.yarr.args[0:3] == [\"-y\", \"yarr-mcp@1.1.1\", \"mcp\"]' '${GEMINI_EXTENSION_JSON}'"
+  check "Gemini extension declares pinned npm stdio MCP server" "jq -er --arg spec '${EXPECTED_LAUNCHER}' '.mcpServers.yarr.command == \"npx\" and .mcpServers.yarr.args[0:3] == [\"-y\", \$spec, \"mcp\"]' '${GEMINI_EXTENSION_JSON}'"
 else
   check "Gemini extension keeps MCP config external" "jq -er 'has(\"mcpServers\") | not' '${GEMINI_EXTENSION_JSON}'"
 fi
@@ -76,7 +82,7 @@ fi
 if [[ "${PLUGIN_ROOT}" == "plugins/yarr" ]]; then
   check "MCP config exists (yarr uses stdio MCP)" "test -f '${MCP_JSON}'"
   check "MCP config uses stdio transport" "jq -er '.mcpServers.yarr.type == \"stdio\"' '${MCP_JSON}'"
-  check "MCP config uses pinned npm launcher" "jq -er '.mcpServers.yarr.command == \"npx\" and .mcpServers.yarr.args[0:3] == [\"-y\", \"yarr-mcp@1.1.1\", \"mcp\"]' '${MCP_JSON}'"
+  check "MCP config uses pinned npm launcher" "jq -er --arg spec '${EXPECTED_LAUNCHER}' '.mcpServers.yarr.command == \"npx\" and .mcpServers.yarr.args[0:3] == [\"-y\", \$spec, \"mcp\"]' '${MCP_JSON}'"
 else
   check "MCP config is absent for skills-only standalone plugin" "test ! -f '${MCP_JSON}'"
 fi


### PR DESCRIPTION
## Problem

Follow-up to #65. After #65's auto-sync step ran on the release PR (#60), its **Repo Contracts** job failed:

```
Coupled-file check failed:
  - scripts changed but scripts/README.md did not; document new or changed script behavior.
```

`sync-plugin-manifests.js` rewrote `scripts/validate-plugin-layout.sh` (a `scripts/*` file) to bump the hard-coded `yarr-mcp@1.1.1` pin — but on the release branch `scripts/README.md` doesn't change alongside it, so `check-coupled-files.sh`'s `scripts/* → scripts/README.md` rule fired.

## Fix

Make the pin a single source of truth so the sync never has to touch `scripts/`:

- **`scripts/validate-plugin-layout.sh`** — derives the expected launcher spec (`yarr-mcp@<version>`) from `packages/yarr-mcp/package.json` at runtime via `jq`, instead of hard-coding it in two `jq` assertions. It's now always correct and never rewritten.
- **`scripts/sync-plugin-manifests.js`** — drops `validate-plugin-layout.sh` from its target list. The sync now only touches `plugins/**`, `server.json`, and docs. `docs/PLUGINS.md` changes alongside the `plugins/yarr/*` pins, satisfying the other coupled-file rule.
- **`scripts/README.md`** — updated to note the exclusion.

## Verification

- `validate-plugin-layout.sh plugins/yarr` → **61/61** at the current `1.1.1` **and** at a simulated `2.0.0` (derivation works).
- Simulated `2.0.0` sync → rewrites 7 files, **none under `scripts/`**.
- `check-coupled-files.sh origin/main HEAD` → passes.
- `sync-plugin-manifests.js --check` → passes.

## Effect on #60

Once this merges, the next release-please regeneration of #60 will re-run the sync (which no longer edits `scripts/`) and `validate-plugin-layout.sh` will derive `2.0.0` — clearing the Repo Contracts failure. The **Test** and **NPM Package** jobs are already green on #60's current head; this removes the last red check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBt5HQEGS79gnHnpm93SGR)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Repo Contracts failures by deriving the `yarr-mcp` launcher pin from `packages/yarr-mcp/package.json` at runtime. The sync no longer touches files under `scripts/`.

- **Bug Fixes**
  - `scripts/validate-plugin-layout.sh`: read expected `yarr-mcp@<version>` with `jq` from `packages/yarr-mcp/package.json` instead of hard-coding it.
  - `scripts/sync-plugin-manifests.js`: remove `scripts/validate-plugin-layout.sh` from rewrite targets; only updates `plugins/**`, `server.json`, and docs.
  - `scripts/README.md`: note that `validate-plugin-layout.sh` derives the pin and is excluded from syncing.

<sup>Written for commit f1ee991e19a51a86606fe7b5e8036e805b77af14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/yarr/pull/66?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

