### PR TITLE
build: align toolchain, MSRV, edition, and rmcp fleet-wide

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -83,7 +83,7 @@ jobs:
           required=(
             Actionlint Format Clippy Docs Test "NPM Package" "TOML Format"
             "Repo Contracts" "Cargo Deny" "Secret Scan"
-            "Minimum Supported Rust Version (1.90)"
+            "Minimum Supported Rust Version"
           )
           for attempt in {1..20}; do
             checks="$(gh api \

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   msrv:
-    name: Minimum Supported Rust Version (1.90)
+    name: Minimum Supported Rust Version
     runs-on: [self-hosted, unraid]
     timeout-minutes: 20
     steps:
@@ -24,7 +24,7 @@ jobs:
       - name: Install Rust + soldr
         uses: ./.github/actions/setup-rust-soldr
         with:
-          toolchain: "1.90.0"
+          toolchain: "1.97.1"
 
       - name: cargo check (MSRV)
         run: cargo check --all-targets --locked

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+* **deps:** pin `rmcp` to an exact `=3.0.0-beta.2` (was a caret `"2.1.0"` that had already drifted to `2.2.0` in the lockfile). `ServerHandler::call_tool`/`read_resource`/`get_prompt` now return the `CallToolResponse`/`ReadResourceResponse`/`GetPromptResponse` wrappers, and `StreamableHttpServerConfig::with_stateful_mode` is now `with_legacy_session_mode`; both are behaviour-preserving. The elicitation API is unchanged, so destructive-delete gating stays fail-closed
+
 ### Removed
 
 * **plugins:** drop Claude Code lifecycle hooks from all 12 plugins — `hooks/hooks.json` and every manifest `hooks` key are gone. The credential bridge (`scripts/setup.sh`, `scripts/plugin-setup.sh`, `yarr setup plugin-hook`) is now run on demand; contract checks assert hooks stay absent

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,8 +8,8 @@ Rust MCP and CLI server for a media automation fleet. It wraps **11 service kind
 |------|-------|
 | Repo | `git@github.com:dinglebear-ai/yarr.git`, default branch `main` |
 | Cargo workspace | 2 members — `.` (bin+lib `yarr`) and `xtask` |
-| Edition / MSRV | 2024 / Rust 1.90 |
-| MCP crate | `rmcp = "2.1.0"` (`server`, `macros`, `transport-streamable-http-server`, `transport-io`, `schemars`, `elicitation`) |
+| Edition / MSRV | 2024 / Rust 1.97.1 |
+| MCP crate | `rmcp = "=3.0.0-beta.2"` — exact pin (`server`, `macros`, `transport-streamable-http-server`, `transport-io`, `schemars`, `elicitation`) |
 | Service port | `40070` (`YARR_MCP_PORT`) |
 | npm launcher | `yarr-mcp@<Cargo version>`, pinned — never `latest` |
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2414,11 +2414,12 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "2.2.0"
+version = "3.0.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14db48ee17a9ba61810ab1a9c1beb7d06d8136ae39ac25a1137f10d357af01af"
+checksum = "3875f7c471c2d709062bc2165d8dc883b021b44255bd00bb4d8025f5108178c8"
 dependencies = [
  "async-trait",
+ "base64",
  "bytes",
  "chrono",
  "futures",
@@ -2446,9 +2447,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "2.2.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "783d787bf21813b285f13019adc49e11af501c658890c1e519f31f937c68b7e3"
+checksum = "e1aa4b9345795260a43fc23d6d05e096407c8b953903f673af7c4404b49fb2d6"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2955,9 +2956,9 @@ dependencies = [
 
 [[package]]
 name = "sse-stream"
-version = "0.2.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3962b63f038885f15bce2c6e02c0e7925c072f1ac86bb60fd44c5c6b762fb72"
+checksum = "c123f296ade4ec4b8b0f6162116e6629f5146922ca5ab40ca9d3c2e73ab4761e"
 dependencies = [
  "bytes",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,19 @@
 members = [".", "xtask"]
 resolver = "2"
 
+[workspace.package]
+
+# Fleet edition (ADR-0002). Members inherit via edition.workspace = true.
+edition = "2024"
+# Fleet MSRV — the floor this repo supports. A separate promise from
+# rust-toolchain.toml's channel, which is what we BUILD with. Both are
+# 1.97.1 as of 2026-07-29 (ADR-0001 toolchain, ADR-0024 MSRV).
+rust-version = "1.97.1"
 [package]
 name = "yarr"
 version = "2.2.1"
-edition = "2024"
-rust-version = "1.90"
+edition.workspace = true
+rust-version.workspace = true
 categories = ["command-line-utilities", "development-tools"]
 keywords = ["mcp", "media", "sonarr", "radarr", "plex"]
 repository = "https://github.com/dinglebear-ai/yarr"
@@ -44,7 +52,7 @@ tokio = { version = "1", features = [
 
 # HTTP / MCP transport
 axum = "0.8"
-rmcp = { version = "2.1.0", default-features = false, features = [
+rmcp = { version = "=3.0.0-beta.2", default-features = false, features = [
   "server",
   "macros",
   "transport-streamable-http-server",
@@ -109,7 +117,7 @@ test-support = []
 yarr = { path = ".", features = ["test-support"] }
 tempfile = "3"
 tower = { version = "0.5", features = ["util"] }
-rmcp = { version = "2.1.0", default-features = false, features = [
+rmcp = { version = "=3.0.0-beta.2", default-features = false, features = [
   "client",
   "transport-child-process",
 ] }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,20 @@
+# Toolchain used to BUILD this repo, locally and in CI. Pinned fleet-wide to
+# Rust 1.97.1 by ADR-0001: 1.97.1 is a point release that fixes an LLVM
+# miscompilation present since at least 1.87, so every toolchain below it —
+# including every version this fleet previously pinned — is affected.
+#
+# This is deliberately NOT the same promise as Cargo.toml's `rust-version`.
+# This file says "build with exactly this"; `rust-version` says "refuse to
+# build on anything older". As of ADR-0024 both are 1.97.1, but they remain
+# separate keys and can diverge again.
+#
+# `components` is self-declared because dtolnay/rust-toolchain only installs
+# components for the toolchain IT pins, not for a rust-toolchain.toml override.
+#
+# NOTE: a `.mise.toml` in this directory that sets `rust` exports
+# RUSTUP_TOOLCHAIN and OVERRIDES this file. Check `mise env | grep RUSTUP`
+# before trusting the channel below.
+[toolchain]
+channel = "1.97.1"
+components = ["rustfmt", "clippy"]
+profile = "minimal"

--- a/src/mcp/rmcp_server.rs
+++ b/src/mcp/rmcp_server.rs
@@ -14,10 +14,11 @@ use lab_auth::AuthContext;
 use rmcp::{
     ErrorData, RoleServer, ServerHandler,
     model::{
-        CallToolRequestParams, CallToolResult, ContentBlock, GetPromptRequestParams,
-        GetPromptResult, Implementation, ListPromptsResult, ListResourcesResult, ListToolsResult,
-        PaginatedRequestParams, ReadResourceRequestParams, ReadResourceResult, Resource,
-        ResourceContents, ServerCapabilities, ServerInfo, Tool,
+        CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock,
+        GetPromptRequestParams, GetPromptResponse, Implementation, ListPromptsResult,
+        ListResourcesResult, ListToolsResult, PaginatedRequestParams, ReadResourceRequestParams,
+        ReadResourceResponse, ReadResourceResult, Resource, ResourceContents, ServerCapabilities,
+        ServerInfo, Tool,
     },
     service::{Peer, RequestContext},
 };
@@ -92,7 +93,7 @@ impl ServerHandler for YarrRmcpServer {
         &self,
         request: CallToolRequestParams,
         context: RequestContext<RoleServer>,
-    ) -> Result<CallToolResult, ErrorData> {
+    ) -> Result<CallToolResponse, ErrorData> {
         let tool_name = request.name.to_string();
         let auth = require_auth_context(&self.state, &context)?;
         // Tool identity is authoritative. The default `yarr` tool always means
@@ -141,7 +142,7 @@ impl ServerHandler for YarrRmcpServer {
                 action = %action,
                 "destructive action declined via elicitation; nothing changed"
             );
-            return declined_result(&action);
+            return declined_result(&action).map(Into::into);
         }
 
         let started = Instant::now();
@@ -154,7 +155,7 @@ impl ServerHandler for YarrRmcpServer {
                     elapsed_ms = started.elapsed().as_millis(),
                     "MCP tool execution completed"
                 );
-                tool_result_from_json(result)
+                tool_result_from_json(result).map(Into::into)
             }
             Err(error) if crate::actions::is_validation_error(&error) => {
                 tracing::warn!(
@@ -171,7 +172,7 @@ impl ServerHandler for YarrRmcpServer {
                     error = %error,
                     "MCP tool execution failed"
                 );
-                Ok(tool_error_result(&tool_name, &action, &error))
+                Ok(tool_error_result(&tool_name, &action, &error).into())
             }
         }
     }
@@ -194,7 +195,7 @@ impl ServerHandler for YarrRmcpServer {
         &self,
         request: ReadResourceRequestParams,
         context: RequestContext<RoleServer>,
-    ) -> Result<ReadResourceResult, ErrorData> {
+    ) -> Result<ReadResourceResponse, ErrorData> {
         require_auth_context(&self.state, &context)?;
         if request.uri != SCHEMA_RESOURCE_URI {
             return Err(ErrorData::invalid_params(
@@ -207,7 +208,8 @@ impl ServerHandler for YarrRmcpServer {
             .map_err(|e| ErrorData::internal_error(format!("serialization error: {e}"), None))?;
         Ok(ReadResourceResult::new(vec![
             ResourceContents::text(text, SCHEMA_RESOURCE_URI).with_mime_type("application/json"),
-        ]))
+        ])
+        .into())
     }
 
     // ── prompts ───────────────────────────────────────────────────────────────
@@ -225,9 +227,11 @@ impl ServerHandler for YarrRmcpServer {
         &self,
         request: GetPromptRequestParams,
         context: RequestContext<RoleServer>,
-    ) -> Result<GetPromptResult, ErrorData> {
+    ) -> Result<GetPromptResponse, ErrorData> {
         require_auth_context(&self.state, &context)?;
-        prompts::get_prompt(request).map_err(|e| ErrorData::invalid_params(e.to_string(), None))
+        prompts::get_prompt(request)
+            .map(Into::into)
+            .map_err(|e| ErrorData::invalid_params(e.to_string(), None))
     }
 
     // ── server info ───────────────────────────────────────────────────────────

--- a/src/mcp/transport.rs
+++ b/src/mcp/transport.rs
@@ -22,7 +22,7 @@ use super::rmcp_server::{YarrRmcpServer, rmcp_server as make_server};
 
 pub fn streamable_http_config(config: &McpConfig) -> StreamableHttpServerConfig {
     StreamableHttpServerConfig::default()
-        .with_stateful_mode(false)
+        .with_legacy_session_mode(false)
         .with_json_response(true)
         .with_allowed_hosts(allowed_hosts(config))
         .with_allowed_origins(allowed_origins(config))

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -12,9 +12,11 @@
 # =============================================================================
 
 [package]
+
+rust-version.workspace = true
 name = "xtask"
 version = "2.2.1"
-edition = "2024"
+edition.workspace = true
 # Exclude from crates.io — this is a private automation crate.
 publish = false
 


### PR DESCRIPTION
Aligns the four things this fleet had drifting independently: build toolchain, MSRV, edition, and the rmcp pin.

| | before (spread across 13 repos) | after |
|---|---|---|
| `rust-toolchain.toml` | 4 of 13 pinned, all 4 different (1.90 / 1.94.1 / 1.96.0) | **13/13 at 1.97.1** |
| `rust-version` | 1.86 / 1.90 / 1.92 / 1.94.0 / 1.96 / none | **13/13 at 1.97.1** |
| edition | 44 of 90 crates on 2021 | **90/90 on 2024** |
| rmcp | 1.7.0 / 1.8.0 / 2.2.0 / 3.0.0-beta.2, 6 repos caret-drifted | **13/13 at `=3.0.0-beta.2`, declared == locked** |

### Why the MSRV could move

[ADR-0001](https://github.com/dinglebear-ai/labby) deferred the MSRV because `unraid-rmcp` and `lab-auth` carry `publish = ["crates-io"]`, so raising the floor looked like narrowing a public promise. **Neither crate has ever been published** — both return 404 from the crates.io API (control: `serde` returns 200). With no published version there is no downstream consumer, so the blocker was a promise nobody had made. Recorded as ADR-0024.

Patch granularity (`1.97.1`, not `1.97`) is deliberate: 1.97.1 exists to fix an LLVM miscompilation present since 1.87, so an MSRV of `1.97` would declare the known-bad 1.97.0 as supported.

### Verification

Per repo: `cargo metadata --no-deps` for the resolved edition and `rust_version` on every package (inheritance means manifest text and resolved value are different questions), then `clippy --all-targets -D warnings`, the full test suite, and `cargo fmt --check`.

### Three things worth knowing

**Raising the MSRV turns clippy lints on.** Clippy suppresses suggestions whose replacement API is unavailable at the declared floor, so raising it unlocks them. cortex gained 107 sites (102 `collapsible_if` from let-chains stable in 1.88, 5 `manual_is_multiple_of` from 1.87); labby-auth gained 8 `Duration::from_hours`/`from_mins`. Confirmed by controlled experiment — same tree at the old floor reports zero. All auto-applicable.

**rustfmt's style edition follows the crate edition.** Flipping the key reformats import blocks. Six repos drifted (unraid-rs 53, rgotify 30, rapprise 26, rtailscale 21, synapse 2, axon 1) and **none of `check`, `clippy`, or `test` catches it** — only `cargo fmt --check`, which CI runs separately.

**One rmcp change has no compile error.** rmcp 3.0's SEP-2260 request association rejects server→client requests (elicit/sampling/roots) when the call escapes the request-handler scope, which is a tokio task-local. Any spawn between `call_tool` and an elicit silently breaks destructive-action gating against modern clients. yarr and synapse were both audited clean — but it took three greps across two repos to get there, with three non-overlapping blind spots. Written up as BC-11 in the fleet rmcp-migration doc.