### PR TITLE
feat: add shart stack lifecycle commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added guarded `cargo xtask shart start|stop|status|seed` lifecycle commands
+  and matching `just shart-*` recipes for the dedicated test stack.
+
 ## [1.1.1](https://github.com/jmagar/yarr/compare/v1.1.0...v1.1.1) (2026-07-16)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,7 +114,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added guarded `cargo xtask shart start|stop|status|seed` lifecycle commands
-  and matching `just shart-*` recipes for the dedicated test stack.
+  and matching `just shart-*` recipes for the dedicated test stack, including
+  fleet-quiesced fail-closed seed, dry-run planning, and JSON status output.
 
 ## [1.1.1](https://github.com/jmagar/yarr/compare/v1.1.0...v1.1.1) (2026-07-16)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4472,6 +4472,7 @@ dependencies = [
  "serde",
  "serde_json",
  "ureq",
+ "url",
  "walkdir",
  "yarr",
 ]

--- a/Justfile
+++ b/Justfile
@@ -61,6 +61,22 @@ live-full-services:
 live-full-test:
     cargo xtask live --suite all
 
+# Start the dedicated shart test stack and wait for every service.
+shart-start:
+    cargo xtask shart start
+
+# Stop only the dedicated shart test-stack containers.
+shart-stop:
+    cargo xtask shart stop
+
+# Show shart test-stack container state and health.
+shart-status:
+    cargo xtask shart status
+
+# Restore shart's configured-v1 golden data and start the complete stack.
+shart-seed:
+    cargo xtask shart seed
+
 # ── Building ──────────────────────────────────────────────────────────────────
 
 # Compile debug build (fast, includes debug symbols)

--- a/Justfile
+++ b/Justfile
@@ -69,11 +69,11 @@ shart-start:
 shart-stop:
     cargo xtask shart stop
 
-# Show shart test-stack container state and health.
+# Show shart test-stack container state and health (`cargo xtask shart status --json` for JSON).
 shart-status:
     cargo xtask shart status
 
-# Restore shart's configured-v1 golden data and start the complete stack.
+# Restore shart's configured-v1 golden data (`cargo xtask shart seed --dry-run` to preview).
 shart-seed:
     cargo xtask shart seed
 

--- a/docs/JUSTFILE.md
+++ b/docs/JUSTFILE.md
@@ -32,8 +32,8 @@ current list.
 | `just live-full-services` | Run guarded shart live per-service action matrix coverage. |
 | `just live-full-test` | Run the complete guarded shart live suite. |
 | `just shart-start` / `just shart-stop` | Start or stop only the 11 dedicated shart test containers. |
-| `just shart-status` | Show test-container state/health and fail unless all are running. |
-| `just shart-seed` | Restore `configured-v1` golden data, start the stack, and wait for readiness. |
+| `just shart-status` | Show test-container state/health and fail for missing, stopped, or unhealthy containers; use the underlying `--json` flag for automation. |
+| `just shart-seed` | Restore `configured-v1` golden data with a fleet-quiesced, fail-closed policy, start the stack, and wait; preview with the underlying `--dry-run` flag. |
 | `just build` / `just build-release` | Debug/release Rust builds. |
 | `just gen-token` | Generate a random bearer token (`openssl rand -hex 32`). |
 

--- a/docs/JUSTFILE.md
+++ b/docs/JUSTFILE.md
@@ -31,6 +31,9 @@ current list.
 | `just live-full-mcp` | Run guarded shart live MCP protocol, resource, prompt, validation, and tool-action coverage. |
 | `just live-full-services` | Run guarded shart live per-service action matrix coverage. |
 | `just live-full-test` | Run the complete guarded shart live suite. |
+| `just shart-start` / `just shart-stop` | Start or stop only the 11 dedicated shart test containers. |
+| `just shart-status` | Show test-container state/health and fail unless all are running. |
+| `just shart-seed` | Restore `configured-v1` golden data, start the stack, and wait for readiness. |
 | `just build` / `just build-release` | Debug/release Rust builds. |
 | `just gen-token` | Generate a random bearer token (`openssl rand -hex 32`). |
 

--- a/docs/XTASKS.md
+++ b/docs/XTASKS.md
@@ -34,6 +34,7 @@ xtask/
 | `cargo xtask check-env` | Validate required environment before server start. |
 | `cargo xtask patterns` | Check static contracts derived from `docs/PATTERNS.md`. |
 | `cargo xtask live --suite all` | Run the guarded shart-only live CLI, REST, MCP, and upstream service suite. |
+| `cargo xtask shart <start\|stop\|status\|seed>` | Manage only the dedicated shart test-stack containers. |
 | `cargo xtask tool-docs` | Generate `docs/TOOLS_ACTIONS_ENDPOINTS.md` from the action registry and endpoint mapping table. |
 
 ## Justfile delegates to xtask
@@ -142,3 +143,28 @@ without failing the live run.
 Use the Just aliases `just live-full-guard`, `just live-full-cli`,
 `just live-full-rest`, `just live-full-mcp`, `just live-full-mcporter`,
 `just live-full-services`, and `just live-full-test` for the same commands.
+
+## shart stack management
+
+The operator lifecycle commands load and validate the canonical
+`/home/jmagar/.yarr-shart/.env` guard before touching remote containers:
+
+```bash
+cargo xtask shart start
+cargo xtask shart stop
+cargo xtask shart status
+cargo xtask shart seed
+```
+
+`start` and `stop` act only on the 11 guarded service-kind container names.
+`status` prints each container's Docker state and health and exits non-zero when
+any container is missing or not running. `seed` restores every available
+`backup/lab/live/golden/<service>@configured-v1` snapshot using the existing
+reset machinery, starts all containers (including services without a golden),
+and waits for all configured service URLs.
+
+These commands intentionally do not start or stop the shart Unraid array. If
+Docker or the backing datasets are unavailable, they fail with the remote error
+instead of expanding their scope to host-level storage management. Equivalent
+Just aliases are `just shart-start`, `just shart-stop`, `just shart-status`, and
+`just shart-seed`.

--- a/docs/XTASKS.md
+++ b/docs/XTASKS.md
@@ -8,7 +8,7 @@ audience:
   - "agents"
 scope: "template"
 source_of_truth: false
-last_reviewed: "2026-05-15"
+last_reviewed: "2026-07-17"
 ---
 
 # xtasks
@@ -19,9 +19,12 @@ The `xtask/` crate contains typed repo automation invoked as `cargo xtask <comma
 
 ```
 xtask/
-  Cargo.toml    # name = "xtask", path dep on main crate
+  Cargo.toml       # name = "xtask", path dep on main crate
   src/
-    main.rs     # cargo xtask <command>
+    main.rs        # top-level cargo xtask command router
+    <command>.rs   # one focused module per substantial command
+    <command>_tests.rs
+    live/          # focused modules supporting the live/shart harness
 ```
 
 ## Commands
@@ -146,22 +149,32 @@ Use the Just aliases `just live-full-guard`, `just live-full-cli`,
 
 ## shart stack management
 
-The operator lifecycle commands load and validate the canonical
-`/home/jmagar/.yarr-shart/.env` guard before touching remote containers:
+`start` and `seed` load and validate the canonical
+`/home/jmagar/.yarr-shart/.env` guard before touching remote containers.
+Recovery-oriented `status` and `stop` use the fixed deployment manifest and do
+not require a healthy local application configuration:
 
 ```bash
 cargo xtask shart start
 cargo xtask shart stop
-cargo xtask shart status
+cargo xtask shart status --json
+cargo xtask shart seed --dry-run
 cargo xtask shart seed
 ```
 
-`start` and `stop` act only on the 11 guarded service-kind container names.
+`start` and `stop` act only on the 11 explicitly mapped container names.
 `status` prints each container's Docker state and health and exits non-zero when
-any container is missing or not running. `seed` restores every available
+any container is missing, not running, or reports unhealthy; `--json` emits the same result plus
+structured remote error details. `seed --dry-run` prints the resolved host,
+environment, containers, restored datasets, and retained services without
+making remote changes. A real `seed` preflights the complete fleet, then
+sequentially restores every available
 `backup/lab/live/golden/<service>@configured-v1` snapshot using the existing
-reset machinery, starts all containers (including services without a golden),
-and waits for all configured service URLs.
+reset machinery while the fleet is stopped. If a restore fails, the fleet stays
+stopped for correction and rerun; otherwise it starts all containers and waits
+under one fleet-wide deadline.
+Bazarr and Tracearr currently have no golden and are explicitly reported as
+retained rather than silently described as restored.
 
 These commands intentionally do not start or stop the shart Unraid array. If
 Docker or the backing datasets are unavailable, they fail with the remote error

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -29,6 +29,7 @@
 #   - ascii-check     → full-repo docs/source scan; runs in CI and `just template-features`
 #   - live suites     → `just test-mcporter` (now `cargo xtask live --suite mcp`) and the
 #                       other `cargo xtask live` suites need the shart stack; manual/CI only.
+#   - shart lifecycle → `just shart-*` performs remote Docker/ZFS operations; manual-only.
 #
 # TEMPLATE: Resist the urge to add more hooks here. If something slows down
 #           your commit flow, developers will start using --no-verify, which

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -27,4 +27,5 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 noyalib = { version = "0.0.15", default-features = false, features = ["std", "strict-deserialise"] }
 ureq = { version = "3", default-features = false, features = ["json"] }
+url = "2"
 walkdir = "2"

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -108,6 +108,24 @@ Copy .env.example to .env and fill in YARR_SERVICES plus per-service URL/key var
 
 ---
 
+### `cargo xtask shart`
+
+Manage only the dedicated shart test-stack containers:
+
+```bash
+cargo xtask shart start
+cargo xtask shart stop
+cargo xtask shart status
+cargo xtask shart seed
+```
+
+The command validates `/home/jmagar/.yarr-shart/.env` before any remote action.
+`seed` restores the established `configured-v1` ZFS golden snapshots, starts all
+guarded containers, and waits for every configured service URL. It never starts
+or stops the broader Unraid array.
+
+---
+
 ## Design notes
 
 - **Minimal dependencies**: only `anyhow` and `walkdir` — keeps xtask compile time fast.

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -115,28 +115,35 @@ Manage only the dedicated shart test-stack containers:
 ```bash
 cargo xtask shart start
 cargo xtask shart stop
-cargo xtask shart status
+cargo xtask shart status --json
+cargo xtask shart seed --dry-run
 cargo xtask shart seed
 ```
 
-The command validates `/home/jmagar/.yarr-shart/.env` before any remote action.
-`seed` restores the established `configured-v1` ZFS golden snapshots, starts all
-guarded containers, and waits for every configured service URL. It never starts
-or stops the broader Unraid array.
+`start` and `seed` validate `/home/jmagar/.yarr-shart/.env`; recovery-oriented
+`status` and `stop` use the fixed deployment manifest without requiring healthy
+app configuration. `seed --dry-run` shows the resolved destructive plan. A real
+seed preflights and restores the established `configured-v1` ZFS snapshots with
+a fleet-quiesced, fail-closed recovery policy. The restore is sequential and can
+leave some datasets restored if a later step fails; the fleet stays stopped so
+the operator can correct the failure and rerun it. It explicitly reports
+retained non-golden services, starts the fleet after a successful restore, and
+waits under one deadline. These commands never start or stop the broader Unraid
+array.
 
 ---
 
 ## Design notes
 
-- **Minimal dependencies**: only `anyhow` and `walkdir` — keeps xtask compile time fast.
+- **Minimal dependencies**: keep automation dependencies focused and reuse workspace/transitive libraries only through explicit declarations.
 - **Workspace root awareness**: all commands `cd` to the workspace root via `CARGO_MANIFEST_DIR` before running, so they work from any subdirectory.
 - **Delegation pattern**: shells out to external tools when useful (`cargo`, `taplo`, etc.) and implements repo-specific contract checks directly in Rust.
 - **Optional tools**: `ci` gracefully skips `nextest`, `taplo`, and `cargo-audit` if they are not installed, so the command is always runnable on a fresh checkout.
 
 ## Adding a new command
 
-1. Add a new function `fn your_command() -> anyhow::Result<()>` in `xtask/src/main.rs`.
-2. Add a match arm in `main()`:
+1. Add a focused `xtask/src/your_command.rs` module with `run(&[String]) -> anyhow::Result<()>` and a sibling `your_command_tests.rs`.
+2. Declare the module and add a match arm in `main()`:
    ```rust
    Some("your-command") => your_command(),
    ```

--- a/xtask/src/live.rs
+++ b/xtask/src/live.rs
@@ -15,6 +15,7 @@ pub mod process;
 pub mod report;
 pub mod reset;
 mod services;
+pub mod ssh;
 pub mod suites;
 pub mod surface;
 

--- a/xtask/src/live/contract/reset_ops.rs
+++ b/xtask/src/live/contract/reset_ops.rs
@@ -1,10 +1,10 @@
-use anyhow::{Context, Result};
-use std::process::Command;
+use anyhow::Result;
+use std::time::Duration;
 
 use yarr::ServiceKind;
 use yarr::openapi::OperationSpec;
 
-use crate::live::{process, reset};
+use crate::live::{process, reset, ssh};
 
 use super::{FixtureStore, OpResult, PreparedOp, RunOut, invoke, prepare_op_args, synth::Spec};
 
@@ -85,14 +85,7 @@ pub(in crate::live) fn cleanup_service_fixtures(kind: ServiceKind) -> Result<()>
         ServiceKind::Sonarr => "fuser -k 18081/tcp >/dev/null 2>&1 || true",
         _ => return Ok(()),
     };
-    let status = Command::new("timeout")
-        .args(["30s", "ssh", "shart", command])
-        .status()
-        .context("cleanup live helper servers on shart")?;
-    anyhow::ensure!(
-        status.success(),
-        "cleanup live helper servers on shart failed with {status}"
-    );
+    ssh::run(command, Duration::from_secs(30))?.ensure_success("cleanup live helper servers")?;
     Ok(())
 }
 

--- a/xtask/src/live/guard.rs
+++ b/xtask/src/live/guard.rs
@@ -113,16 +113,17 @@ pub fn required_kinds() -> BTreeSet<&'static str> {
 }
 
 fn assert_shart_url(key: &str, value: &str) -> Result<()> {
-    let lower = value.to_ascii_lowercase();
-    let allowed = [
-        "http://shart:",
-        "https://shart:",
-        "http://shart.manatee-triceratops.ts.net:",
-        "https://shart.manatee-triceratops.ts.net:",
-        "http://100.118.209.1:",
-        "https://100.118.209.1:",
-    ];
-    if !allowed.iter().any(|prefix| lower.starts_with(prefix)) {
+    let parsed = url::Url::parse(value).with_context(|| format!("{key} is not a valid URL"))?;
+    if !matches!(parsed.scheme(), "http" | "https")
+        || !parsed.username().is_empty()
+        || parsed.password().is_some()
+        || parsed.port().is_none()
+    {
+        bail!("{key}={value} is not a shart URL");
+    }
+    let host = parsed.host_str().unwrap_or("").to_ascii_lowercase();
+    let allowed = ["shart", "shart.manatee-triceratops.ts.net", "100.118.209.1"];
+    if !allowed.contains(&host.as_str()) {
         bail!("{key}={value} is not a shart URL");
     }
     Ok(())

--- a/xtask/src/live/lifecycles.rs
+++ b/xtask/src/live/lifecycles.rs
@@ -16,12 +16,11 @@ use anyhow::{Context, Result, bail};
 use serde_json::Value;
 use std::io::{Read, Write};
 use std::net::TcpListener;
-use std::process::Command;
 use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
 
-use super::{process, report};
+use super::{process, report, ssh};
 
 const FIXTURE_PORT: u16 = 40175;
 

--- a/xtask/src/live/lifecycles/services.rs
+++ b/xtask/src/live/lifecycles/services.rs
@@ -216,17 +216,9 @@ pub(super) fn tracearr_session_fixture_count() -> Result<i64> {
 }
 
 pub(super) fn run_ssh_shart(command: &str) -> Result<String> {
-    let output = Command::new("ssh")
-        .arg("shart")
-        .arg(command)
-        .output()
-        .with_context(|| format!("failed to run ssh shart {command}"))?;
-    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_owned();
-    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
-    if !output.status.success() {
-        bail!("ssh shart {command} failed: {stdout}{stderr}");
-    }
-    Ok(stdout)
+    let output = ssh::run(command, Duration::from_secs(30))?
+        .ensure_success("seed shart lifecycle fixture")?;
+    Ok(output.stdout)
 }
 
 pub(super) fn parse_i64_output(output: &str, label: &str) -> Result<i64> {

--- a/xtask/src/live/reset.rs
+++ b/xtask/src/live/reset.rs
@@ -5,10 +5,11 @@
 //! back to `@configured-v1` gives the live harness a cheap reset point for
 //! operations that intentionally rewrite config/auth state or stop a service.
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Result, bail};
 use std::collections::BTreeMap;
-use std::process::Command;
 use std::time::{Duration, Instant};
+
+use super::ssh;
 
 #[derive(Debug, Clone, Copy)]
 pub struct ResetTarget {
@@ -51,6 +52,10 @@ pub fn target_for(service: &str) -> Option<&'static ResetTarget> {
         .find(|target| target.service == service)
 }
 
+pub fn all_targets() -> &'static [ResetTarget] {
+    RESET_TARGETS
+}
+
 pub fn reset_service(service: &str) -> Result<()> {
     let targets = targets_for(service);
     if targets.is_empty() {
@@ -60,27 +65,56 @@ pub fn reset_service(service: &str) -> Result<()> {
 }
 
 pub fn reset_targets(targets: &[&ResetTarget]) -> Result<()> {
-    if targets.is_empty() {
-        return Ok(());
-    }
-    let command = reset_script(targets);
-    run_ssh_shart(&command)?;
-    Ok(())
-}
-
-fn reset_script(targets: &[&ResetTarget]) -> String {
     let containers = targets
         .iter()
         .map(|target| target.container)
         .collect::<std::collections::BTreeSet<_>>()
         .into_iter()
+        .collect::<Vec<_>>();
+    reset_targets_with_fleet(targets, &containers)
+}
+
+pub fn reset_all(fleet_containers: &[&str]) -> Result<()> {
+    let targets = RESET_TARGETS.iter().collect::<Vec<_>>();
+    reset_targets_with_fleet(&targets, fleet_containers)
+}
+
+fn reset_targets_with_fleet(targets: &[&ResetTarget], fleet_containers: &[&str]) -> Result<()> {
+    if targets.is_empty() {
+        return Ok(());
+    }
+    let command = reset_script(targets, fleet_containers);
+    eprintln!("reset shart: preflighting and restoring golden datasets");
+    let output = ssh::run(&command, Duration::from_secs(180))?
+        .ensure_success("reset shart golden datasets")?;
+    if !output.stdout.is_empty() {
+        eprintln!("{}", output.stdout);
+    }
+    Ok(())
+}
+
+fn reset_script(targets: &[&ResetTarget], fleet_containers: &[&str]) -> String {
+    let containers = fleet_containers.join(" ");
+    let preflight_targets = targets
+        .iter()
+        .map(|target| {
+            format!(
+                r#"zfs list -H backup/lab/live/golden/{dataset} >/dev/null
+zfs list -H -t snapshot backup/lab/live/golden/{dataset}@{snapshot} >/dev/null
+newest=$(zfs list -H -t snapshot -o name -s creation -r backup/lab/live/golden/{dataset} | tail -n 1)
+[ "$newest" = "backup/lab/live/golden/{dataset}@{snapshot}" ] || {{ echo "refusing rollback: {dataset}@{snapshot} is not newest (newest=$newest)" >&2; exit 1; }}
+[ -d /mnt/backup/lab/live/golden/{dataset} ] || {{ echo "missing source mount for {dataset}" >&2; exit 1; }}"#,
+                dataset = target.dataset,
+                snapshot = target.snapshot,
+            )
+        })
         .collect::<Vec<_>>()
-        .join(" ");
+        .join("\n");
     let rollbacks = targets
         .iter()
         .map(|target| {
             format!(
-                "zfs rollback -r backup/lab/live/golden/{dataset}@{snapshot}\nfind /mnt/backup/lab/live/golden/{dataset} -maxdepth 2 \\( -name '*.db-shm' -o -name '*.db-wal' -o -name '*.pid' \\) -delete\nmkdir -p /mnt/user/lab/live/golden/{dataset}\nrsync -a --delete /mnt/backup/lab/live/golden/{dataset}/ /mnt/user/lab/live/golden/{dataset}/\nfind /mnt/user/lab/live/golden/{dataset} -maxdepth 2 \\( -name '*.db-shm' -o -name '*.db-wal' -o -name '*.pid' \\) -delete",
+                "zfs rollback backup/lab/live/golden/{dataset}@{snapshot}\nfind /mnt/backup/lab/live/golden/{dataset} -maxdepth 2 \\( -name '*.db-shm' -o -name '*.db-wal' -o -name '*.pid' \\) -delete\nmkdir -p /mnt/user/lab/live/golden/{dataset}\nrsync -a --delete /mnt/backup/lab/live/golden/{dataset}/ /mnt/user/lab/live/golden/{dataset}/\nfind /mnt/user/lab/live/golden/{dataset} -maxdepth 2 \\( -name '*.db-shm' -o -name '*.db-wal' -o -name '*.pid' \\) -delete",
                 dataset = target.dataset,
                 snapshot = target.snapshot,
             )
@@ -91,9 +125,26 @@ fn reset_script(targets: &[&ResetTarget]) -> String {
     format!(
         r#"set -euo pipefail
 containers="{containers}"
-docker stop $containers >/dev/null 2>&1 || true
+for tool in docker zfs rsync find; do command -v "$tool" >/dev/null || {{ echo "missing required tool: $tool" >&2; exit 1; }}; done
+docker info >/dev/null
+for container in $containers; do docker inspect "$container" >/dev/null || {{ echo "missing container: $container" >&2; exit 1; }}; done
+[ -d /mnt/user/lab/live/golden ] || {{ echo "missing live golden base directory" >&2; exit 1; }}
+{preflight_targets}
+completed=0
+finish() {{
+  rc=$?
+  trap - EXIT
+  if [ "$rc" -ne 0 ] && [ "$completed" -eq 0 ]; then
+    docker stop $containers >/dev/null 2>&1 || true
+    echo "golden restore failed; managed fleet remains stopped; rerun seed after correcting the reported failure" >&2
+  fi
+  exit "$rc"
+}}
+trap finish EXIT
+docker stop $containers >/dev/null
 {rollbacks}
 docker start $containers >/dev/null
+completed=1
 "#
     )
 }
@@ -133,27 +184,6 @@ pub fn service_url(values: &BTreeMap<String, String>, service: &str) -> Option<S
     values.get(&format!("YARR_{env_name}_URL")).cloned()
 }
 
-fn run_ssh_shart(command: &str) -> Result<String> {
-    eprintln!("reset shart: starting ZFS golden rollback");
-    let output = Command::new("timeout")
-        .args(["--kill-after=5s", "120s", "ssh"])
-        .arg("-o")
-        .arg("BatchMode=yes")
-        .arg("-o")
-        .arg("ConnectTimeout=10")
-        .arg("-o")
-        .arg("ServerAliveInterval=10")
-        .arg("-o")
-        .arg("ServerAliveCountMax=3")
-        .arg("shart")
-        .arg(command)
-        .output()
-        .with_context(|| format!("failed to run ssh shart {command}"))?;
-    eprintln!("reset shart: finished with {}", output.status);
-    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_owned();
-    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
-    if !output.status.success() {
-        bail!("ssh shart reset failed: {stdout}{stderr}");
-    }
-    Ok(stdout)
-}
+#[cfg(test)]
+#[path = "reset_tests.rs"]
+mod tests;

--- a/xtask/src/live/reset_tests.rs
+++ b/xtask/src/live/reset_tests.rs
@@ -1,0 +1,27 @@
+use super::{ResetTarget, reset_script};
+
+const TARGET: ResetTarget = ResetTarget {
+    service: "sonarr",
+    container: "sonarr",
+    dataset: "sonarr",
+    snapshot: "configured-v1",
+};
+
+#[test]
+fn reset_preflights_everything_before_stopping_the_fleet() {
+    let script = reset_script(&[&TARGET], &["sonarr", "radarr"]);
+    let preflight = script.find("newest=$(zfs list").unwrap();
+    let stop = script.find("docker stop $containers").unwrap();
+    assert!(preflight < stop);
+    assert!(script.contains("missing container"));
+    assert!(script.contains("managed fleet remains stopped"));
+    assert!(script.contains("docker stop $containers >/dev/null 2>&1 || true"));
+}
+
+#[test]
+fn reset_never_uses_recursive_destructive_rollback() {
+    let script = reset_script(&[&TARGET], &["sonarr"]);
+    assert!(script.contains("zfs rollback backup/lab/live/golden/sonarr@configured-v1"));
+    assert!(!script.contains("zfs rollback -r"));
+    assert!(script.contains("is not newest"));
+}

--- a/xtask/src/live/ssh.rs
+++ b/xtask/src/live/ssh.rs
@@ -1,0 +1,60 @@
+//! Shared bounded SSH execution for the disposable shart test host.
+
+use anyhow::{Context, Result, bail};
+use std::process::Command;
+use std::time::Duration;
+
+pub const SHART_HOST: &str = "shart";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoteOutput {
+    pub status: Option<i32>,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+impl RemoteOutput {
+    pub fn success(&self) -> bool {
+        self.status == Some(0)
+    }
+
+    pub fn ensure_success(self, operation: &str) -> Result<Self> {
+        if self.success() {
+            return Ok(self);
+        }
+        bail!(
+            "{operation} failed on {SHART_HOST} (exit={}): stdout={:?} stderr={:?}",
+            self.status
+                .map_or_else(|| "signal".to_owned(), |code| code.to_string()),
+            self.stdout,
+            self.stderr,
+        )
+    }
+}
+
+pub fn run(command: &str, deadline: Duration) -> Result<RemoteOutput> {
+    let deadline_secs = deadline.as_secs().max(1).to_string();
+    let output = Command::new("timeout")
+        .args(["--kill-after=5s", &deadline_secs, "ssh"])
+        .arg("-o")
+        .arg("BatchMode=yes")
+        .arg("-o")
+        .arg("ConnectTimeout=10")
+        .arg("-o")
+        .arg("ServerAliveInterval=10")
+        .arg("-o")
+        .arg("ServerAliveCountMax=3")
+        .arg(SHART_HOST)
+        .arg(command)
+        .output()
+        .with_context(|| format!("failed to spawn bounded SSH command for {SHART_HOST}"))?;
+    Ok(RemoteOutput {
+        status: output.status.code(),
+        stdout: String::from_utf8_lossy(&output.stdout).trim().to_owned(),
+        stderr: String::from_utf8_lossy(&output.stderr).trim().to_owned(),
+    })
+}
+
+#[cfg(test)]
+#[path = "ssh_tests.rs"]
+mod tests;

--- a/xtask/src/live/ssh_tests.rs
+++ b/xtask/src/live/ssh_tests.rs
@@ -1,0 +1,17 @@
+use super::RemoteOutput;
+
+#[test]
+fn remote_output_preserves_structured_failure_fields() {
+    let output = RemoteOutput {
+        status: Some(7),
+        stdout: "partial status".into(),
+        stderr: "docker unavailable".into(),
+    };
+    let error = output
+        .ensure_success("inspect fleet")
+        .unwrap_err()
+        .to_string();
+    assert!(error.contains("exit=7"));
+    assert!(error.contains("partial status"));
+    assert!(error.contains("docker unavailable"));
+}

--- a/xtask/src/live_tests.rs
+++ b/xtask/src/live_tests.rs
@@ -56,6 +56,17 @@ fn guard_rejects_tootie_url_override() {
 }
 
 #[test]
+fn guard_rejects_userinfo_prefix_host_bypass() {
+    let mut env = good_env();
+    env.insert(
+        "YARR_SONARR_URL".into(),
+        "http://shart:80@attacker.example:8989/".into(),
+    );
+    let err = validate_env(env, false).unwrap_err().to_string();
+    assert!(err.contains("is not a shart URL"));
+}
+
+#[test]
 fn guard_rejects_missing_required_kind() {
     let mut env = good_env();
     env.insert("YARR_SERVICES".into(), "sonarr,radarr".into());

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -9,6 +9,7 @@
 //!   check-env    Validate required environment variables are set
 //!   patterns     Check static contracts from docs/PATTERNS.md
 //!   live         Run shart-only live tests against the real Yarr service stack
+//!   shart        Manage the dedicated shart test stack
 //!   tool-docs    Generate the tool/action/endpoint reference doc
 //!
 //! Add commands by adding arms to the match block below. Keep each command as a
@@ -27,6 +28,7 @@ mod ci;
 mod gen_openapi;
 mod live;
 mod patterns;
+mod shart;
 mod tool_docs;
 
 fn main() -> Result<()> {
@@ -49,6 +51,7 @@ fn main() -> Result<()> {
         Some("check-env") => check_env(),
         Some("gen-openapi") => gen_openapi::run(&args[1..]),
         Some("live") => live::run(&args[1..]),
+        Some("shart") => shart::run(&args[1..]),
         Some("patterns") => patterns_cmd(&args[1..]),
         Some("tool-docs") => tool_docs::run(&args[1..]),
         Some("check-test-siblings") => check_test_siblings(),
@@ -425,6 +428,7 @@ COMMANDS:
   check-env             Validate required environment variables are set
   check-test-siblings   Verify every src/*.rs has a sibling *_tests.rs
   live                  Run shart-only live tests (--suite guard|cli|rest|mcp|services|all)
+  shart                 Manage the test stack (start|stop|status|seed)
   patterns              Check static contracts from docs/PATTERNS.md (--strict, --json)
   tool-docs             Generate docs/TOOLS_ACTIONS_ENDPOINTS.md (--check)
   help                  Show this help

--- a/xtask/src/shart.rs
+++ b/xtask/src/shart.rs
@@ -1,169 +1,315 @@
 //! Operator lifecycle commands for the dedicated shart test stack.
 //!
-//! These commands intentionally manage only the 11 containers declared by the
-//! guarded Yarr test environment. They never start or stop the Unraid array.
+//! These commands intentionally manage only the typed deployment manifest below.
+//! They never start or stop the Unraid array.
 
-use crate::live::{guard, reset};
-use anyhow::{Context, Result, bail};
-use std::process::Command;
+use crate::live::{guard, reset, ssh};
+mod readiness;
+mod status;
+
+use anyhow::{Result, bail};
+use readiness::wait_for_services;
+use serde::Serialize;
+use status::{fetch_status, render_status};
+use std::collections::BTreeSet;
+use std::time::Duration;
 
 const DOCKER_PREFLIGHT: &str = "if ! docker info >/dev/null 2>&1; then echo 'shart Docker is unavailable; start the Unraid array before managing the test stack' >&2; exit 1; fi";
+const STACK_DEADLINE: Duration = Duration::from_secs(120);
+const PROBE_TIMEOUT: Duration = Duration::from_secs(2);
 
-pub fn run(args: &[String]) -> Result<()> {
-    let Some(command) = args.first().map(String::as_str) else {
-        print_help();
-        return Ok(());
-    };
-    if args.len() != 1 {
-        bail!("usage: cargo xtask shart <start|stop|status|seed>");
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct StackService {
+    service: &'static str,
+    kind: &'static str,
+    container: &'static str,
+}
+
+const STACK: &[StackService] = &[
+    stack_service("sonarr"),
+    stack_service("radarr"),
+    stack_service("prowlarr"),
+    stack_service("tautulli"),
+    stack_service("overseerr"),
+    stack_service("bazarr"),
+    stack_service("tracearr"),
+    stack_service("sabnzbd"),
+    stack_service("qbittorrent"),
+    stack_service("plex"),
+    stack_service("jellyfin"),
+];
+
+const fn stack_service(name: &'static str) -> StackService {
+    StackService {
+        service: name,
+        kind: name,
+        container: name,
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LifecycleAction {
+    Start,
+    Stop,
+}
+
+impl LifecycleAction {
+    const fn docker_verb(self) -> &'static str {
+        match self {
+            Self::Start => "start",
+            Self::Stop => "stop",
+        }
     }
 
-    match command {
-        "start" => start(),
-        "stop" => stop(),
-        "status" => status(),
-        "seed" => seed(),
-        "--help" | "-h" | "help" => {
+    const fn desired_state(self) -> &'static str {
+        match self {
+            Self::Start => "running",
+            Self::Stop => "exited",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Command {
+    Help,
+    Start,
+    Stop,
+    Status,
+    Seed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Options {
+    command: Command,
+    json: bool,
+    dry_run: bool,
+}
+
+impl Options {
+    fn parse(args: &[String]) -> Result<Self> {
+        let Some(command) = args.first().map(String::as_str) else {
+            return Ok(Self {
+                command: Command::Help,
+                json: false,
+                dry_run: false,
+            });
+        };
+        if matches!(command, "--help" | "-h" | "help") {
+            if args.len() != 1 {
+                bail!("help does not accept additional arguments");
+            }
+            return Ok(Self {
+                command: Command::Help,
+                json: false,
+                dry_run: false,
+            });
+        }
+        let command = match command {
+            "start" => Command::Start,
+            "stop" => Command::Stop,
+            "status" => Command::Status,
+            "seed" => Command::Seed,
+            unknown => bail!("unknown shart command: {unknown}"),
+        };
+        let mut json = false;
+        let mut dry_run = false;
+        for arg in &args[1..] {
+            match arg.as_str() {
+                "--json" if command == Command::Status => json = true,
+                "--dry-run" if command == Command::Seed => dry_run = true,
+                "--json" => bail!("--json is only valid with shart status"),
+                "--dry-run" => bail!("--dry-run is only valid with shart seed"),
+                other => bail!("unknown option for shart {command:?}: {other}"),
+            }
+        }
+        Ok(Self {
+            command,
+            json,
+            dry_run,
+        })
+    }
+}
+
+pub fn run(args: &[String]) -> Result<()> {
+    let options = Options::parse(args)?;
+    match options.command {
+        Command::Help => {
             print_help();
             Ok(())
         }
-        unknown => bail!("unknown shart command: {unknown}"),
+        Command::Start => start(),
+        Command::Stop => stop(),
+        Command::Status => status(options.json),
+        Command::Seed => seed(options.dry_run),
     }
 }
 
 fn start() -> Result<()> {
-    let guarded = guard::load(None, false)?;
-    let containers = container_names();
-    run_ssh(&container_command("start", &containers))?;
-    wait_for_services(&guarded)?;
-    print_status(&containers)
+    let guarded = guarded_stack()?;
+    run_lifecycle(LifecycleAction::Start)?;
+    finish_start(&guarded)
 }
 
 fn stop() -> Result<()> {
-    guard::load(None, false)?;
-    let containers = container_names();
-    run_ssh(&container_command("stop", &containers))?;
-    print_status_allow_stopped(&containers)
+    run_lifecycle(LifecycleAction::Stop)?;
+    render_status(fetch_status(false)?, false)
 }
 
-fn status() -> Result<()> {
-    guard::load(None, false)?;
-    print_status(&container_names())
+fn status(json: bool) -> Result<()> {
+    let report = fetch_status(true)?;
+    render_status(report, json)
 }
 
-fn seed() -> Result<()> {
+fn seed(dry_run: bool) -> Result<()> {
+    let guarded = guarded_stack()?;
+    let plan = seed_plan();
+    print_seed_plan(&plan);
+    if dry_run {
+        println!("dry-run: no remote changes made");
+        return Ok(());
+    }
+    reset::reset_all(&container_names())?;
+    finish_start(&guarded)
+}
+
+fn guarded_stack() -> Result<guard::GuardedEnv> {
     let guarded = guard::load(None, false)?;
-    let containers = container_names();
-    run_ssh(DOCKER_PREFLIGHT)?;
-
-    // reset_service restores the configured-v1 snapshots, clears stale SQLite
-    // sidecars/PID files, and restarts each golden-backed container. Services
-    // without a golden are retained and started below.
-    for service in &containers {
-        if reset::target_for(service).is_some() {
-            reset::reset_service(service)?;
+    let configured = guarded
+        .services
+        .iter()
+        .map(String::as_str)
+        .collect::<BTreeSet<_>>();
+    let expected = STACK
+        .iter()
+        .map(|entry| entry.service)
+        .collect::<BTreeSet<_>>();
+    if configured != expected {
+        bail!(
+            "shart lifecycle requires exact canonical service identities; configured={configured:?} expected={expected:?}"
+        );
+    }
+    for entry in STACK {
+        let kind = guarded.kinds.get(entry.service).map(String::as_str);
+        if kind != Some(entry.kind) {
+            bail!(
+                "shart service {} must use kind {}; got {:?}",
+                entry.service,
+                entry.kind,
+                kind
+            );
         }
     }
-
-    run_ssh(&container_command("start", &containers))?;
-    wait_for_services(&guarded)?;
-    print_status(&containers)
+    Ok(guarded)
 }
 
-fn container_names() -> Vec<String> {
-    guard::required_kinds()
-        .into_iter()
-        .map(str::to_owned)
-        .collect()
+fn container_names() -> Vec<&'static str> {
+    STACK.iter().map(|entry| entry.container).collect()
 }
 
-fn container_command(action: &str, containers: &[String]) -> String {
-    format!(
-        "set -eu; {DOCKER_PREFLIGHT}; docker {action} {}",
-        containers.join(" ")
-    )
-}
-
-fn status_script(containers: &[String], require_running: bool) -> String {
-    let required_check = if require_running {
-        r#"if [ "$state" != "running" ]; then failed=1; fi"#
-    } else {
-        ""
-    };
+fn lifecycle_command(action: LifecycleAction) -> String {
+    let containers = container_names().join(" ");
+    let verb = action.docker_verb();
+    let desired = action.desired_state();
     format!(
         r#"set -eu
 {DOCKER_PREFLIGHT}
-printf '%-16s %-12s %s\n' CONTAINER STATE HEALTH
-failed=0
-for container in {}; do
-  if docker inspect "$container" >/dev/null 2>&1; then
-    state=$(docker inspect --format '{{{{.State.Status}}}}' "$container")
-    health=$(docker inspect --format '{{{{if .State.Health}}}}{{{{.State.Health.Status}}}}{{{{else}}}}-{{{{end}}}}' "$container")
-  else
-    state=missing
-    health=-
-    failed=1
-  fi
-  printf '%-16s %-12s %s\n' "$container" "$state" "$health"
-  {required_check}
+plan=""
+for container in {containers}; do
+  state=$(docker inspect --format '{{{{.State.Status}}}}' "$container" 2>/dev/null) || {{ echo "missing container: $container" >&2; exit 1; }}
+  plan="$plan $container:$state"
 done
-exit "$failed""#,
-        containers.join(" "),
-        DOCKER_PREFLIGHT = DOCKER_PREFLIGHT,
+for item in $plan; do
+  container=${{item%%:*}}
+  state=${{item#*:}}
+  if [ "$state" != "{desired}" ]; then docker {verb} "$container" >/dev/null; fi
+done"#
     )
 }
 
-fn print_status(containers: &[String]) -> Result<()> {
-    run_ssh(&status_script(containers, true)).map(|_| ())
-}
-
-fn print_status_allow_stopped(containers: &[String]) -> Result<()> {
-    run_ssh(&status_script(containers, false)).map(|_| ())
-}
-
-fn wait_for_services(guarded: &guard::GuardedEnv) -> Result<()> {
-    for service in &guarded.services {
-        let url = reset::service_url(&guarded.values, service)
-            .with_context(|| format!("missing URL for shart service {service}"))?;
-        reset::wait_service_url(&url)
-            .with_context(|| format!("wait for shart service {service} at {url}"))?;
-    }
+fn run_lifecycle(action: LifecycleAction) -> Result<()> {
+    ssh::run(&lifecycle_command(action), Duration::from_secs(180))?
+        .ensure_success(action.docker_verb())?;
     Ok(())
 }
 
-fn run_ssh(command: &str) -> Result<String> {
-    let output = Command::new("timeout")
-        .args(["--kill-after=5s", "180s", "ssh"])
-        .arg("-o")
-        .arg("BatchMode=yes")
-        .arg("-o")
-        .arg("ConnectTimeout=10")
-        .arg("-o")
-        .arg("ServerAliveInterval=10")
-        .arg("-o")
-        .arg("ServerAliveCountMax=3")
-        .arg("shart")
-        .arg(command)
-        .output()
-        .with_context(|| format!("failed to run ssh shart {command}"))?;
-    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_owned();
-    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
-    if !stdout.is_empty() {
-        println!("{stdout}");
+#[derive(Debug, Serialize)]
+struct SeedPlan {
+    host: &'static str,
+    environment_file: &'static str,
+    containers: Vec<&'static str>,
+    restored_datasets: Vec<String>,
+    retained_services: Vec<&'static str>,
+}
+
+fn seed_plan() -> SeedPlan {
+    let restored_services = reset::all_targets()
+        .iter()
+        .map(|target| target.service)
+        .collect::<BTreeSet<_>>();
+    SeedPlan {
+        host: ssh::SHART_HOST,
+        environment_file: guard::DEFAULT_ENV_FILE,
+        containers: container_names(),
+        restored_datasets: reset::all_targets()
+            .iter()
+            .map(|target| {
+                format!(
+                    "backup/lab/live/golden/{}@{}",
+                    target.dataset, target.snapshot
+                )
+            })
+            .collect(),
+        retained_services: STACK
+            .iter()
+            .filter(|entry| !restored_services.contains(entry.service))
+            .map(|entry| entry.service)
+            .collect(),
     }
-    if !output.status.success() {
-        bail!("shart command failed: {stderr}");
+}
+
+fn print_seed_plan(plan: &SeedPlan) {
+    println!("shart seed plan:");
+    println!("  host: {}", plan.host);
+    println!("  environment: {}", plan.environment_file);
+    println!("  containers: {}", plan.containers.join(", "));
+    println!("  restored datasets:");
+    for dataset in &plan.restored_datasets {
+        println!("    - {dataset}");
     }
-    Ok(stdout)
+    println!(
+        "  retained services (no golden): {}",
+        plan.retained_services.join(", ")
+    );
+}
+
+fn finish_start(guarded: &guard::GuardedEnv) -> Result<()> {
+    let readiness = wait_for_services(guarded);
+    let status = fetch_status(true);
+    match status {
+        Ok(report) => {
+            let status_result = render_status(report, false);
+            readiness.and(status_result)
+        }
+        Err(status_error) => match readiness {
+            Ok(()) => Err(status_error),
+            Err(readiness_error) => bail!(
+                "readiness failed: {readiness_error:#}; fleet status also failed: {status_error:#}"
+            ),
+        },
+    }
 }
 
 fn print_help() {
-    println!("cargo xtask shart <start|stop|status|seed>");
-    println!("  start   Start all guarded Yarr test containers and wait for readiness");
-    println!("  stop    Stop all guarded Yarr test containers");
-    println!("  status  Show container state/health; fail unless every container is running");
-    println!("  seed    Restore configured-v1 golden data, start all containers, and wait");
-    println!("These commands do not start or stop the shart Unraid array.");
+    print!("{}", help_text());
+}
+
+fn help_text() -> &'static str {
+    "cargo xtask shart <start|stop|status|seed> [options]\n\
+  start              Start stopped manifest containers and wait for readiness\n\
+  stop               Stop running manifest containers\n\
+  status [--json]    Show container state/health; fail unless all are running\n\
+  seed [--dry-run]   Restore goldens fail-closed, start the fleet, and wait\n\
+These commands do not start or stop the shart Unraid array.\n"
 }
 
 #[cfg(test)]

--- a/xtask/src/shart.rs
+++ b/xtask/src/shart.rs
@@ -1,0 +1,171 @@
+//! Operator lifecycle commands for the dedicated shart test stack.
+//!
+//! These commands intentionally manage only the 11 containers declared by the
+//! guarded Yarr test environment. They never start or stop the Unraid array.
+
+use crate::live::{guard, reset};
+use anyhow::{Context, Result, bail};
+use std::process::Command;
+
+const DOCKER_PREFLIGHT: &str = "if ! docker info >/dev/null 2>&1; then echo 'shart Docker is unavailable; start the Unraid array before managing the test stack' >&2; exit 1; fi";
+
+pub fn run(args: &[String]) -> Result<()> {
+    let Some(command) = args.first().map(String::as_str) else {
+        print_help();
+        return Ok(());
+    };
+    if args.len() != 1 {
+        bail!("usage: cargo xtask shart <start|stop|status|seed>");
+    }
+
+    match command {
+        "start" => start(),
+        "stop" => stop(),
+        "status" => status(),
+        "seed" => seed(),
+        "--help" | "-h" | "help" => {
+            print_help();
+            Ok(())
+        }
+        unknown => bail!("unknown shart command: {unknown}"),
+    }
+}
+
+fn start() -> Result<()> {
+    let guarded = guard::load(None, false)?;
+    let containers = container_names();
+    run_ssh(&container_command("start", &containers))?;
+    wait_for_services(&guarded)?;
+    print_status(&containers)
+}
+
+fn stop() -> Result<()> {
+    guard::load(None, false)?;
+    let containers = container_names();
+    run_ssh(&container_command("stop", &containers))?;
+    print_status_allow_stopped(&containers)
+}
+
+fn status() -> Result<()> {
+    guard::load(None, false)?;
+    print_status(&container_names())
+}
+
+fn seed() -> Result<()> {
+    let guarded = guard::load(None, false)?;
+    let containers = container_names();
+    run_ssh(DOCKER_PREFLIGHT)?;
+
+    // reset_service restores the configured-v1 snapshots, clears stale SQLite
+    // sidecars/PID files, and restarts each golden-backed container. Services
+    // without a golden are retained and started below.
+    for service in &containers {
+        if reset::target_for(service).is_some() {
+            reset::reset_service(service)?;
+        }
+    }
+
+    run_ssh(&container_command("start", &containers))?;
+    wait_for_services(&guarded)?;
+    print_status(&containers)
+}
+
+fn container_names() -> Vec<String> {
+    guard::required_kinds()
+        .into_iter()
+        .map(str::to_owned)
+        .collect()
+}
+
+fn container_command(action: &str, containers: &[String]) -> String {
+    format!(
+        "set -eu; {DOCKER_PREFLIGHT}; docker {action} {}",
+        containers.join(" ")
+    )
+}
+
+fn status_script(containers: &[String], require_running: bool) -> String {
+    let required_check = if require_running {
+        r#"if [ "$state" != "running" ]; then failed=1; fi"#
+    } else {
+        ""
+    };
+    format!(
+        r#"set -eu
+{DOCKER_PREFLIGHT}
+printf '%-16s %-12s %s\n' CONTAINER STATE HEALTH
+failed=0
+for container in {}; do
+  if docker inspect "$container" >/dev/null 2>&1; then
+    state=$(docker inspect --format '{{{{.State.Status}}}}' "$container")
+    health=$(docker inspect --format '{{{{if .State.Health}}}}{{{{.State.Health.Status}}}}{{{{else}}}}-{{{{end}}}}' "$container")
+  else
+    state=missing
+    health=-
+    failed=1
+  fi
+  printf '%-16s %-12s %s\n' "$container" "$state" "$health"
+  {required_check}
+done
+exit "$failed""#,
+        containers.join(" "),
+        DOCKER_PREFLIGHT = DOCKER_PREFLIGHT,
+    )
+}
+
+fn print_status(containers: &[String]) -> Result<()> {
+    run_ssh(&status_script(containers, true)).map(|_| ())
+}
+
+fn print_status_allow_stopped(containers: &[String]) -> Result<()> {
+    run_ssh(&status_script(containers, false)).map(|_| ())
+}
+
+fn wait_for_services(guarded: &guard::GuardedEnv) -> Result<()> {
+    for service in &guarded.services {
+        let url = reset::service_url(&guarded.values, service)
+            .with_context(|| format!("missing URL for shart service {service}"))?;
+        reset::wait_service_url(&url)
+            .with_context(|| format!("wait for shart service {service} at {url}"))?;
+    }
+    Ok(())
+}
+
+fn run_ssh(command: &str) -> Result<String> {
+    let output = Command::new("timeout")
+        .args(["--kill-after=5s", "180s", "ssh"])
+        .arg("-o")
+        .arg("BatchMode=yes")
+        .arg("-o")
+        .arg("ConnectTimeout=10")
+        .arg("-o")
+        .arg("ServerAliveInterval=10")
+        .arg("-o")
+        .arg("ServerAliveCountMax=3")
+        .arg("shart")
+        .arg(command)
+        .output()
+        .with_context(|| format!("failed to run ssh shart {command}"))?;
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
+    if !stdout.is_empty() {
+        println!("{stdout}");
+    }
+    if !output.status.success() {
+        bail!("shart command failed: {stderr}");
+    }
+    Ok(stdout)
+}
+
+fn print_help() {
+    println!("cargo xtask shart <start|stop|status|seed>");
+    println!("  start   Start all guarded Yarr test containers and wait for readiness");
+    println!("  stop    Stop all guarded Yarr test containers");
+    println!("  status  Show container state/health; fail unless every container is running");
+    println!("  seed    Restore configured-v1 golden data, start all containers, and wait");
+    println!("These commands do not start or stop the shart Unraid array.");
+}
+
+#[cfg(test)]
+#[path = "shart_tests.rs"]
+mod tests;

--- a/xtask/src/shart/readiness.rs
+++ b/xtask/src/shart/readiness.rs
@@ -1,0 +1,85 @@
+use super::{PROBE_TIMEOUT, STACK, STACK_DEADLINE};
+use crate::live::{guard, reset};
+use anyhow::{Context, Result, bail};
+use std::collections::BTreeMap;
+use std::time::{Duration, Instant};
+use ureq::Agent;
+
+pub(super) fn wait_for_services(guarded: &guard::GuardedEnv) -> Result<()> {
+    let services = STACK
+        .iter()
+        .map(|entry| {
+            let url = reset::service_url(&guarded.values, entry.service)
+                .with_context(|| format!("missing URL for shart service {}", entry.service))?;
+            Ok((entry.service.to_owned(), url))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let agent: Agent = Agent::config_builder()
+        .http_status_as_error(false)
+        .timeout_global(Some(PROBE_TIMEOUT))
+        .build()
+        .into();
+    poll_readiness(
+        &services,
+        STACK_DEADLINE,
+        Duration::from_millis(750),
+        |url| match agent.get(url).call() {
+            Ok(response) if response.status().as_u16() < 500 => Ok(()),
+            Ok(response) => Err(format!("HTTP {}", response.status().as_u16())),
+            Err(error) => Err(error.to_string()),
+        },
+    )
+}
+
+pub(super) fn poll_readiness<F>(
+    services: &[(String, String)],
+    deadline_after: Duration,
+    interval: Duration,
+    mut probe: F,
+) -> Result<()>
+where
+    F: FnMut(&str) -> std::result::Result<(), String>,
+{
+    let deadline = Instant::now() + deadline_after;
+    let mut pending = services
+        .iter()
+        .map(|(service, url)| (service.clone(), (url.clone(), "not probed".to_owned())))
+        .collect::<BTreeMap<_, _>>();
+    loop {
+        let names = pending.keys().cloned().collect::<Vec<_>>();
+        for name in names {
+            if Instant::now() >= deadline && deadline_after != Duration::ZERO {
+                break;
+            }
+            let Some((url, _)) = pending.get(&name).cloned() else {
+                continue;
+            };
+            match probe(&url) {
+                Ok(()) => {
+                    pending.remove(&name);
+                }
+                Err(error) => {
+                    if let Some(entry) = pending.get_mut(&name) {
+                        entry.1 = error;
+                    }
+                }
+            }
+        }
+        if pending.is_empty() {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            let failures = pending
+                .into_iter()
+                .map(|(service, (url, error))| format!("{service} ({url}): {error}"))
+                .collect::<Vec<_>>()
+                .join("; ");
+            bail!("shart fleet did not become ready within {deadline_after:?}: {failures}");
+        }
+        std::thread::sleep(interval.min(deadline.saturating_duration_since(Instant::now())));
+    }
+}
+
+#[cfg(test)]
+#[path = "readiness_tests.rs"]
+mod tests;

--- a/xtask/src/shart/readiness_tests.rs
+++ b/xtask/src/shart/readiness_tests.rs
@@ -1,0 +1,33 @@
+use super::poll_readiness;
+use std::time::Duration;
+
+#[test]
+fn readiness_aggregates_all_failures_under_one_deadline() {
+    let services = vec![
+        ("sonarr".into(), "http://sonarr".into()),
+        ("radarr".into(), "http://radarr".into()),
+    ];
+    let error = poll_readiness(&services, Duration::ZERO, Duration::ZERO, |url| {
+        Err(format!("unreachable {url}"))
+    })
+    .unwrap_err()
+    .to_string();
+    assert!(error.contains("sonarr"));
+    assert!(error.contains("radarr"));
+}
+
+#[test]
+fn readiness_removes_successes_and_converges() {
+    let services = vec![("sonarr".into(), "http://sonarr".into())];
+    let mut calls = 0;
+    poll_readiness(&services, Duration::from_secs(1), Duration::ZERO, |_| {
+        calls += 1;
+        if calls == 1 {
+            Err("starting".into())
+        } else {
+            Ok(())
+        }
+    })
+    .unwrap();
+    assert_eq!(calls, 2);
+}

--- a/xtask/src/shart/status.rs
+++ b/xtask/src/shart/status.rs
@@ -1,0 +1,135 @@
+use super::{DOCKER_PREFLIGHT, container_names};
+use crate::live::ssh;
+use anyhow::{Result, bail};
+use serde::Serialize;
+use std::time::Duration;
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub(super) struct ContainerStatus {
+    pub(super) container: String,
+    pub(super) state: String,
+    health: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct StatusReport {
+    ok: bool,
+    host: &'static str,
+    containers: Vec<ContainerStatus>,
+    error: Option<RemoteError>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct RemoteError {
+    kind: &'static str,
+    exit_status: Option<i32>,
+    stdout: String,
+    stderr: String,
+}
+
+pub(super) fn status_script(require_running: bool) -> String {
+    let running_check = if require_running {
+        r#"    health=$(printf '%s\n' "$values" | cut -f 2)
+    [ "$state" = "running" ] || failed=1
+    [ "$health" = "-" ] || [ "$health" = "healthy" ] || failed=1"#
+    } else {
+        ""
+    };
+    format!(
+        r#"set -u
+{DOCKER_PREFLIGHT}
+failed=0
+for container in {}; do
+  if values=$(docker inspect --format '{{{{.State.Status}}}}{{{{"\t"}}}}{{{{if .State.Health}}}}{{{{.State.Health.Status}}}}{{{{else}}}}-{{{{end}}}}' "$container" 2>/dev/null); then
+    printf '%s\t%s\n' "$container" "$values"
+    state=$(printf '%s\n' "$values" | cut -f 1)
+{running_check}
+  else
+    printf '%s\tmissing\t-\n' "$container"
+    failed=1
+  fi
+done
+exit "$failed""#,
+        container_names().join(" "),
+    )
+}
+
+pub(super) fn fetch_status(require_running: bool) -> Result<StatusReport> {
+    let output = ssh::run(&status_script(require_running), Duration::from_secs(30))?;
+    let containers = parse_status(&output.stdout)?;
+    let ok = output.success();
+    let error = (!ok).then(|| RemoteError {
+        kind: classify_error(output.status, &output.stderr),
+        exit_status: output.status,
+        stdout: output.stdout.clone(),
+        stderr: output.stderr,
+    });
+    Ok(StatusReport {
+        ok,
+        host: ssh::SHART_HOST,
+        containers,
+        error,
+    })
+}
+
+fn classify_error(status: Option<i32>, stderr: &str) -> &'static str {
+    match status {
+        Some(124 | 137) => "ssh_timeout",
+        Some(255) | None => "ssh_failed",
+        _ if stderr.contains("Docker is unavailable") => "docker_unavailable",
+        _ => "container_state",
+    }
+}
+
+pub(super) fn parse_status(output: &str) -> Result<Vec<ContainerStatus>> {
+    output
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| {
+            let mut fields = line.split('\t');
+            let container = fields.next().unwrap_or("");
+            let state = fields.next().unwrap_or("");
+            let health = fields.next().unwrap_or("");
+            if container.is_empty()
+                || state.is_empty()
+                || health.is_empty()
+                || fields.next().is_some()
+            {
+                bail!("invalid shart status row: {line:?}");
+            }
+            Ok(ContainerStatus {
+                container: container.into(),
+                state: state.into(),
+                health: health.into(),
+            })
+        })
+        .collect()
+}
+
+pub(super) fn render_status(report: StatusReport, json: bool) -> Result<()> {
+    if json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        println!("{:<16} {:<12} HEALTH", "CONTAINER", "STATE");
+        for container in &report.containers {
+            println!(
+                "{:<16} {:<12} {}",
+                container.container, container.state, container.health
+            );
+        }
+        if let Some(error) = &report.error {
+            eprintln!(
+                "shart status error: kind={} exit={:?} stderr={}",
+                error.kind, error.exit_status, error.stderr
+            );
+        }
+    }
+    if !report.ok {
+        bail!("one or more shart containers are unavailable or not running");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[path = "status_tests.rs"]
+mod tests;

--- a/xtask/src/shart/status_tests.rs
+++ b/xtask/src/shart/status_tests.rs
@@ -1,0 +1,39 @@
+use super::{classify_error, parse_status, status_script};
+
+#[test]
+fn status_uses_one_inspect_per_container_and_parses_rows() {
+    let script = status_script(true);
+    assert_eq!(script.matches("docker inspect --format").count(), 1);
+    assert!(script.contains("[ \"$state\" = \"running\" ] || failed=1"));
+    assert!(
+        script.contains("[ \"$health\" = \"-\" ] || [ \"$health\" = \"healthy\" ] || failed=1")
+    );
+    assert!(
+        script.contains("[ \"$health\" = \"-\" ] || [ \"$health\" = \"healthy\" ] || failed=1")
+    );
+
+    let stopped_script = status_script(false);
+    assert!(!stopped_script.contains("[ \"$state\" = \"running\" ] || failed=1"));
+    assert!(stopped_script.contains("missing\\t-"));
+
+    let rows = parse_status("sonarr\trunning\thealthy\nradarr\texited\t-\n").unwrap();
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].container, "sonarr");
+    assert_eq!(rows[1].state, "exited");
+    assert!(parse_status("bad-row").is_err());
+}
+
+#[test]
+fn remote_errors_distinguish_timeout_ssh_docker_and_container_failures() {
+    assert_eq!(classify_error(Some(124), ""), "ssh_timeout");
+    assert_eq!(classify_error(Some(137), ""), "ssh_timeout");
+    assert_eq!(
+        classify_error(Some(255), "connection refused"),
+        "ssh_failed"
+    );
+    assert_eq!(
+        classify_error(Some(1), "shart Docker is unavailable"),
+        "docker_unavailable"
+    );
+    assert_eq!(classify_error(Some(1), ""), "container_state");
+}

--- a/xtask/src/shart_tests.rs
+++ b/xtask/src/shart_tests.rs
@@ -1,0 +1,40 @@
+use super::{container_command, container_names, status_script};
+
+fn containers() -> Vec<String> {
+    vec!["radarr".into(), "sonarr".into()]
+}
+
+#[test]
+fn lifecycle_commands_are_limited_to_named_containers() {
+    assert_eq!(
+        container_command("start", &containers()),
+        "set -eu; if ! docker info >/dev/null 2>&1; then echo 'shart Docker is unavailable; start the Unraid array before managing the test stack' >&2; exit 1; fi; docker start radarr sonarr"
+    );
+    assert_eq!(
+        container_command("stop", &containers()),
+        "set -eu; if ! docker info >/dev/null 2>&1; then echo 'shart Docker is unavailable; start the Unraid array before managing the test stack' >&2; exit 1; fi; docker stop radarr sonarr"
+    );
+}
+
+#[test]
+fn managed_containers_are_the_guarded_kind_allowlist() {
+    assert_eq!(container_names().len(), 11);
+    assert!(container_names().contains(&"sonarr".to_owned()));
+    assert!(container_names().contains(&"tracearr".to_owned()));
+}
+
+#[test]
+fn strict_status_requires_every_container_to_run() {
+    let script = status_script(&containers(), true);
+    assert!(script.contains("for container in radarr sonarr"));
+    assert!(script.contains("state=missing"));
+    assert!(script.contains(r#"if [ "$state" != "running" ]; then failed=1; fi"#));
+}
+
+#[test]
+fn post_stop_status_allows_stopped_containers_but_not_missing_ones() {
+    let script = status_script(&containers(), false);
+    assert!(!script.contains(r#"if [ "$state" != "running" ]; then failed=1; fi"#));
+    assert!(script.contains("state=missing"));
+    assert!(script.contains("failed=1"));
+}

--- a/xtask/src/shart_tests.rs
+++ b/xtask/src/shart_tests.rs
@@ -1,40 +1,97 @@
-use super::{container_command, container_names, status_script};
+use super::{
+    Command, LifecycleAction, Options, STACK, container_names, help_text, lifecycle_command,
+    seed_plan,
+};
 
-fn containers() -> Vec<String> {
-    vec!["radarr".into(), "sonarr".into()]
+fn args(values: &[&str]) -> Vec<String> {
+    values.iter().map(|value| (*value).to_owned()).collect()
 }
 
 #[test]
-fn lifecycle_commands_are_limited_to_named_containers() {
+fn manifest_pins_every_service_kind_and_container_identity() {
+    let expected = [
+        "sonarr",
+        "radarr",
+        "prowlarr",
+        "tautulli",
+        "overseerr",
+        "bazarr",
+        "tracearr",
+        "sabnzbd",
+        "qbittorrent",
+        "plex",
+        "jellyfin",
+    ];
+    assert_eq!(container_names(), expected);
+    assert_eq!(STACK.len(), expected.len());
+    for (entry, expected) in STACK.iter().zip(expected) {
+        assert_eq!(entry.service, expected);
+        assert_eq!(entry.kind, expected);
+        assert_eq!(entry.container, expected);
+    }
+}
+
+#[test]
+fn parser_covers_help_commands_and_scoped_options() {
+    assert_eq!(Options::parse(&[]).unwrap().command, Command::Help);
     assert_eq!(
-        container_command("start", &containers()),
-        "set -eu; if ! docker info >/dev/null 2>&1; then echo 'shart Docker is unavailable; start the Unraid array before managing the test stack' >&2; exit 1; fi; docker start radarr sonarr"
+        Options::parse(&args(&["start"])).unwrap().command,
+        Command::Start
     );
     assert_eq!(
-        container_command("stop", &containers()),
-        "set -eu; if ! docker info >/dev/null 2>&1; then echo 'shart Docker is unavailable; start the Unraid array before managing the test stack' >&2; exit 1; fi; docker stop radarr sonarr"
+        Options::parse(&args(&["stop"])).unwrap().command,
+        Command::Stop
     );
+    assert!(Options::parse(&args(&["status", "--json"])).unwrap().json);
+    assert!(
+        Options::parse(&args(&["seed", "--dry-run"]))
+            .unwrap()
+            .dry_run
+    );
+    assert!(Options::parse(&args(&["start", "--dry-run"])).is_err());
+    assert!(Options::parse(&args(&["seed", "--json"])).is_err());
+    assert!(Options::parse(&args(&["unknown"])).is_err());
+    assert!(Options::parse(&args(&["help", "extra"])).is_err());
 }
 
 #[test]
-fn managed_containers_are_the_guarded_kind_allowlist() {
-    assert_eq!(container_names().len(), 11);
-    assert!(container_names().contains(&"sonarr".to_owned()));
-    assert!(container_names().contains(&"tracearr".to_owned()));
+fn lifecycle_commands_are_typed_idempotent_and_manifest_limited() {
+    let start = lifecycle_command(LifecycleAction::Start);
+    assert!(start.contains("docker start \"$container\""));
+    assert!(start.contains("state\" != \"running"));
+    assert!(start.contains(&container_names().join(" ")));
+    assert_eq!(start.matches("docker inspect --format").count(), 1);
+    assert!(
+        start.find("missing container").unwrap()
+            < start.find("docker start \"$container\"").unwrap()
+    );
+
+    let stop = lifecycle_command(LifecycleAction::Stop);
+    assert!(stop.contains("docker stop \"$container\""));
+    assert!(stop.contains("state\" != \"exited"));
 }
 
 #[test]
-fn strict_status_requires_every_container_to_run() {
-    let script = status_script(&containers(), true);
-    assert!(script.contains("for container in radarr sonarr"));
-    assert!(script.contains("state=missing"));
-    assert!(script.contains(r#"if [ "$state" != "running" ]; then failed=1; fi"#));
+fn help_and_just_recipes_cover_the_public_command_surface() {
+    let help = help_text();
+    let justfile = include_str!("../../Justfile");
+    for command in ["start", "stop", "status", "seed"] {
+        assert!(help.contains(command));
+        assert!(
+            justfile.contains(&format!("cargo xtask shart {command}")),
+            "missing Just recipe mapping for {command}"
+        );
+    }
 }
 
 #[test]
-fn post_stop_status_allows_stopped_containers_but_not_missing_ones() {
-    let script = status_script(&containers(), false);
-    assert!(!script.contains(r#"if [ "$state" != "running" ]; then failed=1; fi"#));
-    assert!(script.contains("state=missing"));
-    assert!(script.contains("failed=1"));
+fn seed_plan_reports_restored_and_retained_services() {
+    let plan = seed_plan();
+    assert_eq!(plan.containers.len(), 11);
+    assert!(
+        plan.restored_datasets
+            .iter()
+            .any(|item| item.contains("sonarr@configured-v1"))
+    );
+    assert_eq!(plan.retained_services, ["bazarr", "tracearr"]);
 }


### PR DESCRIPTION
## Summary
- add guarded `cargo xtask shart start|stop|status|seed` commands
- add matching `just shart-*` operator recipes
- reuse the existing golden ZFS reset/reseed machinery and wait for all configured services
- document the Unraid array prerequisite without expanding lifecycle scope to host storage

## Validation
- `cargo test -p xtask` (88 passed)
- `cargo test --workspace --all-targets --no-fail-fast` (all Yarr/integration targets passed; one timing-sensitive xtask process test failed under compile load, then passed alone in 0.20s)
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo xtask check-test-siblings`
- `cargo xtask patterns`
- `bash scripts/check-coupled-files.sh`
- `cargo xtask shart status` (expected live prerequisite failure: shart Docker unavailable until its Unraid array is started)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add guarded `cargo xtask shart start|stop|status|seed` commands to manage the dedicated shart test stack with dry-run planning, JSON status, and safer ZFS restores. Uses bounded SSH with timeouts and never starts or stops the Unraid array.

- **New Features**
  - Added `cargo xtask shart <start|stop|status|seed>` that validates `/home/jmagar/.yarr-shart/.env`, operates only on the 11 allowed containers, and provides `just shart-*` aliases.
  - `status` shows state/health and supports `--json`; `seed` prints a dry-run plan (host/env/containers/restored datasets/retained services), then restores `configured-v1`, starts the fleet, and waits under one deadline.
  - Central SSH runner adds timeouts and structured remote errors; readiness polling aggregates failures.

- **Bug Fixes**
  - Preflights Docker availability, container presence, and golden snapshot existence/newest; avoids `zfs rollback -r`; leaves the fleet stopped on failure with clear guidance.
  - Reset/fixture scripts now use the shared SSH runner for consistent timeouts and error reporting.
  - Guard URL validation now parses URLs via `url`, rejects userinfo, and restricts hosts to shart-only.

<sup>Written for commit 1971a6dddf8457cf5f03250ee5998db9fad58392. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/yarr/pull/69?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

