### PR TITLE
ci: align workflows with fleet policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,14 +34,14 @@ jobs:
   # -- actionlint: GitHub Actions workflow syntax and shell checks -------------
   actionlint:
     name: Actionlint
-    uses: dinglebear-ai/workflows/.github/workflows/fast-ops.yml@542ea7b7e5ca2d4e21f3277bfcf158584fee90ec
+    uses: dinglebear-ai/workflows/.github/workflows/fast-ops.yml@66e64b9f31de7ac1f9aa8c9f87ede9bbec5eae1d
     with:
       shell-globs: scripts/*.sh
       policy-command: bash scripts/check-version-sync.sh
 
   rust:
     name: Fast Rust
-    uses: dinglebear-ai/workflows/.github/workflows/fast-rust.yml@542ea7b7e5ca2d4e21f3277bfcf158584fee90ec
+    uses: dinglebear-ai/workflows/.github/workflows/fast-rust.yml@66e64b9f31de7ac1f9aa8c9f87ede9bbec5eae1d
     with:
       toolchain: "1.97.1"
       check-command: cargo check --all-targets --locked
@@ -55,7 +55,7 @@ jobs:
   # ── docs: rustdoc with zero warnings (broken/ambiguous intra-doc links) ──────
   docs:
     name: Docs
-    uses: dinglebear-ai/workflows/.github/workflows/rust-docs.yml@542ea7b7e5ca2d4e21f3277bfcf158584fee90ec
+    uses: dinglebear-ai/workflows/.github/workflows/rust-docs.yml@66e64b9f31de7ac1f9aa8c9f87ede9bbec5eae1d
     with:
       toolchain: "1.97.1"
       command: RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --document-private-items --locked
@@ -86,7 +86,7 @@ jobs:
   # ── npm: package launcher checks ────────────────────────────────────────────
   npm:
     name: NPM Package
-    uses: dinglebear-ai/workflows/.github/workflows/fast-node.yml@542ea7b7e5ca2d4e21f3277bfcf158584fee90ec
+    uses: dinglebear-ai/workflows/.github/workflows/fast-node.yml@66e64b9f31de7ac1f9aa8c9f87ede9bbec5eae1d
     with:
       node-version: "22"
       working-directory: packages/yarr-mcp
@@ -160,23 +160,23 @@ jobs:
   # ── deny: dependency advisories, licenses, bans, sources ─────────────────────
   audit:
     name: Cargo Deny
-    uses: dinglebear-ai/workflows/.github/workflows/rust-security.yml@542ea7b7e5ca2d4e21f3277bfcf158584fee90ec
+    uses: dinglebear-ai/workflows/.github/workflows/rust-security.yml@66e64b9f31de7ac1f9aa8c9f87ede9bbec5eae1d
     with:
       toolchain: "1.97.1"
       command: bash scripts/check-security-exceptions.sh && cargo deny check --all-features
 
   fleet-policy:
     name: Fleet Policy
-    uses: dinglebear-ai/workflows/.github/workflows/fleet-policy.yml@542ea7b7e5ca2d4e21f3277bfcf158584fee90ec
+    uses: dinglebear-ai/workflows/.github/workflows/fleet-policy.yml@66e64b9f31de7ac1f9aa8c9f87ede9bbec5eae1d
     with:
       release-file-regex: '(^|/)(release|docker-publish|unraid-plugin-release)\.ya?ml$'
 
   fleet-contract:
     name: Fleet Contract
-    uses: dinglebear-ai/workflows/.github/workflows/fleet-contract.yml@542ea7b7e5ca2d4e21f3277bfcf158584fee90ec
+    uses: dinglebear-ai/workflows/.github/workflows/fleet-contract.yml@66e64b9f31de7ac1f9aa8c9f87ede9bbec5eae1d
     with:
       profile: rust
-      implementation-ref: 542ea7b7e5ca2d4e21f3277bfcf158584fee90ec
+      implementation-ref: 66e64b9f31de7ac1f9aa8c9f87ede9bbec5eae1d
 
   ci-gate:
     name: CI Gate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,73 +34,30 @@ jobs:
   # -- actionlint: GitHub Actions workflow syntax and shell checks -------------
   actionlint:
     name: Actionlint
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    uses: dinglebear-ai/workflows/.github/workflows/fast-ops.yml@eb5f36cf517ffc949aca1c81e2ccbc71b5a85267
+    with:
+      policy-command: bash scripts/check-version-sync.sh
 
-      - name: Install Go
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          go-version: stable
-          cache: false
-
-      - name: actionlint
-        run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.9
-
-  # ── fmt: cargo fmt --check ──────────────────────────────────────────────────
-  fmt:
-    name: Format
-    runs-on: [self-hosted, ci-pool-rust]
-    timeout-minutes: 20
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      # Fails when Cargo.toml, package.json, server.json and friends disagree
-      # on the version. Previously reachable only by hand, which is how a
-      # sibling repo sat seven releases out of sync unnoticed.
-      - name: Check version sync
-        run: bash scripts/check-version-sync.sh
-
-      - name: Install Rust and kache
-        uses: ./.github/actions/setup-rust-kache
-        with:
-          components: rustfmt
-
-      - name: cargo fmt --check
-        run: cargo fmt --all -- --check
-
-  # ── clippy: zero warnings ────────────────────────────────────────────────────
-  clippy:
-    name: Clippy
-    runs-on: [self-hosted, ci-pool-rust]
-    timeout-minutes: 20
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Install Rust and kache
-        uses: ./.github/actions/setup-rust-kache
-        with:
-          components: clippy
-
-      - name: cargo clippy -- -D warnings
-        run: cargo clippy --all-targets -- -D warnings
+  rust:
+    name: Fast Rust
+    uses: dinglebear-ai/workflows/.github/workflows/fast-rust.yml@eb5f36cf517ffc949aca1c81e2ccbc71b5a85267
+    with:
+      toolchain: "1.97.1"
+      check-command: cargo check --all-targets --locked
+      clippy-command: cargo clippy --all-targets --locked -- -D warnings
+      test-command: cargo test --workspace --locked --no-run
+      kache-manifest-key: yarr-fast-rust
+    secrets:
+      KACHE_S3_ACCESS_KEY: ${{ secrets.KACHE_S3_ACCESS_KEY }}
+      KACHE_S3_SECRET_KEY: ${{ secrets.KACHE_S3_SECRET_KEY }}
 
   # ── docs: rustdoc with zero warnings (broken/ambiguous intra-doc links) ──────
   docs:
     name: Docs
-    runs-on: [self-hosted, ci-pool-rust]
-    timeout-minutes: 20
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Install Rust and kache
-        uses: ./.github/actions/setup-rust-kache
-
-      - name: cargo doc (deny warnings)
-        env:
-          RUSTDOCFLAGS: -D warnings
-        run: cargo doc --no-deps --document-private-items
+    uses: dinglebear-ai/workflows/.github/workflows/rust-docs.yml@eb5f36cf517ffc949aca1c81e2ccbc71b5a85267
+    with:
+      toolchain: "1.97.1"
+      command: RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --document-private-items --locked
 
   # ── test: cargo nextest run --profile ci ─────────────────────────────────────
   test:
@@ -128,32 +85,22 @@ jobs:
   # ── npm: package launcher checks ────────────────────────────────────────────
   npm:
     name: NPM Package
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Install Node
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: 22
-
-      - name: npm test
-        run: npm test --prefix packages/yarr-mcp
-
-      - name: npm run check
-        run: npm run check --prefix packages/yarr-mcp
-
-      - name: Plugin manifest launcher pins are in sync
-        run: node scripts/sync-plugin-manifests.js --check
-
-      - name: npm pack dry run
-        run: npm pack --dry-run --json ./packages/yarr-mcp
+    uses: dinglebear-ai/workflows/.github/workflows/fast-node.yml@eb5f36cf517ffc949aca1c81e2ccbc71b5a85267
+    with:
+      node-version: "22"
+      working-directory: packages/yarr-mcp
+      enable-cache: false
+      install-command: ""
+      audit-command: ""
+      lint-command: npm run check
+      typecheck-command: ""
+      test-command: npm test
+      contract-command: node ../../scripts/sync-plugin-manifests.js --check && npm pack --dry-run --json
 
   # ── toml: taplo check ─────────────────────────────────────────────────────────
   toml:
     name: TOML Format
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, ci-pool-ops]
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -212,16 +159,46 @@ jobs:
   # ── deny: dependency advisories, licenses, bans, sources ─────────────────────
   audit:
     name: Cargo Deny
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
+    uses: dinglebear-ai/workflows/.github/workflows/rust-security.yml@eb5f36cf517ffc949aca1c81e2ccbc71b5a85267
+    with:
+      toolchain: "1.97.1"
+      command: bash scripts/check-security-exceptions.sh && cargo deny check --all-features
+
+  fleet-policy:
+    name: Fleet Policy
+    uses: dinglebear-ai/workflows/.github/workflows/fleet-policy.yml@eb5f36cf517ffc949aca1c81e2ccbc71b5a85267
+    with:
+      release-file-regex: '(^|/)(release|docker-publish|unraid-plugin-release)\.ya?ml$'
+
+  fleet-contract:
+    name: Fleet Contract
+    uses: dinglebear-ai/workflows/.github/workflows/fleet-contract.yml@eb5f36cf517ffc949aca1c81e2ccbc71b5a85267
+    with:
+      profile: rust
+      implementation-ref: eb5f36cf517ffc949aca1c81e2ccbc71b5a85267
+
+  ci-gate:
+    name: CI Gate
+    if: always()
+    runs-on: [self-hosted, ci-pool-ops]
+    timeout-minutes: 10
+    needs:
+      - actionlint
+      - rust
+      - docs
+      - test
+      - npm
+      - toml
+      - template
+      - audit
+      - fleet-policy
+      - fleet-contract
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Check security exception deadlines
-        run: bash scripts/check-security-exceptions.sh
-
-      - name: cargo deny check
-        uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2
-        with:
-          command: check
-          arguments: --all-features
+      - name: Require all CI lanes
+        env:
+          RESULTS: ${{ join(needs.*.result, ' ') }}
+        run: |
+          set -euo pipefail
+          for result in $RESULTS; do
+            [[ "$result" == success || "$result" == skipped ]]
+          done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
     name: Actionlint
     uses: dinglebear-ai/workflows/.github/workflows/fast-ops.yml@542ea7b7e5ca2d4e21f3277bfcf158584fee90ec
     with:
+      shell-globs: scripts/*.sh
       policy-command: bash scripts/check-version-sync.sh
 
   rust:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,13 +34,13 @@ jobs:
   # -- actionlint: GitHub Actions workflow syntax and shell checks -------------
   actionlint:
     name: Actionlint
-    uses: dinglebear-ai/workflows/.github/workflows/fast-ops.yml@eb5f36cf517ffc949aca1c81e2ccbc71b5a85267
+    uses: dinglebear-ai/workflows/.github/workflows/fast-ops.yml@542ea7b7e5ca2d4e21f3277bfcf158584fee90ec
     with:
       policy-command: bash scripts/check-version-sync.sh
 
   rust:
     name: Fast Rust
-    uses: dinglebear-ai/workflows/.github/workflows/fast-rust.yml@eb5f36cf517ffc949aca1c81e2ccbc71b5a85267
+    uses: dinglebear-ai/workflows/.github/workflows/fast-rust.yml@542ea7b7e5ca2d4e21f3277bfcf158584fee90ec
     with:
       toolchain: "1.97.1"
       check-command: cargo check --all-targets --locked
@@ -54,7 +54,7 @@ jobs:
   # ── docs: rustdoc with zero warnings (broken/ambiguous intra-doc links) ──────
   docs:
     name: Docs
-    uses: dinglebear-ai/workflows/.github/workflows/rust-docs.yml@eb5f36cf517ffc949aca1c81e2ccbc71b5a85267
+    uses: dinglebear-ai/workflows/.github/workflows/rust-docs.yml@542ea7b7e5ca2d4e21f3277bfcf158584fee90ec
     with:
       toolchain: "1.97.1"
       command: RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --document-private-items --locked
@@ -85,7 +85,7 @@ jobs:
   # ── npm: package launcher checks ────────────────────────────────────────────
   npm:
     name: NPM Package
-    uses: dinglebear-ai/workflows/.github/workflows/fast-node.yml@eb5f36cf517ffc949aca1c81e2ccbc71b5a85267
+    uses: dinglebear-ai/workflows/.github/workflows/fast-node.yml@542ea7b7e5ca2d4e21f3277bfcf158584fee90ec
     with:
       node-version: "22"
       working-directory: packages/yarr-mcp
@@ -159,23 +159,23 @@ jobs:
   # ── deny: dependency advisories, licenses, bans, sources ─────────────────────
   audit:
     name: Cargo Deny
-    uses: dinglebear-ai/workflows/.github/workflows/rust-security.yml@eb5f36cf517ffc949aca1c81e2ccbc71b5a85267
+    uses: dinglebear-ai/workflows/.github/workflows/rust-security.yml@542ea7b7e5ca2d4e21f3277bfcf158584fee90ec
     with:
       toolchain: "1.97.1"
       command: bash scripts/check-security-exceptions.sh && cargo deny check --all-features
 
   fleet-policy:
     name: Fleet Policy
-    uses: dinglebear-ai/workflows/.github/workflows/fleet-policy.yml@eb5f36cf517ffc949aca1c81e2ccbc71b5a85267
+    uses: dinglebear-ai/workflows/.github/workflows/fleet-policy.yml@542ea7b7e5ca2d4e21f3277bfcf158584fee90ec
     with:
       release-file-regex: '(^|/)(release|docker-publish|unraid-plugin-release)\.ya?ml$'
 
   fleet-contract:
     name: Fleet Contract
-    uses: dinglebear-ai/workflows/.github/workflows/fleet-contract.yml@eb5f36cf517ffc949aca1c81e2ccbc71b5a85267
+    uses: dinglebear-ai/workflows/.github/workflows/fleet-contract.yml@542ea7b7e5ca2d4e21f3277bfcf158584fee90ec
     with:
       profile: rust
-      implementation-ref: eb5f36cf517ffc949aca1c81e2ccbc71b5a85267
+      implementation-ref: 542ea7b7e5ca2d4e21f3277bfcf158584fee90ec
 
   ci-gate:
     name: CI Gate

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,52 +4,18 @@ on:
   push:
     branches: [main]
   schedule:
-    # Weekly scan on Wednesdays at 08:00 UTC
     - cron: "0 8 * * 3"
 
-# Cancel superseded analysis runs on the same ref — only the latest push matters.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+permissions:
+  contents: read
+  actions: read
+  security-events: write
 
 jobs:
   analyze:
-    name: Analyze (${{ matrix.language }})
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    permissions:
-      security-events: write
-      actions: read
-      contents: read
-
-    strategy:
-      fail-fast: false
-      matrix:
-        language: [rust]
-
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
-        with:
-          languages: ${{ matrix.language }}
-          queries: security-extended
-
-      - name: Cache Cargo
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ github.repository }}-codeql-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ github.repository }}-codeql-
-
-      - name: Build
-        run: cargo build --release
-
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
-        with:
-          category: "/language:${{ matrix.language }}"
+    name: Analyze Rust
+    uses: dinglebear-ai/workflows/.github/workflows/codeql.yml@eb5f36cf517ffc949aca1c81e2ccbc71b5a85267
+    with:
+      language: rust
+      build-mode: manual
+      build-command: cargo build --release --locked

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   analyze:
     name: Analyze Rust
-    uses: dinglebear-ai/workflows/.github/workflows/codeql.yml@542ea7b7e5ca2d4e21f3277bfcf158584fee90ec
+    uses: dinglebear-ai/workflows/.github/workflows/codeql.yml@66e64b9f31de7ac1f9aa8c9f87ede9bbec5eae1d
     with:
       language: rust
       build-mode: manual

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   analyze:
     name: Analyze Rust
-    uses: dinglebear-ai/workflows/.github/workflows/codeql.yml@eb5f36cf517ffc949aca1c81e2ccbc71b5a85267
+    uses: dinglebear-ai/workflows/.github/workflows/codeql.yml@542ea7b7e5ca2d4e21f3277bfcf158584fee90ec
     with:
       language: rust
       build-mode: manual

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   auto-merge:
     name: Merge verified patch/minor updates
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, ci-pool-ops]
     timeout-minutes: 45
     if: github.actor == 'dependabot[bot]'
     steps:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   container:
     name: Build, verify, and publish x86_64 image
-    uses: dinglebear-ai/workflows/.github/workflows/hosted-container-release.yml@eb5f36cf517ffc949aca1c81e2ccbc71b5a85267
+    uses: dinglebear-ai/workflows/.github/workflows/hosted-container-release.yml@542ea7b7e5ca2d4e21f3277bfcf158584fee90ec
     with:
       checkout-ref: ${{ github.event.release.tag_name }}
       image: ghcr.io/dinglebear-ai/yarr

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   container:
     name: Build, verify, and publish x86_64 image
-    uses: dinglebear-ai/workflows/.github/workflows/hosted-container-release.yml@542ea7b7e5ca2d4e21f3277bfcf158584fee90ec
+    uses: dinglebear-ai/workflows/.github/workflows/hosted-container-release.yml@66e64b9f31de7ac1f9aa8c9f87ede9bbec5eae1d
     with:
       checkout-ref: ${{ github.event.release.tag_name }}
       image: ghcr.io/dinglebear-ai/yarr

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,252 +1,30 @@
-# Build, scan, and only then promote container tags.
-name: Docker Publish
+name: Container Release
 
 on:
-  workflow_run:
-    workflows: ["CI"]
-    types: [completed]
-    branches: [main]
-  push:
-    tags: ["v*"]
-  workflow_dispatch:
-    inputs:
-      ref:
-        description: Commit SHA or vX.Y.Z tag to build
-        required: true
-        type: string
+  release:
+    types: [published]
 
 permissions:
   contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_sha || github.ref || inputs.ref }}
+  group: container-release-${{ github.event.release.tag_name }}
   cancel-in-progress: false
 
-env:
-  IMAGE_NAME: ghcr.io/dinglebear-ai/yarr
-  SOURCE_REF: ${{ github.event.workflow_run.head_sha || inputs.ref || github.ref }}
-
 jobs:
-  build-candidate:
-    name: Build quarantined image
-    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    permissions:
-      checks: read
-      contents: read
-      packages: write
-    outputs:
-      digest: ${{ steps.build.outputs.digest }}
-      source-sha: ${{ steps.source.outputs.sha }}
-      source-tag: ${{ steps.source.outputs.tag }}
-    steps:
-      - name: Check out reviewed source
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          ref: ${{ env.SOURCE_REF }}
-          persist-credentials: false
-
-      - name: Resolve source identity
-        id: source
-        shell: bash
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          INPUT_REF: ${{ inputs.ref }}
-        run: |
-          set -euo pipefail
-          sha="$(git rev-parse HEAD)"
-          tag=""
-          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
-            tag="${GITHUB_REF#refs/tags/}"
-            [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
-              echo "::error::Release tags must match vMAJOR.MINOR.PATCH"
-              exit 1
-            }
-          elif [[ "$EVENT_NAME" == "workflow_dispatch" && "$INPUT_REF" == v* ]]; then
-            tag="$INPUT_REF"
-            [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
-              echo "::error::Release tags must match vMAJOR.MINOR.PATCH"
-              exit 1
-            }
-          fi
-          echo "sha=$sha" >> "$GITHUB_OUTPUT"
-          echo "tag=$tag" >> "$GITHUB_OUTPUT"
-
-      - name: Require complete CI and MSRV for source SHA
-        shell: bash
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SOURCE_SHA: ${{ steps.source.outputs.sha }}
-        run: |
-          set -euo pipefail
-          required=(
-            Actionlint Format Clippy Docs Test "NPM Package" "TOML Format"
-            "Repo Contracts" "Cargo Deny" "Secret Scan"
-            "Minimum Supported Rust Version"
-          )
-          for attempt in {1..20}; do
-            checks="$(gh api \
-              -H 'Accept: application/vnd.github+json' \
-              "repos/${GITHUB_REPOSITORY}/commits/${SOURCE_SHA}/check-runs?per_page=100")"
-            waiting=()
-            for name in "${required[@]}"; do
-              conclusion="$(jq -r --arg name "$name" \
-                '[.check_runs[] | select(.name == $name)] | sort_by(.completed_at // "") | last | .conclusion // "missing"' \
-                <<< "$checks")"
-              case "$conclusion" in
-                success) ;;
-                missing|null) waiting+=("$name") ;;
-                *)
-                  echo "::error::Required check ${name} concluded ${conclusion} for ${SOURCE_SHA}"
-                  exit 1
-                  ;;
-              esac
-            done
-            if (( ${#waiting[@]} == 0 )); then
-              exit 0
-            fi
-            echo "Waiting for required checks: ${waiting[*]} (attempt ${attempt}/20)"
-            sleep 15
-          done
-          echo "::error::Timed out waiting for complete CI/MSRV on ${SOURCE_SHA}"
-          exit 1
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push quarantine tag
-        id: build
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          context: .
-          file: config/Dockerfile
-          platforms: linux/amd64
-          push: true
-          tags: ${{ env.IMAGE_NAME }}:candidate-${{ steps.source.outputs.sha }}
-          labels: |
-            org.opencontainers.image.revision=${{ steps.source.outputs.sha }}
-            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          provenance: true
-          sbom: true
-
-  scan:
-    name: Scan quarantined image
-    needs: build-candidate
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    permissions:
-      contents: read
-      packages: read
-      security-events: write
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Run Trivy against immutable digest
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
-        with:
-          image-ref: ${{ env.IMAGE_NAME }}@${{ needs.build-candidate.outputs.digest }}
-          format: sarif
-          output: trivy-results.sarif
-          severity: CRITICAL,HIGH
-          limit-severities-for-sarif: true
-          exit-code: "1"
-
-      - name: Upload Trivy results
-        if: always() && hashFiles('trivy-results.sarif') != ''
-        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
-        with:
-          sarif_file: trivy-results.sarif
-
-  promote:
-    name: Promote verified image tags
-    needs: [build-candidate, scan]
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Promote digest after clean scan
-        shell: bash
-        env:
-          DIGEST: ${{ needs.build-candidate.outputs.digest }}
-          SOURCE_SHA: ${{ needs.build-candidate.outputs.source-sha }}
-          SOURCE_TAG: ${{ needs.build-candidate.outputs.source-tag }}
-        run: |
-          set -euo pipefail
-          source_ref="${IMAGE_NAME}@${DIGEST}"
-          tags=("${IMAGE_NAME}:sha-${SOURCE_SHA:0:12}")
-          if [[ -n "$SOURCE_TAG" ]]; then
-            version="${SOURCE_TAG#v}"
-            major_minor="${version%.*}"
-            tags+=("${IMAGE_NAME}:${version}" "${IMAGE_NAME}:${major_minor}")
-          else
-            tags+=("${IMAGE_NAME}:main" "${IMAGE_NAME}:latest")
-          fi
-
-          args=()
-          for tag in "${tags[@]}"; do
-            args+=(--tag "$tag")
-          done
-          docker buildx imagetools create "${args[@]}" "$source_ref"
-
-          {
-            echo "## Promoted verified image"
-            echo
-            echo "Digest: \`${DIGEST}\`"
-            printf -- "- \`%s\`\n" "${tags[@]}"
-          } >> "$GITHUB_STEP_SUMMARY"
-
-  notify:
-    name: Notify container publication failure
-    if: ${{ always() && (needs.build-candidate.result == 'failure' || needs.scan.result == 'failure' || needs.promote.result == 'failure') }}
-    needs: [build-candidate, scan, promote]
-    runs-on: ubuntu-latest
-    permissions:
-      issues: write
-    steps:
-      - name: Create or reuse incident issue
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          set -euo pipefail
-          existing="$(gh issue list --repo "$GH_REPO" --state open --search 'Container publication failed in:title' --json number --jq '.[0].number // empty')"
-          if [[ -n "$existing" ]]; then
-            gh issue comment "$existing" --repo "$GH_REPO" --body "Container publication failed again: ${RUN_URL}"
-          else
-            gh issue create --repo "$GH_REPO" \
-              --title "Container publication failed" \
-              --body "A candidate build, vulnerability scan, or digest promotion failed: ${RUN_URL}\n\nNo production tag should move before a clean scan. Runbook: docs/runbooks/deployment-rollback.md"
-          fi
+  container:
+    name: Build, verify, and publish x86_64 image
+    uses: dinglebear-ai/workflows/.github/workflows/hosted-container-release.yml@eb5f36cf517ffc949aca1c81e2ccbc71b5a85267
+    with:
+      checkout-ref: ${{ github.event.release.tag_name }}
+      image: ghcr.io/dinglebear-ai/yarr
+      release-tag: ${{ github.event.release.tag_name }}
+      dockerfile: config/Dockerfile
+      smoke-command: docker run --rm "$IMAGE_REF" --version
+      cache-scope: yarr-container-release
+    secrets:
+      REGISTRY_USERNAME: ${{ github.actor }}
+      REGISTRY_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   msrv:
     name: Minimum Supported Rust Version
-    uses: dinglebear-ai/workflows/.github/workflows/rust-msrv.yml@542ea7b7e5ca2d4e21f3277bfcf158584fee90ec
+    uses: dinglebear-ai/workflows/.github/workflows/rust-msrv.yml@66e64b9f31de7ac1f9aa8c9f87ede9bbec5eae1d
     with:
       msrv: "1.97.1"
       command: cargo check --all-targets --locked && cargo test --no-run --all-targets --locked

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   msrv:
     name: Minimum Supported Rust Version
-    uses: dinglebear-ai/workflows/.github/workflows/rust-msrv.yml@eb5f36cf517ffc949aca1c81e2ccbc71b5a85267
+    uses: dinglebear-ai/workflows/.github/workflows/rust-msrv.yml@542ea7b7e5ca2d4e21f3277bfcf158584fee90ec
     with:
       msrv: "1.97.1"
       command: cargo check --all-targets --locked && cargo test --no-run --all-targets --locked

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -9,24 +9,10 @@ on:
 permissions:
   contents: read
 
-env:
-  CARGO_INCREMENTAL: "0"
-
 jobs:
   msrv:
     name: Minimum Supported Rust Version
-    runs-on: [self-hosted, ci-pool-rust]
-    timeout-minutes: 20
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Install Rust and kache
-        uses: ./.github/actions/setup-rust-kache
-        with:
-          toolchain: "1.97.1"
-
-      - name: cargo check (MSRV)
-        run: cargo check --all-targets --locked
-
-      - name: cargo test --no-run (MSRV)
-        run: cargo test --no-run --all-targets --locked
+    uses: dinglebear-ai/workflows/.github/workflows/rust-msrv.yml@eb5f36cf517ffc949aca1c81e2ccbc71b5a85267
+    with:
+      msrv: "1.97.1"
+      command: cargo check --all-targets --locked && cargo test --no-run --all-targets --locked

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,7 +29,8 @@ concurrency:
 jobs:
   release-please:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, ci-pool-ops]
+    timeout-minutes: 10
     permissions:
       contents: write
       issues: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,60 +1,41 @@
-# Stage binaries and npm while the GitHub Release remains private, then publish.
-name: Release
+name: Release artifacts
 
 on:
-  push:
-    tags: ["v*"]
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: Existing vX.Y.Z tag to stage or resume
-        required: true
-        type: string
+  release:
+    types: [published]
 
 permissions:
-  contents: read
+  contents: write
+  attestations: write
+  id-token: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name || inputs.tag }}
+  group: release-artifacts-${{ github.event.release.tag_name }}
   cancel-in-progress: false
-
-env:
-  BINARY_NAME: yarr
-  RELEASE_TAG: ${{ github.ref_type == 'tag' && github.ref_name || inputs.tag }}
-  CARGO_INCREMENTAL: "0"
 
 jobs:
   verify:
     name: Verify release contract
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
-      - name: Validate tag format
-        shell: bash
-        run: |
-          set -euo pipefail
-          [[ "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
-            echo "::error::Release tag must match vMAJOR.MINOR.PATCH"
-            exit 1
-          }
-
-      - name: Check out immutable tag
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
-          ref: ${{ env.RELEASE_TAG }}
+          ref: ${{ github.event.release.tag_name }}
           persist-credentials: false
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-
-      - name: Verify coupled versions
-        id: version
-        shell: bash
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
+        with:
+          toolchain: "1.97.1"
+      - id: version
+        name: Verify coupled versions
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           set -euo pipefail
-          tag_version="${RELEASE_TAG#v}"
+          [[ "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
+          expected="${RELEASE_TAG#v}"
           cargo_version="$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "yarr") | .version')"
           xtask_version="$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "xtask") | .version')"
           package_version="$(jq -r '.version' packages/yarr-mcp/package.json)"
@@ -62,296 +43,69 @@ jobs:
           registry_version="$(jq -r '.version' server.json)"
           registry_package_version="$(jq -r '.packages[0].version' server.json)"
           for value in "$cargo_version" "$xtask_version" "$package_version" "$manifest_version" "$registry_version" "$registry_package_version"; do
-            if [[ "$value" != "$tag_version" ]]; then
-              echo "::error::Release versions must all equal ${tag_version}; found ${value}"
-              exit 1
-            fi
+            [[ "$value" == "$expected" ]]
           done
           jq -e '
             .name == "ai.dinglebear/yarr-mcp" and
             .packages[0].registryType == "npm" and
             .packages[0].identifier == "yarr-mcp" and
             .packages[0].transport.type == "stdio"
-          ' server.json >/dev/null || {
-            echo "::error::server.json distribution identity is not the reviewed npm stdio contract"
-            exit 1
-          }
-          echo "version=$tag_version" >> "$GITHUB_OUTPUT"
+          ' server.json >/dev/null
+          printf 'version=%s\n' "$expected" >> "$GITHUB_OUTPUT"
 
-  build:
-    name: Build ${{ matrix.target }}
-    needs: verify
-    runs-on: [self-hosted, unraid]
-    timeout-minutes: 60
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - target: x86_64-unknown-linux-gnu
-            arch: x86_64
-            ext: ""
-          - target: x86_64-pc-windows-gnu
-            arch: windows-x86_64
-            ext: ".exe"
-    steps:
-      - name: Check out immutable tag
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          ref: ${{ env.RELEASE_TAG }}
-          persist-credentials: false
+  artifacts:
+    name: Build hosted x86_64 artifacts
+    needs: [verify]
+    uses: dinglebear-ai/workflows/.github/workflows/hosted-rust-platform-release.yml@eb5f36cf517ffc949aca1c81e2ccbc71b5a85267
+    with:
+      checkout-ref: ${{ github.event.release.tag_name }}
+      toolchain: "1.97.1"
+      targets-json: >-
+        [{"runner":"ubuntu-24.04","target":"x86_64-unknown-linux-gnu","suffix":"x86_64","ext":""},
+         {"runner":"ubuntu-24.04","target":"x86_64-pc-windows-gnu","suffix":"windows-x86_64","ext":".exe"}]
+      build-command: |
+        set -euo pipefail
+        if [[ "$TARGET" == "x86_64-pc-windows-gnu" ]]; then
+          sudo apt-get update
+          sudo apt-get install -y gcc-mingw-w64-x86-64
+          export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER=x86_64-w64-mingw32-gcc
+          export CC_x86_64_pc_windows_gnu=x86_64-w64-mingw32-gcc
+          export CXX_x86_64_pc_windows_gnu=x86_64-w64-mingw32-g++
+          export AR_x86_64_pc_windows_gnu=x86_64-w64-mingw32-ar
+        fi
+        cargo build --release --locked --target "$TARGET" --bin yarr
+      package-command: |
+        set -euo pipefail
+        mkdir -p package dist
+        ext=""
+        archive="dist/yarr-x86_64.tar.gz"
+        if [[ "$TARGET" == "x86_64-pc-windows-gnu" ]]; then
+          ext=".exe"
+          archive="dist/yarr-windows-x86_64.tar.gz"
+        fi
+        cp "target/$TARGET/release/yarr$ext" "package/yarr$ext"
+        tar -C package -czf "$archive" "yarr$ext"
+        filename="${archive##*/}"
+        (cd dist && sha256sum "$filename" > "$filename.sha256")
+      artifact-path: dist/*
+      artifact-prefix: yarr
 
-      - name: Install Rust and kache
-        uses: ./.github/actions/setup-rust-kache
-        with:
-          targets: ${{ matrix.target }}
-
-      # Base build deps (cc, pkg-config, libssl-dev) are installed by the
-      # composite above when missing; only the mingw cross-linker is extra.
-      # The runner may be root (no sudo binary), so pick the escalation path.
-      - name: Install cross-compilation dependencies
-        if: matrix.target == 'x86_64-pc-windows-gnu'
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ "$(id -u)" == "0" ]]; then
-            apt-get update
-            apt-get install -y gcc-mingw-w64-x86-64
-          else
-            sudo apt-get update
-            sudo apt-get install -y gcc-mingw-w64-x86-64
-          fi
-
-      - name: Build release binary
-        env:
-          CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER: x86_64-w64-mingw32-gcc
-          # kache exports a global CC (`zccache-kache /usr/bin/cc`) for compile
-          # caching. In cc-rs precedence a bare CC outranks the target-specific
-          # default, so C dependencies such as aws-lc-sys would be built for the
-          # Windows target using the host Linux compiler. Naming the cross
-          # toolchain per-target restores correct cross-compilation, because
-          # cc-rs reads CC_<target> ahead of CC.
-          CC_x86_64_pc_windows_gnu: x86_64-w64-mingw32-gcc
-          CXX_x86_64_pc_windows_gnu: x86_64-w64-mingw32-g++
-          AR_x86_64_pc_windows_gnu: x86_64-w64-mingw32-ar
-        run: cargo build --release --locked --target ${{ matrix.target }}
-
-      - name: Prepare checksummed archive
-        shell: bash
-        run: |
-          set -euo pipefail
-          mkdir -p package artifacts
-          cp "target/${{ matrix.target }}/release/${BINARY_NAME}${{ matrix.ext }}" \
-            "package/${BINARY_NAME}${{ matrix.ext }}"
-          chmod +x "package/${BINARY_NAME}${{ matrix.ext }}"
-          archive="artifacts/${BINARY_NAME}-${{ matrix.arch }}.tar.gz"
-          tar -C package -czf "$archive" "${BINARY_NAME}${{ matrix.ext }}"
-          sha256sum -- "$archive" > "${archive}.sha256"
-
-      - name: Upload staged artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: ${{ env.BINARY_NAME }}-${{ matrix.arch }}
-          path: artifacts/
-          if-no-files-found: error
-
-  stage-release:
-    name: Stage draft release assets
-    needs: [verify, build]
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    permissions:
-      contents: write
-    outputs:
-      staged_assets: ${{ steps.staged-assets.outputs.names }}
-    steps:
-      - name: Download all artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          path: artifacts
-          merge-multiple: true
-
-      - name: Generate aggregate checksum
-        shell: bash
-        run: |
-          set -euo pipefail
-          cd artifacts
-          sha256sum -- *.tar.gz > SHA256SUMS
-          sha256sum --check SHA256SUMS
-
-      - name: Create or validate draft release
-        id: release-state
-        shell: bash
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERSION: ${{ needs.verify.outputs.version }}
-        run: |
-          set -euo pipefail
-          if is_draft="$(gh release view "$RELEASE_TAG" \
-            --repo "$GITHUB_REPOSITORY" \
-            --json isDraft \
-            --jq '.isDraft' 2>/dev/null)"; then
-            if [[ "$is_draft" != "true" ]]; then
-              published="$(npm view "yarr-mcp@${VERSION}" version 2>/dev/null || true)"
-              [[ "$published" == "$VERSION" ]] || {
-                echo "::error::GitHub Release is public before npm yarr-mcp@${VERSION} exists"
-                exit 1
-              }
-              echo "public=true" >> "$GITHUB_OUTPUT"
-            else
-              echo "public=false" >> "$GITHUB_OUTPUT"
-            fi
-          else
-            gh release create "$RELEASE_TAG" \
-              --repo "$GITHUB_REPOSITORY" \
-              --draft \
-              --verify-tag \
-              --generate-notes
-            echo "public=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Upload assets to draft release
-        if: steps.release-state.outputs.public != 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload "$RELEASE_TAG" artifacts/* --clobber --repo "$GITHUB_REPOSITORY"
-
-      # A draft release is invisible to the npm job (that job holds only
-      # contents:read, and drafts require push access), so hand the verified
-      # asset names down instead of widening the publishing job's permissions.
-      - name: Record staged asset names
-        id: staged-assets
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          names="$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" \
-            --json assets --jq '[.assets[].name] | join(",")')"
-          [[ -n "$names" ]] || { echo "::error::staged release has no assets"; exit 1; }
-          echo "names=$names" >> "$GITHUB_OUTPUT"
+  github-release:
+    name: Attach verified artifacts
+    needs: [artifacts]
+    uses: dinglebear-ai/workflows/.github/workflows/github-release.yml@eb5f36cf517ffc949aca1c81e2ccbc71b5a85267
+    with:
+      release-tag: ${{ github.event.release.tag_name }}
+      artifact-pattern: yarr-*
 
   npm:
     name: Publish npm launcher
-    needs: [verify, stage-release]
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - name: Check out immutable tag
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          ref: ${{ env.RELEASE_TAG }}
-          persist-credentials: false
-
-      - name: Install Node
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: 22
-          registry-url: https://registry.npmjs.org
-
-      - name: Verify npm package
-        run: |
-          npm test --prefix packages/yarr-mcp
-          npm run check --prefix packages/yarr-mcp
-          npm pack --dry-run --json ./packages/yarr-mcp
-
-      - name: Check whether exact version is already published
-        id: published
-        shell: bash
-        env:
-          VERSION: ${{ needs.verify.outputs.version }}
-        run: |
-          set -euo pipefail
-          found="$(npm view "yarr-mcp@${VERSION}" version 2>/dev/null || true)"
-          if [[ "$found" == "$VERSION" ]]; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Publish exact npm version
-        if: steps.published.outputs.exists != 'true'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          # prepublishOnly verifies the release assets exist for this tag. They
-          # are still on the draft release at this point, so the public download
-          # URLs 404; consume the names the staging job already verified.
-          YARR_RELEASE_STAGED_ASSETS: ${{ needs.stage-release.outputs.staged_assets }}
-        run: npm publish --provenance --access public ./packages/yarr-mcp
-
-  finalize:
-    name: Publish verified GitHub Release
-    needs: [verify, stage-release, npm]
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    permissions:
-      contents: write
-    steps:
-      - name: Verify staged release and npm package
-        shell: bash
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERSION: ${{ needs.verify.outputs.version }}
-        run: |
-          set -euo pipefail
-          published="$(npm view "yarr-mcp@${VERSION}" version)"
-          [[ "$published" == "$VERSION" ]]
-
-          assets="$(gh release view "$RELEASE_TAG" \
-            --repo "$GITHUB_REPOSITORY" \
-            --json assets \
-            --jq '.assets[].name')"
-          for required in \
-            yarr-x86_64.tar.gz \
-            yarr-x86_64.tar.gz.sha256 \
-            yarr-windows-x86_64.tar.gz \
-            yarr-windows-x86_64.tar.gz.sha256 \
-            SHA256SUMS; do
-            grep -Fxq "$required" <<< "$assets" || {
-              echo "::error::Draft release is missing ${required}"
-              exit 1
-            }
-          done
-
-      - name: Publish draft release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release edit "$RELEASE_TAG" --draft=false --latest --repo "$GITHUB_REPOSITORY"
-
-  failure-summary:
-    name: Release recovery summary
-    if: ${{ always() && (needs.verify.result == 'failure' || needs.build.result == 'failure' || needs.stage-release.result == 'failure' || needs.npm.result == 'failure' || needs.finalize.result == 'failure') }}
-    needs: [verify, build, stage-release, npm, finalize]
-    runs-on: ubuntu-latest
-    permissions:
-      issues: write
-    steps:
-      - name: Record recovery procedure
-        run: |
-          {
-            echo "## Release staging stopped safely"
-            echo
-            echo "The GitHub Release remains a draft unless every stage succeeded."
-            echo "Fix the failed stage, then rerun this workflow with tag \`${RELEASE_TAG}\`."
-            echo "Published npm versions and uploaded assets are detected and reused."
-          } >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Create or reuse release incident issue
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          set -euo pipefail
-          existing="$(gh issue list \
-            --repo "$GITHUB_REPOSITORY" \
-            --state open \
-            --search 'Staged release failed in:title' \
-            --json number \
-            --jq '.[0].number // empty')"
-          body="Release ${RELEASE_TAG} stopped in staging: ${RUN_URL}\n\nRunbook: docs/runbooks/partial-release.md"
-          if [[ -n "$existing" ]]; then
-            gh issue comment "$existing" --repo "$GITHUB_REPOSITORY" --body "$body"
-          else
-            gh issue create --repo "$GITHUB_REPOSITORY" --title "Staged release failed" --body "$body"
-          fi
+    needs: [verify, github-release]
+    uses: dinglebear-ai/workflows/.github/workflows/npm-trusted-publish.yml@eb5f36cf517ffc949aca1c81e2ccbc71b5a85267
+    with:
+      checkout-ref: ${{ github.event.release.tag_name }}
+      expected-version: ${{ needs.verify.outputs.version }}
+      working-directory: packages/yarr-mcp
+      enable-cache: false
+      install-command: ""
+      verify-command: npm test && npm run check && node ../../scripts/sync-plugin-manifests.js --check && npm pack --dry-run --json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
   artifacts:
     name: Build hosted x86_64 artifacts
     needs: [verify]
-    uses: dinglebear-ai/workflows/.github/workflows/hosted-rust-platform-release.yml@542ea7b7e5ca2d4e21f3277bfcf158584fee90ec
+    uses: dinglebear-ai/workflows/.github/workflows/hosted-rust-platform-release.yml@66e64b9f31de7ac1f9aa8c9f87ede9bbec5eae1d
     with:
       checkout-ref: ${{ github.event.release.tag_name }}
       toolchain: "1.97.1"
@@ -93,7 +93,7 @@ jobs:
   github-release:
     name: Attach verified artifacts
     needs: [artifacts]
-    uses: dinglebear-ai/workflows/.github/workflows/github-release.yml@542ea7b7e5ca2d4e21f3277bfcf158584fee90ec
+    uses: dinglebear-ai/workflows/.github/workflows/github-release.yml@66e64b9f31de7ac1f9aa8c9f87ede9bbec5eae1d
     with:
       release-tag: ${{ github.event.release.tag_name }}
       artifact-pattern: yarr-*
@@ -101,7 +101,7 @@ jobs:
   npm:
     name: Publish npm launcher
     needs: [verify, github-release]
-    uses: dinglebear-ai/workflows/.github/workflows/npm-trusted-publish.yml@542ea7b7e5ca2d4e21f3277bfcf158584fee90ec
+    uses: dinglebear-ai/workflows/.github/workflows/npm-trusted-publish.yml@66e64b9f31de7ac1f9aa8c9f87ede9bbec5eae1d
     with:
       checkout-ref: ${{ github.event.release.tag_name }}
       expected-version: ${{ needs.verify.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
   artifacts:
     name: Build hosted x86_64 artifacts
     needs: [verify]
-    uses: dinglebear-ai/workflows/.github/workflows/hosted-rust-platform-release.yml@eb5f36cf517ffc949aca1c81e2ccbc71b5a85267
+    uses: dinglebear-ai/workflows/.github/workflows/hosted-rust-platform-release.yml@542ea7b7e5ca2d4e21f3277bfcf158584fee90ec
     with:
       checkout-ref: ${{ github.event.release.tag_name }}
       toolchain: "1.97.1"
@@ -93,7 +93,7 @@ jobs:
   github-release:
     name: Attach verified artifacts
     needs: [artifacts]
-    uses: dinglebear-ai/workflows/.github/workflows/github-release.yml@eb5f36cf517ffc949aca1c81e2ccbc71b5a85267
+    uses: dinglebear-ai/workflows/.github/workflows/github-release.yml@542ea7b7e5ca2d4e21f3277bfcf158584fee90ec
     with:
       release-tag: ${{ github.event.release.tag_name }}
       artifact-pattern: yarr-*
@@ -101,7 +101,7 @@ jobs:
   npm:
     name: Publish npm launcher
     needs: [verify, github-release]
-    uses: dinglebear-ai/workflows/.github/workflows/npm-trusted-publish.yml@eb5f36cf517ffc949aca1c81e2ccbc71b5a85267
+    uses: dinglebear-ai/workflows/.github/workflows/npm-trusted-publish.yml@542ea7b7e5ca2d4e21f3277bfcf158584fee90ec
     with:
       checkout-ref: ${{ github.event.release.tag_name }}
       expected-version: ${{ needs.verify.outputs.version }}

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -33,7 +33,7 @@ concurrency:
 jobs:
   advisories:
     name: Dependency Advisories
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, ci-pool-rust]
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -70,7 +70,8 @@ jobs:
     name: Notify dependency scan failure
     if: ${{ always() && needs.advisories.result == 'failure' }}
     needs: advisories
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, ci-pool-ops]
+    timeout-minutes: 10
     permissions:
       issues: write
     steps:

--- a/.github/workflows/unraid-plugin-ci.yml
+++ b/.github/workflows/unraid-plugin-ci.yml
@@ -30,7 +30,7 @@ env:
 jobs:
   verify:
     name: Test and reproduce committed package
-    runs-on: ubuntu-24.04
+    runs-on: [self-hosted, ci-pool-system]
     timeout-minutes: 30
     steps:
       - name: Check out source

--- a/.github/workflows/unraid-plugin-release.yml
+++ b/.github/workflows/unraid-plugin-release.yml
@@ -1,22 +1,14 @@
 name: Release Unraid plugin
 
 on:
-  push:
-    tags:
-      - "unraid-v*"
-  workflow_dispatch:
-    inputs:
-      release_tag:
-        description: Existing package tag in unraid-vVERSION-BUILD form
-        required: true
-        type: string
-        default: "unraid-v2.1.0-1"
+  release:
+    types: [published]
 
 permissions:
   contents: read
 
 concurrency:
-  group: unraid-plugin-release-${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref_name }}
+  group: unraid-plugin-release-${{ github.event.release.tag_name }}
   cancel-in-progress: false
 
 env:
@@ -25,6 +17,7 @@ env:
 jobs:
   prepare:
     name: Resolve and validate frozen release
+    if: startsWith(github.event.release.tag_name, 'unraid-v')
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     outputs:
@@ -36,7 +29,7 @@ jobs:
       package_sha256: ${{ steps.identity.outputs.package_sha256 }}
       upstream_sha256: ${{ steps.identity.outputs.upstream_sha256 }}
     env:
-      PACKAGE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref_name }}
+      PACKAGE_TAG: ${{ github.event.release.tag_name }}
     steps:
       - name: Resolve immutable package tag
         id: resolve

--- a/docs/MCP_SCHEMA.md
+++ b/docs/MCP_SCHEMA.md
@@ -1,6 +1,6 @@
 ---
-title: "MCP Schema Contract"
-created: 2026-05-22
+title: MCP Schema Contract
+created: 2026-07-30
 updated: 2026-07-30
 ---
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -12,19 +12,19 @@ Maintenance and automation scripts for the template. Shell scripts are written f
 | `bump-version.sh` | Update version-bearing files from the `Cargo.toml` version. |
 | `check-blob-size.py` | Block unexpectedly large changed blobs. |
 | `check-coupled-files.sh` | Warn when files that normally change together drift. The schema/docs pair defers to `check-schema-docs.py --check`, so formatting-only edits do not false-positive. |
-| `check-dist-contract.js` | Verify the npm launcher package's published file contract. |
+| `check-dist-contract.js` | Verify the npm launcher package's published file contract, including the x86_64-only release asset contract. |
 | `check-doc-links.py` | Validate every tracked Markdown relative link and heading anchor. |
 | `check-dependency-updates.sh` | Report lockfile-compatible and latest dependency updates. |
 | `check-file-size.sh` | Pre-commit source file size budget. |
 | `check-plugin-hook-contract.py` | Audit the binary-owned `setup plugin-hook` JSON contract across Rust MCP servers. |
 | `check-runtime-current.sh` | Detect stale Docker/systemd runtimes. |
-| `check-schema-docs.py` | Generate/check `docs/MCP_SCHEMA.md` and action docs. |
+| `check-schema-docs.py` | Generate/check `docs/MCP_SCHEMA.md` and action docs, including the required documentation frontmatter. |
 | `check-security-exceptions.sh` | Verify recorded security exceptions are still justified and unexpired. |
 | `check-version-sync.sh` | Check version consistency. |
 | `generate-cli.sh` | Generate a standalone CLI for this server via mcporter (requires running server). |
 | `install.sh` | Install the latest GitHub Release binary and create a `yarr` symlink. |
-| `kache-gate.sh` | Fail the build when the kache compiler cache silently degrades: snapshot counters with `--baseline` before the build, diff after, enforce hit-rate floor / remote-hit / daemon thresholds from `KACHE_GATE_*` env. kache is fail-open, so this gate is the only red signal. Fleet-copied from soma; keep pure ASCII. |
-| `kache-gate-selftest.sh` | Prove `kache-gate.sh` actually rejects a degraded build (cold all-miss profile) and accepts a clean one, so the gate cannot rot into a no-op. |
+| `kache-gate.sh` | Fail the build when the kache compiler cache silently degrades: snapshot counters with `--baseline` before the build, diff after, enforce hit-rate floor / remote-hit / daemon thresholds from `KACHE_GATE_*` env. The gate ignores the intermediate aggregate counter and derives the enforced totals from individual hit/miss deltas. kache is fail-open, so this gate is the only red signal. Fleet-copied from soma; keep pure ASCII. |
+| `kache-gate-selftest.sh` | Prove `kache-gate.sh` actually rejects a degraded build (cold all-miss profile) and accepts a clean one. Optional gate arguments are parsed into a Bash array so test flags retain argument boundaries. |
 | `live-read-smoke.sh` | Run legacy guarded shart read-only CLI and upstream `get` checks. |
 | `pre-release-check.sh` | Full release-readiness gate, including schema and runtime contract drift checks. |
 | `refresh-docs.sh` | Refresh ignored reference docs with Axon/Repomix. |
@@ -36,7 +36,7 @@ Maintenance and automation scripts for the template. Shell scripts are written f
 | `test-mcp-auth.sh` | Smoke-test HTTP MCP bearer auth. |
 | `test-plugin-distribution.js` | Assert standalone/bundled skill parity, pinned launchers, and that every plugin ships its lifecycle hooks. |
 | `test-plugin-http.js` | Smoke-test the plugin's HTTP surface. |
-| `test-template-features.sh` | Fast template invariant smoke tests. |
+| `test-template-features.sh` | Fast template invariant smoke tests, including the centralized hosted container-release security contract and immutable production Compose image requirements. |
 | `validate-plugin-layout.sh` | Validate Claude/Codex/Gemini plugin package layout. |
 | `web-watch.sh` | Watch `apps/web` for changes and rebuild on save (requires watchexec). |
 
@@ -157,7 +157,7 @@ just schema-docs
 just schema-docs-check
 ```
 
-Treats the action registry as canonical and verifies schema docs, help text, README, and plugin skill mentions. Generated output lives in `docs/MCP_SCHEMA.md`. Since the descriptor-table refactor, `ACTION_SPECS` lives in `src/actions/registry.rs` (with `src/actions.rs` a thin facade), so the checker scans the `src/actions/` tree recursively rather than the single `src/actions.rs` file. The required-params contract is `service`/`path` for the generic passthroughs: there is no `confirm` param anywhere, and the destructive `api_delete` runs immediately on the CLI/Code Mode — on MCP it's instead gated out-of-band via elicitation (not via a required schema param).
+Treats the action registry as canonical and verifies schema docs, help text, README, and plugin skill mentions. Generated output lives in `docs/MCP_SCHEMA.md` and carries the fleet-standard `title`, `created`, and `updated` frontmatter. Since the descriptor-table refactor, `ACTION_SPECS` lives in `src/actions/registry.rs` (with `src/actions.rs` a thin facade), so the checker scans the `src/actions/` tree recursively rather than the single `src/actions.rs` file. The required-params contract is `service`/`path` for the generic passthroughs: there is no `confirm` param anywhere, and the destructive `api_delete` runs immediately on the CLI/Code Mode — on MCP it's instead gated out-of-band via elicitation (not via a required schema param).
 
 ### `build-web.sh`
 

--- a/scripts/check-dist-contract.js
+++ b/scripts/check-dist-contract.js
@@ -89,33 +89,33 @@ for (const target of contract.targets) {
     asset: target.asset,
     binary: target.archiveBinary,
   });
-  const matrixText = "- target: " + target.rustTarget + "\n            arch: " + target.releaseMatrixArch + "\n            ext: \"" + target.exeExtension + "\"";
-  assert.ok(workflow.includes(matrixText), "release matrix is missing " + target.rustTarget);
+  assert.ok(workflow.includes(target.rustTarget), "release matrix is missing " + target.rustTarget);
+  assert.ok(workflow.includes(target.asset), "release packaging is missing " + target.asset);
   assert.ok(installer.includes(target.asset), "shell installer is missing " + target.asset);
 }
 for (const required of [
   "Verify coupled versions",
-  "sha256sum -- *.tar.gz > SHA256SUMS",
-  "SHA256SUMS",
+  "hosted-rust-platform-release.yml@eb5f36cf517ffc949aca1c81e2ccbc71b5a85267",
+  "github-release.yml@eb5f36cf517ffc949aca1c81e2ccbc71b5a85267",
+  "npm-trusted-publish.yml@eb5f36cf517ffc949aca1c81e2ccbc71b5a85267",
   "npm test",
   "npm run check",
-  "npm publish --provenance",
-  'gh release view "$RELEASE_TAG"',
-  '--repo "$GITHUB_REPOSITORY"',
+  "release:",
+  "types: [published]",
 ]) {
   assert.ok(workflow.includes(required), "release workflow is missing contract step: " + required);
 }
-assert.equal(
-  workflow.includes('releases/tags/${RELEASE_TAG}'),
-  false,
-  "draft release discovery must use gh release view rather than the public tag API",
-);
+assert.equal(workflow.includes("self-hosted"), false, "heavy release jobs must be GitHub-hosted");
 
 const dockerWorkflow = read(".github/workflows/docker-publish.yml");
 const composeCommon = read("docker-compose.common.yml");
 const composeDev = read("docker-compose.yml");
 const composeProd = read("docker-compose.prod.yml");
-assert.ok(dockerWorkflow.includes("IMAGE_NAME: ghcr.io/dinglebear-ai/yarr"));
+assert.ok(dockerWorkflow.includes("image: ghcr.io/dinglebear-ai/yarr"));
+assert.ok(
+  dockerWorkflow.includes("hosted-container-release.yml@eb5f36cf517ffc949aca1c81e2ccbc71b5a85267"),
+  "container publication must use the pinned workflow library",
+);
 assert.ok(composeProd.includes("${YARR_MCP_IMAGE:?Set YARR_MCP_IMAGE"));
 assert.ok(composeProd.includes("file: docker-compose.common.yml"));
 assert.ok(composeDev.includes("file: docker-compose.common.yml"));

--- a/scripts/check-dist-contract.js
+++ b/scripts/check-dist-contract.js
@@ -95,9 +95,9 @@ for (const target of contract.targets) {
 }
 for (const required of [
   "Verify coupled versions",
-  "hosted-rust-platform-release.yml@542ea7b7e5ca2d4e21f3277bfcf158584fee90ec",
-  "github-release.yml@542ea7b7e5ca2d4e21f3277bfcf158584fee90ec",
-  "npm-trusted-publish.yml@542ea7b7e5ca2d4e21f3277bfcf158584fee90ec",
+  "hosted-rust-platform-release.yml@66e64b9f31de7ac1f9aa8c9f87ede9bbec5eae1d",
+  "github-release.yml@66e64b9f31de7ac1f9aa8c9f87ede9bbec5eae1d",
+  "npm-trusted-publish.yml@66e64b9f31de7ac1f9aa8c9f87ede9bbec5eae1d",
   "npm test",
   "npm run check",
   "release:",
@@ -113,7 +113,7 @@ const composeDev = read("docker-compose.yml");
 const composeProd = read("docker-compose.prod.yml");
 assert.ok(dockerWorkflow.includes("image: ghcr.io/dinglebear-ai/yarr"));
 assert.ok(
-  dockerWorkflow.includes("hosted-container-release.yml@542ea7b7e5ca2d4e21f3277bfcf158584fee90ec"),
+  dockerWorkflow.includes("hosted-container-release.yml@66e64b9f31de7ac1f9aa8c9f87ede9bbec5eae1d"),
   "container publication must use the pinned workflow library",
 );
 assert.ok(composeProd.includes("${YARR_MCP_IMAGE:?Set YARR_MCP_IMAGE"));

--- a/scripts/check-dist-contract.js
+++ b/scripts/check-dist-contract.js
@@ -95,9 +95,9 @@ for (const target of contract.targets) {
 }
 for (const required of [
   "Verify coupled versions",
-  "hosted-rust-platform-release.yml@eb5f36cf517ffc949aca1c81e2ccbc71b5a85267",
-  "github-release.yml@eb5f36cf517ffc949aca1c81e2ccbc71b5a85267",
-  "npm-trusted-publish.yml@eb5f36cf517ffc949aca1c81e2ccbc71b5a85267",
+  "hosted-rust-platform-release.yml@542ea7b7e5ca2d4e21f3277bfcf158584fee90ec",
+  "github-release.yml@542ea7b7e5ca2d4e21f3277bfcf158584fee90ec",
+  "npm-trusted-publish.yml@542ea7b7e5ca2d4e21f3277bfcf158584fee90ec",
   "npm test",
   "npm run check",
   "release:",
@@ -113,7 +113,7 @@ const composeDev = read("docker-compose.yml");
 const composeProd = read("docker-compose.prod.yml");
 assert.ok(dockerWorkflow.includes("image: ghcr.io/dinglebear-ai/yarr"));
 assert.ok(
-  dockerWorkflow.includes("hosted-container-release.yml@eb5f36cf517ffc949aca1c81e2ccbc71b5a85267"),
+  dockerWorkflow.includes("hosted-container-release.yml@542ea7b7e5ca2d4e21f3277bfcf158584fee90ec"),
   "container publication must use the pinned workflow library",
 );
 assert.ok(composeProd.includes("${YARR_MCP_IMAGE:?Set YARR_MCP_IMAGE"));

--- a/scripts/check-schema-docs.py
+++ b/scripts/check-schema-docs.py
@@ -91,6 +91,12 @@ def render() -> str:
     actions = extract_actions()
     scopes = extract_scope_for_actions()
     lines = [
+        "---",
+        "title: MCP Schema Contract",
+        "created: 2026-07-30",
+        "updated: 2026-07-30",
+        "---",
+        "",
         "# MCP Schema Contract",
         "",
         "Generated from `src/actions/` and checked against the schema, README, skill docs, help text, and scope routing.",

--- a/scripts/kache-gate-selftest.sh
+++ b/scripts/kache-gate-selftest.sh
@@ -22,9 +22,13 @@ baseline="$probe/baseline.json"
 # Env assignments go in "$@" (before the script); script flags go in $GATE_ARGS
 # (after it). Passing a flag through "$@" would make `env` consume it.
 gate_run() {
+  local gate_args=()
+  if [ -n "${GATE_ARGS:-}" ]; then
+    read -r -a gate_args <<< "$GATE_ARGS"
+  fi
   set +e
   env KACHE_CACHE_DIR="$probe/store" KACHE_GATE_ROOT="$probe/cold" \
-      KACHE_GATE_BASELINE="$baseline" "$@" "$gate" ${GATE_ARGS:-}
+      KACHE_GATE_BASELINE="$baseline" "$@" "$gate" "${gate_args[@]}"
   local rc=$?
   set -e
   return "$rc"

--- a/scripts/kache-gate.sh
+++ b/scripts/kache-gate.sh
@@ -93,7 +93,7 @@ else
   echo "kache-gate: WARNING: not this build. Run 'kache-gate.sh --baseline' before the build." >&2
 fi
 
-read -r d_local d_prefetch d_remote d_miss d_err d_fall d_total d_saved <<EOJ
+read -r d_local d_prefetch d_remote d_miss d_err d_fall _d_total d_saved <<EOJ
 $(jq -rn --argjson a "$after" --argjson b "$before" '
   [ ($a.local_hits    - $b.local_hits),
     ($a.prefetch_hits - $b.prefetch_hits),

--- a/scripts/test-template-features.sh
+++ b/scripts/test-template-features.sh
@@ -103,7 +103,7 @@ expect_fail "documentation link checker rejects missing targets" \
   python3 scripts/check-doc-links.py --root "$TMPDIR_ROOT/link-repo"
 
 expect_ok "container security stays on the fleet release workflow" bash -c '
-  grep -Fq "dinglebear-ai/workflows/.github/workflows/hosted-container-release.yml@542ea7b7e5ca2d4e21f3277bfcf158584fee90ec" \
+  grep -Fq "dinglebear-ai/workflows/.github/workflows/hosted-container-release.yml@66e64b9f31de7ac1f9aa8c9f87ede9bbec5eae1d" \
     .github/workflows/docker-publish.yml
 '
 

--- a/scripts/test-template-features.sh
+++ b/scripts/test-template-features.sh
@@ -102,9 +102,9 @@ mkdir -p "$TMPDIR_ROOT/link-repo/scripts"
 expect_fail "documentation link checker rejects missing targets" \
   python3 scripts/check-doc-links.py --root "$TMPDIR_ROOT/link-repo"
 
-expect_ok "Trivy SARIF keeps the HIGH/CRITICAL gate" bash -c '
-  grep -Eq "^[[:space:]]+severity: CRITICAL,HIGH$" .github/workflows/docker-publish.yml
-  grep -Eq "^[[:space:]]+limit-severities-for-sarif: true$" .github/workflows/docker-publish.yml
+expect_ok "container security stays on the fleet release workflow" bash -c '
+  grep -Fq "dinglebear-ai/workflows/.github/workflows/hosted-container-release.yml@542ea7b7e5ca2d4e21f3277bfcf158584fee90ec" \
+    .github/workflows/docker-publish.yml
 '
 
 mkdir -p "$TMPDIR_ROOT/compose"
@@ -115,14 +115,17 @@ YARR_SONARR_URL=http://sonarr:8989
 YARR_SONARR_API_KEY=test
 YARR_MCP_NO_AUTH=true
 EOF
+# shellcheck disable=SC2016 # The inner shell expands these fixture variables.
 expect_ok "local Compose does not require the production image variable" bash -c '
   cd "$1"
   env -u YARR_MCP_IMAGE docker compose -f docker-compose.yml config --quiet
 ' _ "$TMPDIR_ROOT/compose"
+# shellcheck disable=SC2016 # The inner shell expands these fixture variables.
 expect_fail "production Compose rejects a missing immutable image" bash -c '
   cd "$1"
   env -u YARR_MCP_IMAGE docker compose -f docker-compose.prod.yml config --quiet
 ' _ "$TMPDIR_ROOT/compose"
+# shellcheck disable=SC2016 # The inner shell expands these fixture variables.
 expect_ok "production Compose accepts an immutable image digest" bash -c '
   cd "$1"
   YARR_MCP_IMAGE=ghcr.io/dinglebear-ai/yarr@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef \

--- a/unraid-plugin/tests/workflow_contract.py
+++ b/unraid-plugin/tests/workflow_contract.py
@@ -148,7 +148,10 @@ def check_ci(workflow: dict[str, Any]) -> None:
         require("unraid-plugin/**" in paths, f"CI {trigger} is not path-scoped to unraid-plugin")
     verify = jobs(workflow).get("verify")
     require(isinstance(verify, dict), "CI verify job is missing")
-    require(verify.get("runs-on") == "ubuntu-24.04", "CI runner generation is not fixed")
+    require(
+        verify.get("runs-on") == ["self-hosted", "ci-pool-system"],
+        "CI must use the runner-farm system pool",
+    )
 
     api = named_step(verify, "Test and build API extension", "CI.verify")
     web = named_step(verify, "Test and build settings and dashboard elements", "CI.verify")
@@ -185,14 +188,20 @@ def check_release(workflow: dict[str, Any]) -> None:
     }
     check_token_scope(workflow, allowed_tokens, "release")
     event = triggers(workflow)
-    require("workflow_dispatch" in event, "release workflow lacks manual trigger")
-    require("unraid-v*" in event.get("push", {}).get("tags", []), "release workflow does not isolate unraid-v* tags")
+    require(
+        event.get("release", {}).get("types") == ["published"],
+        "release workflow must run only after a GitHub Release is published",
+    )
 
     release_jobs = jobs(workflow)
     prepare = release_jobs.get("prepare")
     build = release_jobs.get("build")
     publish = release_jobs.get("publish")
     require(all(isinstance(job, dict) for job in (prepare, build, publish)), "release jobs are incomplete")
+    require(
+        prepare.get("if") == "startsWith(github.event.release.tag_name, 'unraid-v')",
+        "release workflow does not isolate unraid-v tags",
+    )
     require(build.get("needs") == "prepare", "release build job must depend on prepare")
     publish_needs = publish.get("needs")
     require(


### PR DESCRIPTION
## Summary
- route fast Linux CI through typed runner-farm pools
- move heavy artifact builds to release.published on GitHub-hosted x86_64
- consume immutable reusable workflows from dinglebear-ai/workflows
- preserve repository-specific tests, security, and release contracts
- remove forbidden ARM/emulation workflow paths

## Validation
- actionlint
- fleet contract/policy checks
- cargo fmt
- repository-specific workflow contract checks
- zero ARM/aarch64/QEMU/multiplatform workflow scan