### PR TITLE
chore: correct the labby-auth vendoring comment in deny.toml

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -79,6 +79,6 @@ unknown-registry = "deny"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 allow-git = [
-  # lab-auth is vendored from the LABBY mono-repo at a pinned rev
+  # labby-auth is vendored from the labby mono-repo at a pinned rev
   "https://github.com/dinglebear-ai/labby.git",
 ]


### PR DESCRIPTION
Leftover from #83. That PR's functional change (the `dinglebear-ai/labby` git URL) had already landed via #79, so the squash merge resolved the conflict in main's favour and dropped the comment reword — the one thing #83 still contributed.

The crate is `package = "labby-auth"` and the repo is `dinglebear-ai/labby`, so the comment now matches both.

Comment-only; `cargo deny check` passes (advisories, bans, licenses, sources all ok).