### PR TITLE
ci: gate version sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,12 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+      # Fails when Cargo.toml, package.json, server.json and friends disagree
+      # on the version. Previously reachable only by hand, which is how a
+      # sibling repo sat seven releases out of sync unnoticed.
+      - name: Check version sync
+        run: bash scripts/check-version-sync.sh
+
       - name: Install Rust + soldr
         uses: ./.github/actions/setup-rust-soldr
         with:


### PR DESCRIPTION
Runs `scripts/check-version-sync.sh` in CI (added to the `fmt` job, right after checkout).

The script already existed here and works — it was just never wired into CI, reachable only by hand. That gap is how rgotify sat with `server.json` at 0.1.3 against `Cargo.toml` 0.1.2, and synapse sat **seven releases** out of sync, both while their guards reported nothing.

Part of a fleet-wide rollout: 16 repos use release-please, only rapprise gated this in CI.