### PR TITLE
fix(release): couple server.json YARR_VERSION placeholder to package version

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -294,7 +294,7 @@ node scripts/sync-plugin-manifests.js          # rewrite pins in place
 node scripts/sync-plugin-manifests.js --check   # fail (non-zero) on drift
 ```
 
-Rewrites every hard-coded `yarr-mcp@<version>` npm launcher pin (in `plugins/yarr/.mcp.json`, `plugins/yarr/gemini-extension.json`, `server.json`, and the plugin docs) plus `server.json`'s `_meta.buildInfo.version` to match `packages/yarr-mcp/package.json` — the single version release-please bumps. release-please cannot template a version embedded inside a launcher-arg string, so the release workflow runs this on the release PR and CI runs `--check` to block drift on `main`. `validate-plugin-layout.sh` derives the expected pin from `package.json` directly, so it is intentionally not rewritten here.
+Rewrites every hard-coded `yarr-mcp@<version>` npm launcher pin (in `plugins/yarr/.mcp.json`, `plugins/yarr/gemini-extension.json`, `server.json`, and the plugin docs) plus `server.json`'s `_meta.buildInfo.version` and its `YARR_VERSION` example placeholder (`v<version>`) to match `packages/yarr-mcp/package.json` — the single version release-please bumps. release-please cannot template a version embedded inside a launcher-arg string, so the release workflow runs this on the release PR and CI runs `--check` to block drift on `main`. `validate-plugin-layout.sh` derives the expected pin from `package.json` directly, so it is intentionally not rewritten here.
 
 ### `test-mcp-auth.sh`
 

--- a/scripts/sync-plugin-manifests.js
+++ b/scripts/sync-plugin-manifests.js
@@ -44,6 +44,10 @@ const launcherPin = new RegExp(`${name}@\\d+\\.\\d+\\.\\d+`, "g");
 // server.json _meta.buildInfo.version travels with the launcher pin (release-please
 // only owns the top-level and packages[] version scalars, not this metadata block).
 const buildInfoVersion = /("buildInfo"\s*:\s*\{\s*"version"\s*:\s*")\d+\.\d+\.\d+(")/;
+// server.json's YARR_VERSION env var advertises the matching release tag as its
+// placeholder; keep that example tag coupled so it never points at a stale release.
+const yarrVersionPlaceholder =
+  /("name"\s*:\s*"YARR_VERSION"[\s\S]*?"placeholder"\s*:\s*"v)\d+\.\d+\.\d+(")/;
 
 const drift = new Set();
 
@@ -60,6 +64,7 @@ for (const relative of pinnedLauncherFiles) {
   apply(relative, (text) => text.replace(launcherPin, spec));
 }
 apply("server.json", (text) => text.replace(buildInfoVersion, `$1${version}$2`));
+apply("server.json", (text) => text.replace(yarrVersionPlaceholder, `$1${version}$2`));
 
 if (drift.size === 0) {
   console.log(`plugin manifest launcher pins already at ${spec}`);

--- a/server.json
+++ b/server.json
@@ -90,7 +90,7 @@
           "format": "string",
           "isRequired": false,
           "isSecret": false,
-          "placeholder": "v1.1.1"
+          "placeholder": "v2.0.0"
         },
         {
           "name": "YARR_REPO",


### PR DESCRIPTION
## Problem

The last blocking review thread on the 2.0.0 release PR (#60) flagged that `server.json`'s `YARR_VERSION` env var still advertised the example release tag `v1.1.1` after the version bump. It's an optional override placeholder, but a user copying it would download the `v1.1.1` release under the `yarr-mcp@2.0.0` launcher — a runtime/version mismatch. Nothing kept it coupled.

## Fix

- **`server.json`** — bump the `YARR_VERSION` placeholder to the current release (`v2.0.0`).
- **`scripts/sync-plugin-manifests.js`** — also rewrite the `YARR_VERSION` `v<version>` placeholder (scoped to that env var block) so it tracks every future release automatically; the `--check` drift guard now covers it too.
- **`scripts/README.md`** — document the added coupling.

## Verification

- Sync at the current `2.0.0` → only `server.json` (the placeholder) changed; rest of the tree already coupled.
- Simulated a `2.1.0` bump → placeholder moves to `v2.1.0` alongside the launcher pins and `buildInfo.version`.
- `check-coupled-files.sh`, `check-dist-contract.js`, `validate-plugin-layout.sh` (61/61), and `sync-plugin-manifests.js --check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBt5HQEGS79gnHnpm93SGR)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Couples the `YARR_VERSION` placeholder in `server.json` to the `packages/yarr-mcp` version and updates it to `v2.0.0`. This prevents users from copying a stale release tag that mismatches the pinned `yarr-mcp@2.0.0` launcher.

- **Bug Fixes**
  - Update `server.json` placeholder from `v1.1.1` to `v2.0.0`.
  - Extend `scripts/sync-plugin-manifests.js` to rewrite the `YARR_VERSION` `v<version>` placeholder and check for drift, keeping it in lockstep with `packages/yarr-mcp/package.json`.
  - Document the coupling in `scripts/README.md`.

<sup>Written for commit 79c89c06b954cb5e53834cb3a41188ffe9210a88. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/yarr/pull/67?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified version synchronization guidance for plugin manifests and the `server.json` example placeholder.

* **Bug Fixes**
  * Improved version synchronization so launcher pins, build information, and the `YARR_VERSION` placeholder remain aligned.
  * Updated the displayed `YARR_VERSION` example to `v2.0.0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->