### PR TITLE
fix(ci): use the mingw cross-compiler for the Windows release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,6 +125,15 @@ jobs:
       - name: Build release binary
         env:
           CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER: x86_64-w64-mingw32-gcc
+          # soldr exports a global CC (`zccache-soldr /usr/bin/cc`) for compile
+          # caching. In cc-rs precedence a bare CC outranks the target-specific
+          # default, so C dependencies such as aws-lc-sys would be built for the
+          # Windows target using the host Linux compiler. Naming the cross
+          # toolchain per-target restores correct cross-compilation, because
+          # cc-rs reads CC_<target> ahead of CC.
+          CC_x86_64_pc_windows_gnu: x86_64-w64-mingw32-gcc
+          CXX_x86_64_pc_windows_gnu: x86_64-w64-mingw32-g++
+          AR_x86_64_pc_windows_gnu: x86_64-w64-mingw32-ar
         run: cargo build --release --locked --target ${{ matrix.target }}
 
       - name: Prepare checksummed archive


### PR DESCRIPTION
## Summary

The `v2.2.0` release failed building `x86_64-pc-windows-gnu`. Root cause is a latent regression from the soldr migration in #76, not a code defect — it only surfaces at release time because regular CI never cross-builds Windows.

soldr exports a **global `CC`** for compile caching. `cc-rs` resolves a bare `CC` ahead of its target-specific default, so C dependencies (`aws-lc-sys`) were compiled for the Windows target with the host Linux compiler:

```
CC_x86_64-pc-windows-gnu = None
CC                       = Some(.../zccache-soldr /usr/bin/cc)
```

```
aws-lc/crypto/asn1/internal.h:552:3: error: unknown type name 'pthread_rwlock_t'
error occurred in cc-rs: command did not execute successfully
```

At `v2.1.0` this job ran on `ubuntu-latest` with no soldr, `CC` was unset, and `cc-rs` auto-selected `x86_64-w64-mingw32-gcc`.

## Fix

Name the cross toolchain per-target so it outranks the global `CC` (`cc-rs` reads `CC_<target>` before `CC`). mingw is already installed by the existing step; only the env wiring was missing.

## Verification

Reproduced and fixed locally against the same toolchain:

- With a global `CC` and no target override → identical `pthread_rwlock_t` failure.
- With `CC_/CXX_/AR_x86_64_pc_windows_gnu` set → `Finished \`release\` profile`, produced an 18 MB `target/x86_64-pc-windows-gnu/release/yarr.exe`.

Also passing: `actionlint`, coupled-file check, dist contract, doc links.

## Follow-up

Unblocks the `v2.2.0` release, which is currently tagged with assets unstaged and npm unpublished. Re-run `release.yml` for `v2.2.0` once this lands.