### PR TITLE
ci: move Rust jobs to self-hosted runners with soldr/zccache

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,4 +1,4 @@
 self-hosted-runner:
-  labels: []
+  labels: [unraid]
 
 config-variables: null

--- a/.github/actions/setup-rust-soldr/action.yml
+++ b/.github/actions/setup-rust-soldr/action.yml
@@ -1,0 +1,137 @@
+name: Setup Rust with soldr
+description: Install a Rust toolchain plus soldr (zccache-backed build caching) and print cache evidence.
+inputs:
+  toolchain:
+    description: Rust toolchain to install.
+    required: false
+    default: stable
+  components:
+    description: Comma-separated Rust components to install.
+    required: false
+    default: ""
+  targets:
+    description: Comma-separated Rust targets to install.
+    required: false
+    default: ""
+  enable-shims:
+    description: >-
+      "true" (default) installs setup-soldr's PATH shims (cargo, rustc,
+      rustfmt, clippy-driver, rustdoc) so plain `cargo ...` steps route
+      through soldr; "false" installs soldr without shims so cargo runs
+      bare — used by native Windows jobs.
+    required: false
+    default: "true"
+runs:
+  using: composite
+  steps:
+    - name: Install Linux build prerequisites
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        set -euo pipefail
+        need_install=false
+        command -v cc >/dev/null 2>&1 || need_install=true
+        command -v pkg-config >/dev/null 2>&1 || need_install=true
+        pkg-config --exists openssl 2>/dev/null || need_install=true
+        if [ "$need_install" = false ]; then
+          exit 0
+        fi
+        packages="build-essential pkg-config libssl-dev"
+        if command -v apt-get >/dev/null 2>&1; then
+          if [ "$(id -u)" = "0" ]; then
+            apt-get update
+            # shellcheck disable=SC2086
+            apt-get install -y $packages
+          elif command -v sudo >/dev/null 2>&1; then
+            sudo apt-get update
+            # shellcheck disable=SC2086
+            sudo apt-get install -y $packages
+          else
+            echo "::error::apt-get is available but the runner is not root and sudo is missing."
+            exit 1
+          fi
+          exit 0
+        fi
+        echo "::error::No C compiler found and no supported package manager is available."
+        exit 1
+
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      with:
+        toolchain: ${{ inputs.toolchain }}
+        components: ${{ inputs.components }}
+        targets: ${{ inputs.targets }}
+
+    # setup-soldr installs the soldr front door (zccache compilation caching).
+    # cache-preset: minimal — these are persistent self-hosted runners, so the
+    # zccache store persists on local disk and GitHub-cache save/restore layers
+    # would only add network overhead. Compile caching itself stays ON (do NOT
+    # use `cache: false` — that exports SOLDR_BUILD_CACHE_MODE=off and disables
+    # zccache entirely). With shims: true, plain `cargo ...` trampolines into
+    # `soldr cargo ...`. version pins the binary; bump deliberately.
+    - name: Install soldr
+      uses: zackees/setup-soldr@c4e66a9114a45193605ff4a27404ef74b9b9a6dc # v0
+      with:
+        version: "0.8.19"
+        cache-preset: minimal
+        shims: ${{ inputs.enable-shims }}
+        toolchain: ${{ inputs.toolchain }}
+        # platform-default keeps the system linker (cc/gcc). soldr's own
+        # default (`fast`) injects a clang + mold/rust-lld toolchain the CI
+        # runner image lacks (`error: linker 'clang' not found`). Matches the
+        # pre-migration behavior (system default linker).
+        linker: platform-default
+        # cargo-chef `cook` prebuild panics / restores mismatched deps; every
+        # cache-preset keeps it on, so opt out explicitly. zccache compile
+        # caching (the actual point of soldr) is unaffected.
+        prebuild-deps: none
+        # Persist the zccache compile store across runs, rooted under the
+        # workspace. $GITHUB_WORKSPACE is /_work/<repo>/<repo>, which the runner
+        # farm bind-mounts persistently per runner. setup-soldr derives
+        # SOLDR_CACHE_DIR=<cache-dir>-soldr, so the store is persistent AND
+        # per-runner (no shared mount, no cross-runner exec race).
+        cache-dir: ${{ github.workspace }}/../.soldr
+
+    # GitHub release assets are MUTABLE: the version pin above pins the tag
+    # name, not the bytes. These hashes anchor the exact 0.8.19 binaries
+    # validated 2026-07-21. On a soldr version bump: download the new release
+    # assets, hash the soldr binary, and update both values deliberately.
+    - name: Verify soldr binary integrity
+      shell: bash
+      run: |
+        set -euo pipefail
+        case "$(uname -s)" in
+          Linux) want="8dc4051fe83c498ded65f8aa245d7a5e5576f3998d971e0c6d501464e9f580ac" ;;
+          MINGW*|MSYS*|CYGWIN*) want="46c95c9e9bfa3ffd99da221ab5bdbcab2723ebc0c98f596905f058ddbb495ddd" ;;
+          *) echo "::warning::no pinned soldr hash for $(uname -s); skipping integrity check"; exit 0 ;;
+        esac
+        bin="$(command -v soldr)"
+        got="$(sha256sum "$bin" | cut -d' ' -f1)"
+        if [ "$got" != "$want" ]; then
+          echo "::error::soldr binary hash mismatch at $bin (got $got want $want) — possible swapped release asset; refusing to build"
+          exit 1
+        fi
+        echo "soldr binary integrity OK: $got"
+
+    - name: Show Rust cache configuration
+      shell: bash
+      run: |
+        set -euo pipefail
+        rustc -vV
+        cargo -V
+        soldr --version
+        printf 'SOLDR_CACHE_DIR=%s\n' "${SOLDR_CACHE_DIR:-}"
+        printf 'RUSTUP_TOOLCHAIN=%s\n' "${RUSTUP_TOOLCHAIN:-}"
+        # Guard against the silent no-op failure mode: if shims were requested,
+        # `cargo` on PATH must resolve into setup-soldr's shims dir. A bare
+        # cargo here means every build silently runs uncached.
+        if [ "${{ inputs.enable-shims }}" = "true" ]; then
+          resolved="$(command -v cargo)"
+          case "$resolved" in
+            *shims*) printf 'cargo shim engaged: %s\n' "$resolved" ;;
+            *)
+              echo "::error::soldr cargo shim NOT engaged (cargo=$resolved); builds would run uncached"
+              exit 1
+              ;;
+          esac
+        fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_HTTP_MULTIPLEXING: false
   RUST_BACKTRACE: 1
+  CARGO_INCREMENTAL: "0"
+  SOLDR_CACHE_DIR: ${{ github.workspace }}/../.soldr-cache
 
 jobs:
   # -- actionlint: GitHub Actions workflow syntax and shell checks -------------
@@ -49,13 +51,13 @@ jobs:
   # ── fmt: cargo fmt --check ──────────────────────────────────────────────────
   fmt:
     name: Format
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, unraid]
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Install Rust (stable with rustfmt)
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - name: Install Rust + soldr
+        uses: ./.github/actions/setup-rust-soldr
         with:
           components: rustfmt
 
@@ -65,26 +67,15 @@ jobs:
   # ── clippy: zero warnings ────────────────────────────────────────────────────
   clippy:
     name: Clippy
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, unraid]
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Install Rust (stable with clippy)
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - name: Install Rust + soldr
+        uses: ./.github/actions/setup-rust-soldr
         with:
           components: clippy
-
-      # Cache Cargo registry and build artifacts between runs.
-      - name: Cache Cargo
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ github.repository }}-clippy-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ github.repository }}-clippy-
 
       - name: cargo clippy -- -D warnings
         run: cargo clippy --all-targets -- -D warnings
@@ -92,23 +83,13 @@ jobs:
   # ── docs: rustdoc with zero warnings (broken/ambiguous intra-doc links) ──────
   docs:
     name: Docs
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, unraid]
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Install Rust (stable)
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-
-      - name: Cache Cargo
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ github.repository }}-docs-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ github.repository }}-docs-
+      - name: Install Rust + soldr
+        uses: ./.github/actions/setup-rust-soldr
 
       - name: cargo doc (deny warnings)
         env:
@@ -118,24 +99,13 @@ jobs:
   # ── test: cargo nextest run --profile ci ─────────────────────────────────────
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, unraid]
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Install Rust (stable)
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-
-      # Cache Cargo registry and build artifacts between runs.
-      - name: Cache Cargo
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ github.repository }}-test-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ github.repository }}-test-
+      - name: Install Rust + soldr
+        uses: ./.github/actions/setup-rust-soldr
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@95cc2373c3f00275e315c306e56fef1c7a8854c0 # cargo-nextest
@@ -187,15 +157,15 @@ jobs:
   # ── contracts: generated docs, plugin layout, coupled files ─────────────────
   template:
     name: Repo Contracts
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, unraid]
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
-      - name: Install Rust (stable)
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - name: Install Rust + soldr
+        uses: ./.github/actions/setup-rust-soldr
 
       - name: Check PATTERNS.md contracts
         run: cargo xtask patterns

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -9,28 +9,22 @@ on:
 permissions:
   contents: read
 
+env:
+  CARGO_INCREMENTAL: "0"
+  SOLDR_CACHE_DIR: ${{ github.workspace }}/../.soldr-cache
+
 jobs:
   msrv:
     name: Minimum Supported Rust Version (1.90)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, unraid]
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Install Rust 1.90
-        run: |
-          rustup toolchain install 1.90.0 --profile minimal
-          rustup default 1.90.0
-
-      - name: Cache Cargo
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Install Rust + soldr
+        uses: ./.github/actions/setup-rust-soldr
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ github.repository }}-msrv-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ github.repository }}-msrv-
+          toolchain: "1.90.0"
 
       - name: cargo check (MSRV)
         run: cargo check --all-targets --locked

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,8 @@ concurrency:
 env:
   BINARY_NAME: yarr
   RELEASE_TAG: ${{ github.ref_type == 'tag' && github.ref_name || inputs.tag }}
+  CARGO_INCREMENTAL: "0"
+  SOLDR_CACHE_DIR: ${{ github.workspace }}/../.soldr-cache
 
 jobs:
   verify:
@@ -80,7 +82,7 @@ jobs:
   build:
     name: Build ${{ matrix.target }}
     needs: verify
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, unraid]
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -99,30 +101,26 @@ jobs:
           ref: ${{ env.RELEASE_TAG }}
           persist-credentials: false
 
-      - name: Install Rust target
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - name: Install Rust + soldr
+        uses: ./.github/actions/setup-rust-soldr
         with:
           targets: ${{ matrix.target }}
 
-      - name: Install build dependencies
+      # Base build deps (cc, pkg-config, libssl-dev) are installed by the
+      # composite above when missing; only the mingw cross-linker is extra.
+      # The runner may be root (no sudo binary), so pick the escalation path.
+      - name: Install cross-compilation dependencies
+        if: matrix.target == 'x86_64-pc-windows-gnu'
         shell: bash
         run: |
           set -euo pipefail
-          sudo apt-get update
-          sudo apt-get install -y pkg-config libssl-dev
-          if [[ "${{ matrix.target }}" == "x86_64-pc-windows-gnu" ]]; then
+          if [[ "$(id -u)" == "0" ]]; then
+            apt-get update
+            apt-get install -y gcc-mingw-w64-x86-64
+          else
+            sudo apt-get update
             sudo apt-get install -y gcc-mingw-w64-x86-64
           fi
-
-      - name: Cache Cargo
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ github.repository }}-release-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ github.repository }}-release-${{ matrix.target }}-
 
       - name: Build release binary
         env:


### PR DESCRIPTION
Moves the Rust-compiling CI jobs off GitHub-hosted `ubuntu-latest` onto the self-hosted `[self-hosted, unraid]` runner farm, and replaces the `actions/cache` Cargo caches with soldr/zccache compile caching.

## New composite action

`.github/actions/setup-rust-soldr/action.yml` — copied verbatim from the pattern already deployed across the sibling rmcp repos. It installs the Rust toolchain via `dtolnay/rust-toolchain`, then `zackees/setup-soldr` (pinned v0.8.19, `cache-preset: minimal`, `linker: platform-default`, `prebuild-deps: none`), verifies the soldr binary hash, and hard-fails if the cargo shim is not engaged (so a build can never silently run uncached).

## Jobs moved to `[self-hosted, unraid]` + soldr

| Workflow | Job | Notes |
|---|---|---|
| `ci.yml` | `fmt` | `components: rustfmt` preserved |
| `ci.yml` | `clippy` | `components: clippy` preserved; Cargo cache removed |
| `ci.yml` | `docs` | Cargo cache removed |
| `ci.yml` | `test` | Cargo cache removed; already used `taiki-e/install-action` for nextest |
| `ci.yml` | `template` | Repo-contract job, runs `cargo xtask` |
| `msrv.yml` | `msrv` | Raw `rustup toolchain install` replaced with the composite at `toolchain: "1.90.0"` — bare `rustup` is not on the self-hosted runner's PATH |
| `release.yml` | `build` (matrix) | Both targets; mingw cross-linker step kept |

Each edited workflow gains top-level `CARGO_INCREMENTAL: "0"` and `SOLDR_CACHE_DIR: ${{ github.workspace }}/../.soldr-cache`.

## Deliberately left on `ubuntu-latest`

- **`ci.yml`**: `actionlint`, `npm`, `toml`, `gitleaks` — non-Rust; `gitleaks` also needs Docker.
- **`ci.yml` `audit`** and **`scheduled.yml` `advisories`** — no Rust toolchain step and no Cargo cache; they only invoke the Docker-based `cargo-deny-action`, so there is nothing for soldr to accelerate.
- **`codeql.yml`** — CodeQL on this runner farm has broken in a sibling repo (`npm: command not found` from the CodeQL bundle's own tooling). Left hosted deliberately rather than risking the security scan.
- **`release.yml`**: `verify`, `stage-release`, `npm`, `finalize`, `failure-summary` — release plumbing needing hosted infra (`npm publish --provenance` requires the hosted OIDC issuer).
- All other workflows (`check-no-mcp-drift`, `dependabot-auto-merge`, `docker-publish`, `openwiki-update`, `release-please`, `sync-marketplace-no-mcp`) untouched.

## Other changes

- `.github/actionlint.yaml`: `self-hosted-runner.labels` was `[]`; added `unraid`. Without this the required `actionlint` check fails the build on the unknown label.
- `release.yml` build deps: base deps (`cc`/`pkg-config`/`libssl-dev`) are now handled by the composite when missing, so the step is narrowed to the mingw cross-linker and made root-tolerant (`sudo` may be absent when the runner executes as root).

`actionlint` passes clean locally (0 errors across all 11 workflows).