### PR TITLE
ci: stop release-building in CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,7 +47,7 @@ jobs:
           restore-keys: ${{ github.repository }}-codeql-
 
       - name: Build
-        run: cargo build --release
+        run: cargo build --locked
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0


### PR DESCRIPTION
CodeQL only needs a deterministic indexed build, not a release artifact. Replace cargo build --release with cargo build --locked. Verified with Actionlint, the fleet contract, git diff hygiene, and the exact replacement build.