### PR TITLE
fix(release): verify staged draft assets so the npm publish can proceed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,6 +162,8 @@ jobs:
     timeout-minutes: 20
     permissions:
       contents: write
+    outputs:
+      staged_assets: ${{ steps.staged-assets.outputs.names }}
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -214,6 +216,20 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release upload "$RELEASE_TAG" artifacts/* --clobber --repo "$GITHUB_REPOSITORY"
 
+      # A draft release is invisible to the npm job (that job holds only
+      # contents:read, and drafts require push access), so hand the verified
+      # asset names down instead of widening the publishing job's permissions.
+      - name: Record staged asset names
+        id: staged-assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          names="$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" \
+            --json assets --jq '[.assets[].name] | join(",")')"
+          [[ -n "$names" ]] || { echo "::error::staged release has no assets"; exit 1; }
+          echo "names=$names" >> "$GITHUB_OUTPUT"
+
   npm:
     name: Publish npm launcher
     needs: [verify, stage-release]
@@ -257,9 +273,13 @@ jobs:
 
       - name: Publish exact npm version
         if: steps.published.outputs.exists != 'true'
-        run: npm publish --provenance --access public ./packages/yarr-mcp
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # prepublishOnly verifies the release assets exist for this tag. They
+          # are still on the draft release at this point, so the public download
+          # URLs 404; consume the names the staging job already verified.
+          YARR_RELEASE_STAGED_ASSETS: ${{ needs.stage-release.outputs.staged_assets }}
+        run: npm publish --provenance --access public ./packages/yarr-mcp
 
   finalize:
     name: Publish verified GitHub Release

--- a/packages/yarr-mcp/scripts/check-package.js
+++ b/packages/yarr-mcp/scripts/check-package.js
@@ -388,6 +388,88 @@ function requestText(url, redirects = 0) {
   });
 }
 
+// The release workflow stages assets on a DRAFT release and only publishes it
+// after npm succeeds, so during `npm publish` the public
+// releases/download/<tag>/... URLs still 404. When the workflow supplies a token
+// we verify the staged assets through the API instead, which can see drafts, and
+// otherwise fall back to the stricter public-URL check below.
+function stagedAssetNamesFromEnv() {
+  const raw = process.env.YARR_RELEASE_STAGED_ASSETS;
+  if (!raw) {
+    return null;
+  }
+  const names = raw
+    .split(",")
+    .map((name) => name.trim())
+    .filter(Boolean);
+  return names.length > 0 ? new Set(names) : null;
+}
+
+function releaseApiContext() {
+  const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN;
+  const repository = process.env.GITHUB_REPOSITORY;
+  if (!token || !repository) {
+    return null;
+  }
+  const tag = process.env.RELEASE_TAG || `v${packageJson.version}`;
+  return { token, repository, tag };
+}
+
+function requestJson(url, token) {
+  return new Promise((resolve, reject) => {
+    const request = https.request(
+      url,
+      {
+        method: "GET",
+        headers: {
+          accept: "application/vnd.github+json",
+          authorization: `Bearer ${token}`,
+          "user-agent": "yarr-mcp-package-check",
+          "x-github-api-version": "2022-11-28",
+        },
+      },
+      (response) => {
+        if (response.statusCode < 200 || response.statusCode >= 300) {
+          response.resume();
+          reject(new Error(`${url} returned ${response.statusCode}`));
+          return;
+        }
+        let body = "";
+        response.setEncoding("utf8");
+        response.on("data", (chunk) => {
+          body += chunk;
+        });
+        response.on("end", () => {
+          try {
+            resolve(JSON.parse(body));
+          } catch (error) {
+            reject(error);
+          }
+        });
+      },
+    );
+    request.setTimeout(15000, () => {
+      request.destroy(new Error(`timeout checking ${url}`));
+    });
+    request.on("error", reject);
+    request.end();
+  });
+}
+
+// A draft release is NOT retrievable through /releases/tags/<tag> — that endpoint
+// 404s until the release is published — so discover it by listing releases and
+// matching tag_name, which is the same reason release.yml uses `gh release view`
+// rather than the public tag API.
+async function stagedAssetNames(context) {
+  const url = `https://api.github.com/repos/${context.repository}/releases?per_page=100`;
+  const releases = await requestJson(url, context.token);
+  const release = (Array.isArray(releases) ? releases : []).find((entry) => entry.tag_name === context.tag);
+  if (!release) {
+    throw new Error(`no release found for ${context.tag}`);
+  }
+  return new Set((release.assets || []).map((asset) => asset.name));
+}
+
 function checksumManifestUrl(assetUrl) {
   return assetUrl.replace(/\/[^/]+$/, "/SHA256SUMS");
 }
@@ -426,7 +508,35 @@ async function checkReleaseAssets() {
     return;
   }
 
+  // Preferred: the staging job already listed the draft's assets with a token
+  // that has push access, and hands the names down as a job output. Falling back
+  // to the API keeps manual/local `--release` runs working.
+  let staged = stagedAssetNamesFromEnv();
+  const apiContext = staged ? null : releaseApiContext();
+  if (apiContext) {
+    try {
+      staged = await stagedAssetNames(apiContext);
+    } catch (error) {
+      // Fall through to the public-URL check, which is stricter, rather than
+      // treating an API problem as a passing verification.
+      staged = null;
+    }
+  }
+  const stagedSource = apiContext ? apiContext.tag : "the staged release";
+
   for (const { osName, arch, target } of supportedTargets(platform)) {
+    if (staged) {
+      assert(
+        staged.has(target.asset),
+        `release asset missing for ${osName}/${arch}: ${target.asset} is not attached to ${stagedSource}`,
+      );
+      assert(
+        staged.has(`${target.asset}.sha256`) || staged.has("SHA256SUMS"),
+        `release checksum missing for ${osName}/${arch}: ${target.asset}`,
+      );
+      continue;
+    }
+
     const url = platform.downloadUrl(target);
     const status = await requestHead(url);
     assert(status >= 200 && status < 300, `release asset missing for ${osName}/${arch}: ${url} returned ${status}`);


### PR DESCRIPTION
Resolves the deadlock behind #80 — the reason `yarr-mcp` is still **1.1.1** on npm while the repo, plugin manifests, and docs all pin **2.2.0**.

## The deadlock

`release.yml` stages assets on a **draft** release and only publishes it *after* npm succeeds. But `prepublishOnly` (`check-package.js --release`) verified assets through the **public** download URLs, which 404 while the release is a draft:

```
package-check: .../releases/download/v2.2.0/SHA256SUMS returned 404
```

npm can't publish until the release is public; the release can't go public until npm publishes. Nothing has published since v1.1.0.

## Fix

The staging job already lists the draft's assets with a token that has push access, so it exports those verified names as a job output and the npm job passes them in via `YARR_RELEASE_STAGED_ASSETS`.

This deliberately avoids giving the **publishing** job `contents: write`, which is what reading a draft would otherwise require.

`check-package.js` now resolves the asset list in three steps, each failing closed:

1. the handed-down staged names,
2. the API — **listing** releases and matching `tag_name` (the by-tag endpoint 404s for drafts, the same reason #79 moved the workflow to `gh release view`; the dist contract forbids that endpoint),
3. the original public-URL check.

## Verification

Against the **live `v2.2.0` draft**:

| Case | Result |
|---|---|
| Real staged names via env | **passes** |
| Env list missing an asset | fails — `yarr-windows-x86_64.tar.gz is not attached` |
| API path with valid token | **passes** |
| Unknown tag, with token | fails |
| Invalid token | falls back to public check, fails |
| No token | unchanged public-URL behaviour |
| Non-release mode (normal CI) | passes |

Also green: `actionlint`, dist contract, `npm run check`, 18 npm tests, doc links, coupled files, ascii.

Once this lands, re-dispatch `release.yml` for the existing `v2.2.0` tag — no new tag, per `docs/runbooks/partial-release.md`.
