### PR TITLE
fix(unraid): prevent test service process leaks

### DIFF
--- a/unraid-plugin/tests/lifecycle-contract.sh
+++ b/unraid-plugin/tests/lifecycle-contract.sh
@@ -8,8 +8,13 @@ classic_uninstall="$repo_root/unraid-plugin/source/usr/local/emhttp/plugins/yarr
 started="$repo_root/unraid-plugin/source/usr/local/emhttp/plugins/yarr/event/started"
 stopping="$repo_root/unraid-plugin/source/usr/local/emhttp/plugins/yarr/event/stopping_svcs"
 unmounting="$repo_root/unraid-plugin/source/usr/local/emhttp/plugins/yarr/event/unmounting_disks"
+cleanup_helper="$repo_root/unraid-plugin/tests/test-service-cleanup.sh"
 tmp_dir=$(mktemp -d)
-trap 'rm -rf "$tmp_dir"' EXIT
+test_root="$tmp_dir/root"
+# shellcheck source-path=SCRIPTDIR
+# shellcheck source=test-service-cleanup.sh
+source "$cleanup_helper"
+yarr_test_install_cleanup "$tmp_dir" "$test_root" "$rc"
 
 fail() {
     printf 'lifecycle contract: %s\n' "$1" >&2
@@ -29,7 +34,6 @@ expect_eq() {
     [[ "$actual" == "$expected" ]] || fail "$label: expected $expected, got $actual"
 }
 
-test_root="$tmp_dir/root"
 YARR_STRONG_TOKEN=$(printf 'a%.0s' {1..64})
 YARR_TEST_PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')
 export YARR_TEST_PORT
@@ -629,5 +633,7 @@ yarr_with_lock yarr_restart_locked
 expect_eq $'stop\ncontender-blocked\nstart' "$(cat "$test_root/restart-lock-trace")" "restart lock trace"
 "$rc" restart
 "$rc" reload
+"$rc" stop
+yarr_test_assert_no_owned_processes "$test_root" "$rc"
 
 printf 'lifecycle contract: PASS\n'

--- a/unraid-plugin/tests/run.sh
+++ b/unraid-plugin/tests/run.sh
@@ -34,6 +34,7 @@ expect_rejection_contains() {
 }
 
 bash "$test_dir/release-contract.sh"
+bash "$test_dir/test-service-cleanup-contract.sh"
 bash "$test_dir/lifecycle-contract.sh"
 bash "$test_dir/update-contract.sh"
 bash "$test_dir/classic-contract.sh"

--- a/unraid-plugin/tests/test-service-cleanup-contract.sh
+++ b/unraid-plugin/tests/test-service-cleanup-contract.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+helper="$repo_root/unraid-plugin/tests/test-service-cleanup.sh"
+tmp_dir=$(mktemp -d)
+test_root="$tmp_dir/root"
+fake_rc="$tmp_dir/rc.yarr"
+pids_file=$(mktemp)
+declare -a child_pids=()
+
+parent_cleanup() {
+    local pid
+    for pid in "${child_pids[@]:-}"; do
+        kill -KILL "$pid" 2>/dev/null || true
+    done
+    rm -rf -- "$tmp_dir"
+    rm -f -- "$pids_file"
+}
+trap parent_cleanup EXIT
+
+cat > "$fake_rc" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+chmod 755 "$fake_rc"
+mkdir -p "$test_root/bin" "$test_root/run" "$test_root/plugin"
+
+set +e
+(
+    export YARR_PLUGIN_ROOT="$test_root/plugin"
+    export YARR_RUN_ROOT="$test_root/run"
+    # shellcheck source-path=SCRIPTDIR
+    # shellcheck source=test-service-cleanup.sh
+    source "$helper"
+    yarr_test_install_cleanup "$tmp_dir" "$test_root" "$fake_rc"
+
+    python_bin=/usr/bin/python3
+    # $1 and $2 intentionally expand inside the child shell.
+    # shellcheck disable=SC2016
+    bash -c 'exec -a "$1" "$2" -c "import time; time.sleep(300)" serve mcp' \
+        _ "$test_root/bin/yarr" "$python_bin" &
+    service_pid=$!
+    # $1 intentionally expands inside the child shell.
+    # shellcheck disable=SC2016
+    env YARR_RUN_ROOT="$YARR_RUN_ROOT" \
+        bash -c 'exec -a "$1" /usr/bin/sleep 300' _ "$fake_rc" &
+    controller_pid=$!
+    # This process is deliberately Yarr-shaped but carries no test-root path
+    # or YARR_* root. Teardown must leave it alone.
+    # shellcheck disable=SC2016
+    env -u YARR_PLUGIN_ROOT -u YARR_RUN_ROOT \
+        bash -c 'exec -a yarr "$1" -c "import time; time.sleep(300)" serve mcp' \
+        _ "$python_bin" &
+    unrelated_pid=$!
+    printf '%s\n%s\n%s\n' "$service_pid" "$controller_pid" "$unrelated_pid" > "$pids_file"
+    sleep 0.1
+    kill -0 "$service_pid" "$controller_pid" "$unrelated_pid"
+    mapfile -t discovered < <(yarr_test_owned_pids "$test_root" "$fake_rc")
+    ((${#discovered[@]} == 2)) || {
+        printf 'test cleanup contract: expected 2 owned processes, found %s\n' \
+            "${#discovered[@]}" >&2
+        exit 1
+    }
+    kill -TERM "$BASHPID"
+)
+status=$?
+set -e
+
+[[ "$status" == 143 ]] || {
+    printf 'test cleanup contract: expected signal exit 143, got %s\n' "$status" >&2
+    exit 1
+}
+mapfile -t child_pids < "$pids_file"
+for pid in "${child_pids[@]:0:2}"; do
+    if kill -0 "$pid" 2>/dev/null; then
+        printf 'test cleanup contract: leaked test-owned PID %s\n' "$pid" >&2
+        exit 1
+    fi
+done
+unrelated_pid=${child_pids[2]}
+kill -0 "$unrelated_pid" 2>/dev/null || {
+    printf 'test cleanup contract: teardown killed unrelated PID %s\n' \
+        "$unrelated_pid" >&2
+    exit 1
+}
+kill -TERM "$unrelated_pid" 2>/dev/null || true
+wait "$unrelated_pid" 2>/dev/null || true
+child_pids=()
+
+printf 'test cleanup contract: PASS\n'

--- a/unraid-plugin/tests/test-service-cleanup.sh
+++ b/unraid-plugin/tests/test-service-cleanup.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+
+# Shared teardown for tests that launch the real rc.yarr service wrapper.
+# Fallback signals are scoped to this test's temporary root, so production
+# Yarr processes cannot match.
+
+yarr_test_pid_running() {
+    local pid=$1 remainder state
+    [[ -r "/proc/${pid}/stat" ]] || return 1
+    remainder=$(<"/proc/${pid}/stat")
+    remainder=${remainder##*) }
+    state=${remainder%% *}
+    [[ "$state" != Z ]]
+}
+
+yarr_test_proc_uses_root() {
+    local proc=$1 root=$2 entry exe env_fd owner
+    owner=$(stat -c '%u' "$proc" 2>/dev/null || true)
+    [[ "$owner" == "$EUID" ]] || return 1
+    exe=$(readlink "${proc}/exe" 2>/dev/null || true)
+    exe=${exe%' (deleted)'}
+    [[ "$exe" == "$root"/* ]] && return 0
+    exec {env_fd}<"${proc}/environ" 2>/dev/null || return 1
+    while IFS= read -r -d '' entry <&"$env_fd"; do
+        case "$entry" in
+            YARR_PLUGIN_ROOT="$root"|YARR_PLUGIN_ROOT="$root"/*|\
+            YARR_APPDATA_ROOT="$root"|YARR_APPDATA_ROOT="$root"/*|\
+            YARR_APPDATA="$root"|YARR_APPDATA="$root"/*|\
+            YARR_RUN_ROOT="$root"|YARR_RUN_ROOT="$root"/*)
+                exec {env_fd}<&-
+                return 0
+                ;;
+        esac
+    done
+    exec {env_fd}<&-
+    return 1
+}
+
+yarr_test_proc_is_owned() {
+    local proc=$1 root=$2 rc_path=$3 arg previous='' candidate=false
+    [[ -r "${proc}/cmdline" ]] || return 1
+    while IFS= read -r -d '' arg; do
+        if [[ "$previous" == serve && "$arg" == mcp ]]; then
+            candidate=true
+            break
+        fi
+        if [[ "$arg" == "$rc_path" || "$arg" == */yarr-update.sh ]]; then
+            candidate=true
+            break
+        fi
+        previous=$arg
+    done < "${proc}/cmdline"
+    [[ "$candidate" == true ]] || return 1
+    yarr_test_proc_uses_root "$proc" "$root"
+}
+
+yarr_test_owned_pids() {
+    local root=$1 rc_path=$2 proc pid
+    for proc in /proc/[0-9]*; do
+        pid=${proc##*/}
+        [[ "$pid" == "$$" || "$pid" == "${BASHPID:-$$}" ]] && continue
+        yarr_test_pid_running "$pid" || continue
+        yarr_test_proc_is_owned "$proc" "$root" "$rc_path" && printf '%s\n' "$pid"
+    done
+}
+
+yarr_test_normal_stop() {
+    local root=$1 rc_path=$2
+    [[ -x "$rc_path" ]] || return 0
+    [[ ${YARR_PLUGIN_ROOT:-} == "$root"/* && ${YARR_RUN_ROOT:-} == "$root"/* ]] || return 0
+    YARR_LOCK_WAIT_SECONDS=0 \
+    YARR_STOP_ATTEMPTS=2 \
+    YARR_STOP_INTERVAL=0.02 \
+        "$rc_path" stop >/dev/null 2>&1 || true
+}
+
+yarr_test_terminate_owned_processes() {
+    local root=$1 rc_path=$2 attempt pid
+    local -a pids=() remaining=()
+    mapfile -t pids < <(yarr_test_owned_pids "$root" "$rc_path")
+    ((${#pids[@]} == 0)) && return 0
+
+    for pid in "${pids[@]}"; do kill -TERM "$pid" 2>/dev/null || true; done
+    for ((attempt = 0; attempt < 100; attempt++)); do
+        remaining=()
+        for pid in "${pids[@]}"; do
+            yarr_test_pid_running "$pid" && remaining+=("$pid")
+        done
+        ((${#remaining[@]} == 0)) && break
+        sleep 0.02
+    done
+    for pid in "${remaining[@]}"; do kill -KILL "$pid" 2>/dev/null || true; done
+    for pid in "${pids[@]}"; do wait "$pid" 2>/dev/null || true; done
+}
+
+yarr_test_assert_no_owned_processes() {
+    local root=$1 rc_path=$2
+    local -a pids=()
+    mapfile -t pids < <(yarr_test_owned_pids "$root" "$rc_path")
+    if ((${#pids[@]} > 0)); then
+        printf 'test cleanup leaked Yarr process(es): %s\n' "${pids[*]}" >&2
+        return 1
+    fi
+}
+
+yarr_test_cleanup_exit() {
+    local status=$?
+    trap - EXIT HUP INT TERM
+    set +e
+    yarr_test_normal_stop "$YARR_TEST_CLEANUP_ROOT" "$YARR_TEST_CLEANUP_RC"
+    yarr_test_terminate_owned_processes "$YARR_TEST_CLEANUP_ROOT" "$YARR_TEST_CLEANUP_RC"
+    if ! yarr_test_assert_no_owned_processes "$YARR_TEST_CLEANUP_ROOT" "$YARR_TEST_CLEANUP_RC"; then
+        [[ "$status" == 0 ]] && status=1
+    fi
+    rm -rf -- "$YARR_TEST_CLEANUP_TMP_DIR"
+    exit "$status"
+}
+
+yarr_test_install_cleanup() {
+    YARR_TEST_CLEANUP_TMP_DIR=$1
+    YARR_TEST_CLEANUP_ROOT=$2
+    YARR_TEST_CLEANUP_RC=$3
+    trap 'yarr_test_cleanup_exit' EXIT
+    trap 'exit 129' HUP
+    trap 'exit 130' INT
+    trap 'exit 143' TERM
+}

--- a/unraid-plugin/tests/update-contract.sh
+++ b/unraid-plugin/tests/update-contract.sh
@@ -8,8 +8,13 @@ rc="$repo_root/unraid-plugin/source/etc/rc.d/rc.yarr"
 fixture="$repo_root/unraid-plugin/tests/fixtures/releases.json"
 started="$repo_root/unraid-plugin/source/usr/local/emhttp/plugins/yarr/event/started"
 stopping="$repo_root/unraid-plugin/source/usr/local/emhttp/plugins/yarr/event/stopping_svcs"
+cleanup_helper="$repo_root/unraid-plugin/tests/test-service-cleanup.sh"
 tmp_dir=$(mktemp -d)
-trap 'rm -rf "$tmp_dir"' EXIT
+test_root="$tmp_dir/root"
+# shellcheck source-path=SCRIPTDIR
+# shellcheck source=test-service-cleanup.sh
+source "$cleanup_helper"
+yarr_test_install_cleanup "$tmp_dir" "$test_root" "$rc"
 
 fail() {
     printf 'update contract: %s\n' "$1" >&2
@@ -39,7 +44,6 @@ if grep -Fq 'local releases=$1 version=$2 tag=' "$release_helper"; then
     fail 'release lookup depends on Bash dynamic scoping'
 fi
 
-test_root="$tmp_dir/root"
 YARR_TEST_PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')
 export YARR_TEST_PORT
 export YARR_PLUGIN_ROOT="$test_root/plugin"
@@ -1269,5 +1273,6 @@ unset YARR_TEST_FAIL_COMMAND YARR_TEST_FAIL_AT YARR_TEST_FAIL_COMMAND_2 \
     YARR_TEST_FAIL_AT_2 YARR_TEST_CORRUPT_INSTALL_AT \
     YARR_TEST_FAIL_RECOVERY_RM YARR_TEST_SIGNAL_COMMAND YARR_TEST_SIGNAL_AT
 "$rc" stop
+yarr_test_assert_no_owned_processes "$test_root" "$rc"
 
 printf 'update contract: PASS\n'


### PR DESCRIPTION
## Summary

- install signal-safe service teardown in lifecycle and updater contracts
- scope fallback termination by UID, exact Yarr-shaped argv, and the test temporary root
- explicitly stop services and fail contracts when any owned listener survives
- add a regression contract that interrupts a test, verifies owned children die, and proves an unrelated Yarr-shaped process is preserved

## Validation

- removed 33 orphaned test servers and 32 orphaned controller/logger shells from DOOKIE
- preserved production Yarr PID 4523
- cleanup interruption contract passed
- lifecycle contract passed with no leaked process
- updater fault-injection contract passed with no leaked process
- full Unraid aggregate contract passed
- exact CI ShellCheck gate passed