### PR TITLE
fix: publish scoped npm launcher

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -49,7 +49,7 @@ jobs:
 
       # release-please bumps JSON scalar version fields (package.json, server.json)
       # but cannot template the version embedded in launcher-arg strings such as
-      # `["-y", "@dinglebear/yarr-mcp@1.1.1", "mcp"]`. Re-couple those pins on the open release
+      # `["-y", "@dinglebear/yarr@1.1.1", "mcp"]`. Re-couple those pins on the open release
       # PR so its CI (coupled-version contract, plugin_contract) stays green.
       - name: Check out release PR branch
         if: ${{ steps.release.outputs.pr }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -49,7 +49,7 @@ jobs:
 
       # release-please bumps JSON scalar version fields (package.json, server.json)
       # but cannot template the version embedded in launcher-arg strings such as
-      # `["-y", "yarr-mcp@1.1.1", "mcp"]`. Re-couple those pins on the open release
+      # `["-y", "@dinglebear/yarr-mcp@1.1.1", "mcp"]`. Re-couple those pins on the open release
       # PR so its CI (coupled-version contract, plugin_contract) stays green.
       - name: Check out release PR branch
         if: ${{ steps.release.outputs.pr }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,9 +68,9 @@ jobs:
             fi
           done
           jq -e '
-            .name == "ai.dinglebear/yarr-mcp" and
+            .name == "ai.dinglebear/yarr" and
             .packages[0].registryType == "npm" and
-            .packages[0].identifier == "yarr-mcp" and
+            .packages[0].identifier == "@dinglebear/yarr-mcp" and
             .packages[0].transport.type == "stdio"
           ' server.json >/dev/null || {
             echo "::error::server.json distribution identity is not the reviewed npm stdio contract"
@@ -191,9 +191,9 @@ jobs:
             --json isDraft \
             --jq '.isDraft' 2>/dev/null)"; then
             if [[ "$is_draft" != "true" ]]; then
-              published="$(npm view "yarr-mcp@${VERSION}" version 2>/dev/null || true)"
+              published="$(npm view "@dinglebear/yarr-mcp@${VERSION}" version 2>/dev/null || true)"
               [[ "$published" == "$VERSION" ]] || {
-                echo "::error::GitHub Release is public before npm yarr-mcp@${VERSION} exists"
+                echo "::error::GitHub Release is public before npm @dinglebear/yarr-mcp@${VERSION} exists"
                 exit 1
               }
               echo "public=true" >> "$GITHUB_OUTPUT"
@@ -250,6 +250,11 @@ jobs:
           node-version: 22
           registry-url: https://registry.npmjs.org
 
+      - name: Validate npm publication identity
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm whoami >/dev/null
+
       - name: Verify npm package
         run: |
           npm test --prefix packages/yarr-mcp
@@ -263,7 +268,7 @@ jobs:
           VERSION: ${{ needs.verify.outputs.version }}
         run: |
           set -euo pipefail
-          found="$(npm view "yarr-mcp@${VERSION}" version 2>/dev/null || true)"
+          found="$(npm view "@dinglebear/yarr-mcp@${VERSION}" version 2>/dev/null || true)"
           if [[ "$found" == "$VERSION" ]]; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
           else
@@ -295,7 +300,7 @@ jobs:
           VERSION: ${{ needs.verify.outputs.version }}
         run: |
           set -euo pipefail
-          published="$(npm view "yarr-mcp@${VERSION}" version)"
+          published="$(npm view "@dinglebear/yarr-mcp@${VERSION}" version)"
           [[ "$published" == "$VERSION" ]]
 
           assets="$(gh release view "$RELEASE_TAG" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
           jq -e '
             .name == "ai.dinglebear/yarr" and
             .packages[0].registryType == "npm" and
-            .packages[0].identifier == "@dinglebear/yarr-mcp" and
+            .packages[0].identifier == "@dinglebear/yarr" and
             .packages[0].transport.type == "stdio"
           ' server.json >/dev/null || {
             echo "::error::server.json distribution identity is not the reviewed npm stdio contract"
@@ -191,9 +191,9 @@ jobs:
             --json isDraft \
             --jq '.isDraft' 2>/dev/null)"; then
             if [[ "$is_draft" != "true" ]]; then
-              published="$(npm view "@dinglebear/yarr-mcp@${VERSION}" version 2>/dev/null || true)"
+              published="$(npm view "@dinglebear/yarr@${VERSION}" version 2>/dev/null || true)"
               [[ "$published" == "$VERSION" ]] || {
-                echo "::error::GitHub Release is public before npm @dinglebear/yarr-mcp@${VERSION} exists"
+                echo "::error::GitHub Release is public before npm @dinglebear/yarr@${VERSION} exists"
                 exit 1
               }
               echo "public=true" >> "$GITHUB_OUTPUT"
@@ -268,7 +268,7 @@ jobs:
           VERSION: ${{ needs.verify.outputs.version }}
         run: |
           set -euo pipefail
-          found="$(npm view "@dinglebear/yarr-mcp@${VERSION}" version 2>/dev/null || true)"
+          found="$(npm view "@dinglebear/yarr@${VERSION}" version 2>/dev/null || true)"
           if [[ "$found" == "$VERSION" ]]; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
           else
@@ -300,7 +300,7 @@ jobs:
           VERSION: ${{ needs.verify.outputs.version }}
         run: |
           set -euo pipefail
-          published="$(npm view "@dinglebear/yarr-mcp@${VERSION}" version)"
+          published="$(npm view "@dinglebear/yarr@${VERSION}" version)"
           [[ "$published" == "$VERSION" ]]
 
           assets="$(gh release view "$RELEASE_TAG" \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ Rust MCP and CLI server for a media automation fleet. It wraps **11 service kind
 | Edition / MSRV | 2024 / Rust 1.97.1 |
 | MCP crate | `rmcp = "=3.0.0-beta.2"` via `[workspace.dependencies]` (`server`, `macros`, `transport-streamable-http-server`, `transport-io`, `schemars`, `elicitation`) |
 | Service port | `40070` (`YARR_MCP_PORT`) |
-| npm launcher | `yarr-mcp@<Cargo version>`, pinned — never `latest` |
+| npm launcher | `@dinglebear/yarr-mcp@<Cargo version>`, pinned — never `latest` |
 
 The MCP surface is a single `yarr` tool that runs Code Mode (the `codemode` action). The 6 spec-backed services (sonarr/radarr/prowlarr/overseerr/jellyfin/plex) are reached through **generated** per-service callables (from vendored OpenAPI specs); download/stats/subtitles/trace keep curated commands; every service also has `service_status` + the `api_get/post/put/delete` generic passthrough. Services are declared via `YARR_SERVICES` plus per-service env (see Environment variables).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ Rust MCP and CLI server for a media automation fleet. It wraps **11 service kind
 | Edition / MSRV | 2024 / Rust 1.97.1 |
 | MCP crate | `rmcp = "=3.0.0-beta.2"` via `[workspace.dependencies]` (`server`, `macros`, `transport-streamable-http-server`, `transport-io`, `schemars`, `elicitation`) |
 | Service port | `40070` (`YARR_MCP_PORT`) |
-| npm launcher | `@dinglebear/yarr-mcp@<Cargo version>`, pinned — never `latest` |
+| npm launcher | `@dinglebear/yarr@<Cargo version>`, pinned — never `latest` |
 
 The MCP surface is a single `yarr` tool that runs Code Mode (the `codemode` action). The 6 spec-backed services (sonarr/radarr/prowlarr/overseerr/jellyfin/plex) are reached through **generated** per-service callables (from vendored OpenAPI specs); download/stats/subtitles/trace keep curated commands; every service also has `service_status` + the `api_get/post/put/delete` generic passthrough. Services are declared via `YARR_SERVICES` plus per-service env (see Environment variables).
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Production Compose deployments select that image by immutable manifest digest.
 Plugin naming is intentionally split:
 
 - `yarr` is the full MCP server plugin. It launches the repository-coupled
-  `@dinglebear/yarr-mcp` npm package over stdio and includes every per-service fallback
+  `@dinglebear/yarr` npm package over stdio and includes every per-service fallback
   skill; it does not commit a platform-specific binary.
 - `sonarr`, `radarr`, `prowlarr`, `overseerr`, `sabnzbd`, `qbittorrent`, `plex`,
   `jellyfin`, `tautulli`, `tracearr`, and `bazarr` are skills-only plugins with
@@ -104,16 +104,16 @@ before using it:
 
 ```bash
 YARR_VERSION=2.1.0
-npm view "@dinglebear/yarr-mcp@${YARR_VERSION}" version
-npx -y "@dinglebear/yarr-mcp@${YARR_VERSION}" mcp
+npm view "@dinglebear/yarr@${YARR_VERSION}" version
+npx -y "@dinglebear/yarr@${YARR_VERSION}" mcp
 # Or, after the same availability check:
-npm i -g "@dinglebear/yarr-mcp@${YARR_VERSION}"
+npm i -g "@dinglebear/yarr@${YARR_VERSION}"
 ```
 
-Never use an unpinned `npx @dinglebear/yarr-mcp` or `@latest` in an MCP manifest: npm may
+Never use an unpinned `npx @dinglebear/yarr` or `@latest` in an MCP manifest: npm may
 still point at an older launcher after a partial release. At the time of this
 documentation refresh, GitHub release `v2.1.0` is public but
-`@dinglebear/yarr-mcp@2.1.0` is not yet available on npm; recovery is tracked in
+`@dinglebear/yarr@2.1.0` is not yet available on npm; recovery is tracked in
 [issue #80](https://github.com/dinglebear-ai/yarr/issues/80). Use the native
 installer, a verified release archive, a source build, or the independent
 Unraid package until the exact npm version resolves.
@@ -182,7 +182,7 @@ The full plugin starts the exact launcher pinned in its manifest. Confirm that
 version exists before installing or debugging the plugin:
 
 ```bash
-npm view @dinglebear/yarr-mcp@2.1.0 version
+npm view @dinglebear/yarr@2.1.0 version
 ```
 
 Until issue #80 is resolved, the full plugin cannot start from npm. The
@@ -538,8 +538,8 @@ curl -fsSL https://raw.githubusercontent.com/dinglebear-ai/yarr/main/install.sh 
 yarr --version
 
 YARR_VERSION=2.1.0
-npm view "@dinglebear/yarr-mcp@${YARR_VERSION}" version
-npx -y "@dinglebear/yarr-mcp@${YARR_VERSION}" mcp
+npm view "@dinglebear/yarr@${YARR_VERSION}" version
+npx -y "@dinglebear/yarr@${YARR_VERSION}" mcp
 ```
 
 Documentation changes also require the repository-local link and anchor guard:
@@ -597,7 +597,7 @@ gateway when exposed outside loopback.
   `codemode.describe(...)`; generated names follow upstream OpenAPI operation
   IDs after normalization.
 - `npm` or the full plugin reports `E404`/`ETARGET`: check the exact pinned
-  launcher with `npm view @dinglebear/yarr-mcp@2.1.0 version`. Do not fall back to unpinned
+  launcher with `npm view @dinglebear/yarr@2.1.0 version`. Do not fall back to unpinned
   `latest`; use the native binary while issue #80 is open.
 
 ## Related Servers

--- a/README.md
+++ b/README.md
@@ -46,13 +46,13 @@ This repository is published at `github.com/dinglebear-ai/yarr`.
 The Rust package and installed binary are both `yarr`. The npm launcher package
 is `yarr-mcp` because the shorter `yarr` name is occupied on npm; installing the
 launcher still gives you a `yarr` command. The MCP registry name is
-`ai.dinglebear/yarr-mcp`, and Docker images use `ghcr.io/dinglebear-ai/yarr`.
+`ai.dinglebear/yarr`, and Docker images use `ghcr.io/dinglebear-ai/yarr`.
 Production Compose deployments select that image by immutable manifest digest.
 
 Plugin naming is intentionally split:
 
 - `yarr` is the full MCP server plugin. It launches the repository-coupled
-  `yarr-mcp` npm package over stdio and includes every per-service fallback
+  `@dinglebear/yarr-mcp` npm package over stdio and includes every per-service fallback
   skill; it does not commit a platform-specific binary.
 - `sonarr`, `radarr`, `prowlarr`, `overseerr`, `sabnzbd`, `qbittorrent`, `plex`,
   `jellyfin`, `tautulli`, `tracearr`, and `bazarr` are skills-only plugins with
@@ -104,16 +104,16 @@ before using it:
 
 ```bash
 YARR_VERSION=2.1.0
-npm view "yarr-mcp@${YARR_VERSION}" version
-npx -y "yarr-mcp@${YARR_VERSION}" mcp
+npm view "@dinglebear/yarr-mcp@${YARR_VERSION}" version
+npx -y "@dinglebear/yarr-mcp@${YARR_VERSION}" mcp
 # Or, after the same availability check:
-npm i -g "yarr-mcp@${YARR_VERSION}"
+npm i -g "@dinglebear/yarr-mcp@${YARR_VERSION}"
 ```
 
-Never use an unpinned `npx yarr-mcp` or `@latest` in an MCP manifest: npm may
+Never use an unpinned `npx @dinglebear/yarr-mcp` or `@latest` in an MCP manifest: npm may
 still point at an older launcher after a partial release. At the time of this
 documentation refresh, GitHub release `v2.1.0` is public but
-`yarr-mcp@2.1.0` is not yet available on npm; recovery is tracked in
+`@dinglebear/yarr-mcp@2.1.0` is not yet available on npm; recovery is tracked in
 [issue #80](https://github.com/dinglebear-ai/yarr/issues/80). Use the native
 installer, a verified release archive, a source build, or the independent
 Unraid package until the exact npm version resolves.
@@ -182,7 +182,7 @@ The full plugin starts the exact launcher pinned in its manifest. Confirm that
 version exists before installing or debugging the plugin:
 
 ```bash
-npm view yarr-mcp@2.1.0 version
+npm view @dinglebear/yarr-mcp@2.1.0 version
 ```
 
 Until issue #80 is resolved, the full plugin cannot start from npm. The
@@ -483,7 +483,7 @@ not patched by hand:
   the git commit SHA.
 - The npm package version and the GitHub Release tag must match.
 - `server.json` must name the exact `yarr-mcp` npm version and stdio launch
-  contract under the `ai.dinglebear/yarr-mcp` registry identity.
+  contract under the `ai.dinglebear/yarr` registry identity.
 - The Docker image path is `ghcr.io/dinglebear-ai/yarr`; production deployment uses a
   promoted immutable `@sha256:` digest.
 
@@ -538,8 +538,8 @@ curl -fsSL https://raw.githubusercontent.com/dinglebear-ai/yarr/main/install.sh 
 yarr --version
 
 YARR_VERSION=2.1.0
-npm view "yarr-mcp@${YARR_VERSION}" version
-npx -y "yarr-mcp@${YARR_VERSION}" mcp
+npm view "@dinglebear/yarr-mcp@${YARR_VERSION}" version
+npx -y "@dinglebear/yarr-mcp@${YARR_VERSION}" mcp
 ```
 
 Documentation changes also require the repository-local link and anchor guard:
@@ -597,7 +597,7 @@ gateway when exposed outside loopback.
   `codemode.describe(...)`; generated names follow upstream OpenAPI operation
   IDs after normalization.
 - `npm` or the full plugin reports `E404`/`ETARGET`: check the exact pinned
-  launcher with `npm view yarr-mcp@2.1.0 version`. Do not fall back to unpinned
+  launcher with `npm view @dinglebear/yarr-mcp@2.1.0 version`. Do not fall back to unpinned
   `latest`; use the native binary while issue #80 is open.
 
 ## Related Servers

--- a/dist.targets.json
+++ b/dist.targets.json
@@ -4,8 +4,8 @@
   "identity": {
     "binaryName": "yarr",
     "canonicalRepo": "dinglebear-ai/yarr",
-    "npmPackage": "yarr-mcp",
-    "mcpName": "ai.dinglebear/yarr-mcp"
+    "npmPackage": "@dinglebear/yarr-mcp",
+    "mcpName": "ai.dinglebear/yarr"
   },
   "versionContract": {
     "mode": "coupled-release-tag",

--- a/dist.targets.json
+++ b/dist.targets.json
@@ -4,7 +4,7 @@
   "identity": {
     "binaryName": "yarr",
     "canonicalRepo": "dinglebear-ai/yarr",
-    "npmPackage": "@dinglebear/yarr-mcp",
+    "npmPackage": "@dinglebear/yarr",
     "mcpName": "ai.dinglebear/yarr"
   },
   "versionContract": {

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -43,7 +43,7 @@ and the command parser for supported flags.
 |---|---|---|
 | Linux x86-64 | Native installer | Verifies release archive and SHA-256; installs to `~/.local/bin` |
 | Contributor checkout | `cargo build --release --locked` | Uses committed Rust lockfile |
-| Node-managed client | Exact `@dinglebear/yarr-mcp@VERSION` | Use only after `npm view` proves that exact version exists |
+| Node-managed client | Exact `@dinglebear/yarr@VERSION` | Use only after `npm view` proves that exact version exists |
 | Container | Immutable GHCR digest | Never deploy mutable `latest` as rollback state |
 | Unraid | Classic `.plg` package | Independent checksummed `unraid-vVERSION-BUILD` release |
 
@@ -58,14 +58,14 @@ yarr --version
 
 ```bash
 YARR_VERSION=2.1.0
-npm view "@dinglebear/yarr-mcp@${YARR_VERSION}" version
-npm install --global "@dinglebear/yarr-mcp@${YARR_VERSION}"
+npm view "@dinglebear/yarr@${YARR_VERSION}" version
+npm install --global "@dinglebear/yarr@${YARR_VERSION}"
 ```
 
 The npm launcher and runtime release are a coupled contract. Do not use
 unpinned `npx yarr-mcp` or `@latest` in production, plugin manifests, or
 reproducibility instructions. GitHub release `v2.1.0` is currently public
-while `@dinglebear/yarr-mcp@2.1.0` is absent from npm; use the native binary until
+while `@dinglebear/yarr@2.1.0` is absent from npm; use the native binary until
 [issue #80](https://github.com/dinglebear-ai/yarr/issues/80) is resolved.
 
 ### Source checkout

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -43,7 +43,7 @@ and the command parser for supported flags.
 |---|---|---|
 | Linux x86-64 | Native installer | Verifies release archive and SHA-256; installs to `~/.local/bin` |
 | Contributor checkout | `cargo build --release --locked` | Uses committed Rust lockfile |
-| Node-managed client | Exact `yarr-mcp@VERSION` | Use only after `npm view` proves that exact version exists |
+| Node-managed client | Exact `@dinglebear/yarr-mcp@VERSION` | Use only after `npm view` proves that exact version exists |
 | Container | Immutable GHCR digest | Never deploy mutable `latest` as rollback state |
 | Unraid | Classic `.plg` package | Independent checksummed `unraid-vVERSION-BUILD` release |
 
@@ -58,14 +58,14 @@ yarr --version
 
 ```bash
 YARR_VERSION=2.1.0
-npm view "yarr-mcp@${YARR_VERSION}" version
-npm install --global "yarr-mcp@${YARR_VERSION}"
+npm view "@dinglebear/yarr-mcp@${YARR_VERSION}" version
+npm install --global "@dinglebear/yarr-mcp@${YARR_VERSION}"
 ```
 
 The npm launcher and runtime release are a coupled contract. Do not use
 unpinned `npx yarr-mcp` or `@latest` in production, plugin manifests, or
 reproducibility instructions. GitHub release `v2.1.0` is currently public
-while `yarr-mcp@2.1.0` is absent from npm; use the native binary until
+while `@dinglebear/yarr-mcp@2.1.0` is absent from npm; use the native binary until
 [issue #80](https://github.com/dinglebear-ai/yarr/issues/80) is resolved.
 
 ### Source checkout

--- a/docs/MCP-REGISTRY-PUBLISH-GUIDE.md
+++ b/docs/MCP-REGISTRY-PUBLISH-GUIDE.md
@@ -7,7 +7,7 @@ updated: 2026-07-30
 # MCP Registry publishing
 
 `server.json` is the authoritative MCP Registry manifest. Yarr is published as
-`ai.dinglebear/yarr-mcp`, proved through the `dinglebear.ai` DNS domain, and its
+`ai.dinglebear/yarr`, proved through the `dinglebear.ai` DNS domain, and its
 runtime package is the npm stdio launcher `yarr-mcp`.
 
 ## Manifest contract
@@ -16,7 +16,7 @@ Before publishing, verify these coupled values:
 
 | Field | Required value |
 |---|---|
-| `name` | `ai.dinglebear/yarr-mcp` |
+| `name` | `ai.dinglebear/yarr` |
 | `version` | Same version as Cargo and npm |
 | `packages[0].registryType` | `npm` |
 | `packages[0].identifier` | `yarr-mcp` |
@@ -26,7 +26,7 @@ Before publishing, verify these coupled values:
 | `_meta...dnsDomain` | `dinglebear.ai` |
 
 The package argument must launch `mcp`, and the distribution metadata must name
-the exact `yarr-mcp@<version>` release. `cargo xtask tool-docs --check`, repo
+the exact `@dinglebear/yarr-mcp@<version>` release. `cargo xtask tool-docs --check`, repo
 contract tests, and release version checks guard related generated/coupled files.
 
 ## Install the publisher deliberately
@@ -59,7 +59,7 @@ installable:
 ```bash
 version="$(jq -r '.version' server.json)"
 test "$(jq -r '.packages[0].version' server.json)" = "$version"
-test "$(npm view "yarr-mcp@${version}" version)" = "$version"
+test "$(npm view "@dinglebear/yarr-mcp@${version}" version)" = "$version"
 ./mcp-publisher publish
 ```
 

--- a/docs/MCP-REGISTRY-PUBLISH-GUIDE.md
+++ b/docs/MCP-REGISTRY-PUBLISH-GUIDE.md
@@ -26,7 +26,7 @@ Before publishing, verify these coupled values:
 | `_meta...dnsDomain` | `dinglebear.ai` |
 
 The package argument must launch `mcp`, and the distribution metadata must name
-the exact `@dinglebear/yarr-mcp@<version>` release. `cargo xtask tool-docs --check`, repo
+the exact `@dinglebear/yarr@<version>` release. `cargo xtask tool-docs --check`, repo
 contract tests, and release version checks guard related generated/coupled files.
 
 ## Install the publisher deliberately
@@ -59,7 +59,7 @@ installable:
 ```bash
 version="$(jq -r '.version' server.json)"
 test "$(jq -r '.packages[0].version' server.json)" = "$version"
-test "$(npm view "@dinglebear/yarr-mcp@${version}" version)" = "$version"
+test "$(npm view "@dinglebear/yarr@${version}" version)" = "$version"
 ./mcp-publisher publish
 ```
 

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -723,7 +723,7 @@ package version must equal the Cargo/server version and must not float:
   "mcpServers": {
     "yarr": {
       "command": "npx",
-      "args": ["-y", "yarr-mcp@<repo-version>", "mcp"]
+      "args": ["-y", "@dinglebear/yarr-mcp@<repo-version>", "mcp"]
     }
   }
 }
@@ -758,7 +758,7 @@ no `config.env` compatibility path.
   provisioned with matching ownership before deployment;
 - port 40070 is exposed and the application-native one-shot health check probes
   `GET /ready` without a shell or curl;
-- the MCP registry label matches `server.json` (`ai.dinglebear/yarr-mcp`).
+- the MCP registry label matches `server.json` (`ai.dinglebear/yarr`).
 
 Refresh base digests deliberately and review the upstream image diff. Do not
 replace a digest with a mutable tag-only reference.
@@ -1432,8 +1432,8 @@ Every server must have a `server.json` in the repo root for publishing to the
 
 Yarr's checked-in contract is npm stdio, not OCI or a hosted remote:
 
-- name `ai.dinglebear/yarr-mcp`, proved through DNS for `dinglebear.ai`;
-- package `yarr-mcp@<repo-version>` with positional `mcp` argument;
+- name `ai.dinglebear/yarr`, proved through DNS for `dinglebear.ai`;
+- package `@dinglebear/yarr-mcp@<repo-version>` with positional `mcp` argument;
 - version coupled to Cargo, npm, release-please, and the registry manifest.
 
 Install a specific, checksum-verified `mcp-publisher` release and publish only
@@ -2255,7 +2255,7 @@ echo "  Run: yarr --version # verify install"
 
 ### Plugin launcher
 
-Plugins launch the exact repository-coupled `yarr-mcp@<version>` npm package
+Plugins launch the exact repository-coupled `@dinglebear/yarr-mcp@<version>` npm package
 through `npx -y`; SessionStart never installs or symlinks a bundled binary.
 
 ---

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -723,7 +723,7 @@ package version must equal the Cargo/server version and must not float:
   "mcpServers": {
     "yarr": {
       "command": "npx",
-      "args": ["-y", "@dinglebear/yarr-mcp@<repo-version>", "mcp"]
+      "args": ["-y", "@dinglebear/yarr@<repo-version>", "mcp"]
     }
   }
 }
@@ -1433,7 +1433,7 @@ Every server must have a `server.json` in the repo root for publishing to the
 Yarr's checked-in contract is npm stdio, not OCI or a hosted remote:
 
 - name `ai.dinglebear/yarr`, proved through DNS for `dinglebear.ai`;
-- package `@dinglebear/yarr-mcp@<repo-version>` with positional `mcp` argument;
+- package `@dinglebear/yarr@<repo-version>` with positional `mcp` argument;
 - version coupled to Cargo, npm, release-please, and the registry manifest.
 
 Install a specific, checksum-verified `mcp-publisher` release and publish only
@@ -2255,7 +2255,7 @@ echo "  Run: yarr --version # verify install"
 
 ### Plugin launcher
 
-Plugins launch the exact repository-coupled `@dinglebear/yarr-mcp@<version>` npm package
+Plugins launch the exact repository-coupled `@dinglebear/yarr@<version>` npm package
 through `npx -y`; SessionStart never installs or symlinks a bundled binary.
 
 ---

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -29,7 +29,7 @@ for Claude Code, Codex, and Gemini CLI. The classic filesystem package under
 
 | Package | Includes | Runtime dependency | Best for |
 |---|---|---|---|
-| `yarr` | Full MCP connection plus all fallback skills | Exact pinned `yarr-mcp@VERSION` | One agent surface for the fleet |
+| `yarr` | Full MCP connection plus all fallback skills | Exact pinned `@dinglebear/yarr-mcp@VERSION` | One agent surface for the fleet |
 | `sonarr`, `radarr`, etc. | One direct-service skill | No Yarr MCP launcher | Narrow direct upstream workflows |
 
 The full plugin and skills-only packages can coexist. The skills call strict
@@ -44,7 +44,7 @@ stdio through the same exact launcher specification:
 ```json
 {
   "command": "npx",
-  "args": ["-y", "yarr-mcp@2.2.1", "mcp"]
+  "args": ["-y", "@dinglebear/yarr-mcp@2.2.1", "mcp"]
 }
 ```
 
@@ -58,11 +58,11 @@ A manifest pin proves intent, not registry availability. Verify the exact
 package before installing or debugging the full plugin:
 
 ```bash
-npm view yarr-mcp@2.2.1 version
+npm view @dinglebear/yarr-mcp@2.2.1 version
 ```
 
 At this documentation revision, GitHub release `v2.1.0` is public but
-`yarr-mcp@2.2.1` returns `E404`; recovery is tracked in
+`@dinglebear/yarr-mcp@2.2.1` returns `E404`; recovery is tracked in
 [issue #80](https://github.com/dinglebear-ai/yarr/issues/80). The full plugin
 cannot start from npm until that exact version resolves. Do not loosen the pin
 or silently use npm `latest` (currently an older launcher). Install the native
@@ -150,8 +150,8 @@ the same strict per-service JSON contract and call only the matching upstream.
 
 ## Maintainer checklist
 
-1. Keep every `yarr-mcp@<version>` pin equal to `packages/yarr-mcp/package.json`.
-2. Verify `npm view yarr-mcp@<version> version` before describing the pin as available.
+1. Keep every `@dinglebear/yarr-mcp@<version>` pin equal to `packages/yarr-mcp/package.json`.
+2. Verify `npm view @dinglebear/yarr-mcp@<version> version` before describing the pin as available.
 3. Keep full-plugin and skills-only boundaries explicit in every marketplace description.
 4. Keep manifests versionless and free of committed platform binaries.
 5. Update plugin docs whenever settings, setup-script, monitor behavior, or fallback config changes.

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -29,7 +29,7 @@ for Claude Code, Codex, and Gemini CLI. The classic filesystem package under
 
 | Package | Includes | Runtime dependency | Best for |
 |---|---|---|---|
-| `yarr` | Full MCP connection plus all fallback skills | Exact pinned `@dinglebear/yarr-mcp@VERSION` | One agent surface for the fleet |
+| `yarr` | Full MCP connection plus all fallback skills | Exact pinned `@dinglebear/yarr@VERSION` | One agent surface for the fleet |
 | `sonarr`, `radarr`, etc. | One direct-service skill | No Yarr MCP launcher | Narrow direct upstream workflows |
 
 The full plugin and skills-only packages can coexist. The skills call strict
@@ -44,7 +44,7 @@ stdio through the same exact launcher specification:
 ```json
 {
   "command": "npx",
-  "args": ["-y", "@dinglebear/yarr-mcp@2.2.1", "mcp"]
+  "args": ["-y", "@dinglebear/yarr@2.2.1", "mcp"]
 }
 ```
 
@@ -58,11 +58,11 @@ A manifest pin proves intent, not registry availability. Verify the exact
 package before installing or debugging the full plugin:
 
 ```bash
-npm view @dinglebear/yarr-mcp@2.2.1 version
+npm view @dinglebear/yarr@2.2.1 version
 ```
 
 At this documentation revision, GitHub release `v2.1.0` is public but
-`@dinglebear/yarr-mcp@2.2.1` returns `E404`; recovery is tracked in
+`@dinglebear/yarr@2.2.1` returns `E404`; recovery is tracked in
 [issue #80](https://github.com/dinglebear-ai/yarr/issues/80). The full plugin
 cannot start from npm until that exact version resolves. Do not loosen the pin
 or silently use npm `latest` (currently an older launcher). Install the native
@@ -150,8 +150,8 @@ the same strict per-service JSON contract and call only the matching upstream.
 
 ## Maintainer checklist
 
-1. Keep every `@dinglebear/yarr-mcp@<version>` pin equal to `packages/yarr-mcp/package.json`.
-2. Verify `npm view @dinglebear/yarr-mcp@<version> version` before describing the pin as available.
+1. Keep every `@dinglebear/yarr@<version>` pin equal to `packages/yarr-mcp/package.json`.
+2. Verify `npm view @dinglebear/yarr@<version> version` before describing the pin as available.
 3. Keep full-plugin and skills-only boundaries explicit in every marketplace description.
 4. Keep manifests versionless and free of committed platform binaries.
 5. Update plugin docs whenever settings, setup-script, monitor behavior, or fallback config changes.

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -56,13 +56,13 @@ The launcher and native release use one version. Never use an unpinned
 
 ```bash
 YARR_VERSION=2.1.0
-npm view "@dinglebear/yarr-mcp@${YARR_VERSION}" version
-npx -y "@dinglebear/yarr-mcp@${YARR_VERSION}" --version
+npm view "@dinglebear/yarr@${YARR_VERSION}" version
+npx -y "@dinglebear/yarr@${YARR_VERSION}" --version
 ```
 
 If `npm view` returns `E404` or `ETARGET`, stop. Use the native binary or
 source build instead of falling back to another npm version. GitHub release
-`v2.1.0` currently exists while `@dinglebear/yarr-mcp@2.1.0` is missing; recovery is
+`v2.1.0` currently exists while `@dinglebear/yarr@2.1.0` is missing; recovery is
 tracked in [issue #80](https://github.com/dinglebear-ai/yarr/issues/80).
 
 ### Unraid

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -56,13 +56,13 @@ The launcher and native release use one version. Never use an unpinned
 
 ```bash
 YARR_VERSION=2.1.0
-npm view "yarr-mcp@${YARR_VERSION}" version
-npx -y "yarr-mcp@${YARR_VERSION}" --version
+npm view "@dinglebear/yarr-mcp@${YARR_VERSION}" version
+npx -y "@dinglebear/yarr-mcp@${YARR_VERSION}" --version
 ```
 
 If `npm view` returns `E404` or `ETARGET`, stop. Use the native binary or
 source build instead of falling back to another npm version. GitHub release
-`v2.1.0` currently exists while `yarr-mcp@2.1.0` is missing; recovery is
+`v2.1.0` currently exists while `@dinglebear/yarr-mcp@2.1.0` is missing; recovery is
 tracked in [issue #80](https://github.com/dinglebear-ai/yarr/issues/80).
 
 ### Unraid

--- a/docs/SYSTEMD.md
+++ b/docs/SYSTEMD.md
@@ -64,7 +64,7 @@ WantedBy=default.target
 Key points:
 - The unit example assumes the native installer. Use the absolute path returned
   by `command -v yarr` if you install elsewhere.
-- The npm launcher is suitable only after `npm view yarr-mcp@2.1.0 version`
+- The npm launcher is suitable only after `npm view @dinglebear/yarr-mcp@2.1.0 version`
   confirms the exact coupled version exists. It is currently missing; issue #80
   tracks recovery, so do not use npm `latest` for this unit.
 - Use `EnvironmentFile` pointing at `~/.yarr/.env` — never hardcode tokens in unit files.

--- a/docs/SYSTEMD.md
+++ b/docs/SYSTEMD.md
@@ -64,7 +64,7 @@ WantedBy=default.target
 Key points:
 - The unit example assumes the native installer. Use the absolute path returned
   by `command -v yarr` if you install elsewhere.
-- The npm launcher is suitable only after `npm view @dinglebear/yarr-mcp@2.1.0 version`
+- The npm launcher is suitable only after `npm view @dinglebear/yarr@2.1.0 version`
   confirms the exact coupled version exists. It is currently missing; issue #80
   tracks recovery, so do not use npm `latest` for this unit.
 - Use `EnvironmentFile` pointing at `~/.yarr/.env` — never hardcode tokens in unit files.

--- a/docs/runbooks/partial-release.md
+++ b/docs/runbooks/partial-release.md
@@ -32,7 +32,7 @@ For version `VERSION`, all of these must agree:
 - Cargo, lockfile, npm package, and `server.json` versions equal `VERSION`;
 - the GitHub Release contains every checksummed platform archive;
 - `SHA256SUMS` and sidecars match redownloaded assets;
-- `yarr-mcp@VERSION` exists on npm with expected provenance;
+- `@dinglebear/yarr-mcp@VERSION` exists on npm with expected provenance;
 - the GitHub Release is public only after every prior condition passes.
 
 The classic Unraid release is independent. It uses
@@ -60,8 +60,8 @@ REPO=dinglebear-ai/yarr
 TAG="v${VERSION}"
 gh release view "$TAG" --repo "$REPO" --json tagName,isDraft,isPrerelease,publishedAt,targetCommitish,assets,url
 gh api "repos/${REPO}/git/ref/tags/${TAG}"
-npm view "yarr-mcp@${VERSION}" version dist.integrity dist.tarball --json
-npm view yarr-mcp version --json
+npm view "@dinglebear/yarr-mcp@${VERSION}" version dist.integrity dist.tarball --json
+npm view @dinglebear/yarr-mcp version --json
 ```
 
 Record the UTC time, operator, source commit, failed workflow URL, tag object
@@ -108,9 +108,9 @@ paths. Keep the downloaded checksums as incident evidence.
 ## 5. Verify npm without changing it
 
 ```bash
-npm view "yarr-mcp@${VERSION}" --json
-npm view "yarr-mcp@${VERSION}" dist.integrity --json
-npm pack "yarr-mcp@${VERSION}" --dry-run --json
+npm view "@dinglebear/yarr-mcp@${VERSION}" --json
+npm view "@dinglebear/yarr-mcp@${VERSION}" dist.integrity --json
+npm pack "@dinglebear/yarr-mcp@${VERSION}" --dry-run --json
 ```
 
 If the exact version is absent, do not use `latest` as a substitute. Plugin
@@ -151,7 +151,7 @@ This is the current `v2.1.0` incident tracked in
 3. Identify why GitHub was published before npm existed.
 4. Obtain explicit authorization for either exact-version npm publication or another documented recovery strategy.
 5. Re-run all distribution contracts and verify both public surfaces after the authorized action.
-6. Close the incident only when `npm view yarr-mcp@VERSION version` and GitHub assets both verify.
+6. Close the incident only when `npm view @dinglebear/yarr-mcp@VERSION version` and GitHub assets both verify.
 
 ## 8. Post-recovery verification
 
@@ -162,15 +162,15 @@ npm run check --prefix packages/yarr-mcp
 npm pack --dry-run --json ./packages/yarr-mcp
 python3 scripts/check-doc-links.py
 gh release view "$TAG" --repo "$REPO" --json isDraft,publishedAt,assets,url
-npm view "yarr-mcp@${VERSION}" version --json
+npm view "@dinglebear/yarr-mcp@${VERSION}" version --json
 ```
 
 Install the native archive in a disposable environment and, only when the npm
 version exists, test the exact launcher:
 
 ```bash
-npx -y "yarr-mcp@${VERSION}" --version
-npx -y "yarr-mcp@${VERSION}" mcp
+npx -y "@dinglebear/yarr-mcp@${VERSION}" --version
+npx -y "@dinglebear/yarr-mcp@${VERSION}" mcp
 ```
 
 ## 9. Closeout

--- a/docs/runbooks/partial-release.md
+++ b/docs/runbooks/partial-release.md
@@ -32,7 +32,7 @@ For version `VERSION`, all of these must agree:
 - Cargo, lockfile, npm package, and `server.json` versions equal `VERSION`;
 - the GitHub Release contains every checksummed platform archive;
 - `SHA256SUMS` and sidecars match redownloaded assets;
-- `@dinglebear/yarr-mcp@VERSION` exists on npm with expected provenance;
+- `@dinglebear/yarr@VERSION` exists on npm with expected provenance;
 - the GitHub Release is public only after every prior condition passes.
 
 The classic Unraid release is independent. It uses
@@ -60,8 +60,8 @@ REPO=dinglebear-ai/yarr
 TAG="v${VERSION}"
 gh release view "$TAG" --repo "$REPO" --json tagName,isDraft,isPrerelease,publishedAt,targetCommitish,assets,url
 gh api "repos/${REPO}/git/ref/tags/${TAG}"
-npm view "@dinglebear/yarr-mcp@${VERSION}" version dist.integrity dist.tarball --json
-npm view @dinglebear/yarr-mcp version --json
+npm view "@dinglebear/yarr@${VERSION}" version dist.integrity dist.tarball --json
+npm view @dinglebear/yarr version --json
 ```
 
 Record the UTC time, operator, source commit, failed workflow URL, tag object
@@ -108,9 +108,9 @@ paths. Keep the downloaded checksums as incident evidence.
 ## 5. Verify npm without changing it
 
 ```bash
-npm view "@dinglebear/yarr-mcp@${VERSION}" --json
-npm view "@dinglebear/yarr-mcp@${VERSION}" dist.integrity --json
-npm pack "@dinglebear/yarr-mcp@${VERSION}" --dry-run --json
+npm view "@dinglebear/yarr@${VERSION}" --json
+npm view "@dinglebear/yarr@${VERSION}" dist.integrity --json
+npm pack "@dinglebear/yarr@${VERSION}" --dry-run --json
 ```
 
 If the exact version is absent, do not use `latest` as a substitute. Plugin
@@ -151,7 +151,7 @@ This is the current `v2.1.0` incident tracked in
 3. Identify why GitHub was published before npm existed.
 4. Obtain explicit authorization for either exact-version npm publication or another documented recovery strategy.
 5. Re-run all distribution contracts and verify both public surfaces after the authorized action.
-6. Close the incident only when `npm view @dinglebear/yarr-mcp@VERSION version` and GitHub assets both verify.
+6. Close the incident only when `npm view @dinglebear/yarr@VERSION version` and GitHub assets both verify.
 
 ## 8. Post-recovery verification
 
@@ -162,15 +162,15 @@ npm run check --prefix packages/yarr-mcp
 npm pack --dry-run --json ./packages/yarr-mcp
 python3 scripts/check-doc-links.py
 gh release view "$TAG" --repo "$REPO" --json isDraft,publishedAt,assets,url
-npm view "@dinglebear/yarr-mcp@${VERSION}" version --json
+npm view "@dinglebear/yarr@${VERSION}" version --json
 ```
 
 Install the native archive in a disposable environment and, only when the npm
 version exists, test the exact launcher:
 
 ```bash
-npx -y "@dinglebear/yarr-mcp@${VERSION}" --version
-npx -y "@dinglebear/yarr-mcp@${VERSION}" mcp
+npx -y "@dinglebear/yarr@${VERSION}" --version
+npx -y "@dinglebear/yarr@${VERSION}" mcp
 ```
 
 ## 9. Closeout

--- a/packages/yarr-mcp/README.md
+++ b/packages/yarr-mcp/README.md
@@ -52,7 +52,7 @@ Production Compose deployments select that image by immutable manifest digest.
 Plugin naming is intentionally split:
 
 - `yarr` is the full MCP server plugin. It launches the repository-coupled
-  `@dinglebear/yarr-mcp` npm package over stdio and includes every per-service fallback
+  `@dinglebear/yarr` npm package over stdio and includes every per-service fallback
   skill; it does not commit a platform-specific binary.
 - `sonarr`, `radarr`, `prowlarr`, `overseerr`, `sabnzbd`, `qbittorrent`, `plex`,
   `jellyfin`, `tautulli`, `tracearr`, and `bazarr` are skills-only plugins with
@@ -104,16 +104,16 @@ before using it:
 
 ```bash
 YARR_VERSION=2.1.0
-npm view "@dinglebear/yarr-mcp@${YARR_VERSION}" version
-npx -y "@dinglebear/yarr-mcp@${YARR_VERSION}" mcp
+npm view "@dinglebear/yarr@${YARR_VERSION}" version
+npx -y "@dinglebear/yarr@${YARR_VERSION}" mcp
 # Or, after the same availability check:
-npm i -g "@dinglebear/yarr-mcp@${YARR_VERSION}"
+npm i -g "@dinglebear/yarr@${YARR_VERSION}"
 ```
 
-Never use an unpinned `npx @dinglebear/yarr-mcp` or `@latest` in an MCP manifest: npm may
+Never use an unpinned `npx @dinglebear/yarr` or `@latest` in an MCP manifest: npm may
 still point at an older launcher after a partial release. At the time of this
 documentation refresh, GitHub release `v2.1.0` is public but
-`@dinglebear/yarr-mcp@2.1.0` is not yet available on npm; recovery is tracked in
+`@dinglebear/yarr@2.1.0` is not yet available on npm; recovery is tracked in
 [issue #80](https://github.com/dinglebear-ai/yarr/issues/80). Use the native
 installer, a verified release archive, a source build, or the independent
 Unraid package until the exact npm version resolves.
@@ -182,7 +182,7 @@ The full plugin starts the exact launcher pinned in its manifest. Confirm that
 version exists before installing or debugging the plugin:
 
 ```bash
-npm view @dinglebear/yarr-mcp@2.1.0 version
+npm view @dinglebear/yarr@2.1.0 version
 ```
 
 Until issue #80 is resolved, the full plugin cannot start from npm. The
@@ -538,8 +538,8 @@ curl -fsSL https://raw.githubusercontent.com/dinglebear-ai/yarr/main/install.sh 
 yarr --version
 
 YARR_VERSION=2.1.0
-npm view "@dinglebear/yarr-mcp@${YARR_VERSION}" version
-npx -y "@dinglebear/yarr-mcp@${YARR_VERSION}" mcp
+npm view "@dinglebear/yarr@${YARR_VERSION}" version
+npx -y "@dinglebear/yarr@${YARR_VERSION}" mcp
 ```
 
 Documentation changes also require the repository-local link and anchor guard:
@@ -597,7 +597,7 @@ gateway when exposed outside loopback.
   `codemode.describe(...)`; generated names follow upstream OpenAPI operation
   IDs after normalization.
 - `npm` or the full plugin reports `E404`/`ETARGET`: check the exact pinned
-  launcher with `npm view @dinglebear/yarr-mcp@2.1.0 version`. Do not fall back to unpinned
+  launcher with `npm view @dinglebear/yarr@2.1.0 version`. Do not fall back to unpinned
   `latest`; use the native binary while issue #80 is open.
 
 ## Related Servers

--- a/packages/yarr-mcp/README.md
+++ b/packages/yarr-mcp/README.md
@@ -46,13 +46,13 @@ This repository is published at `github.com/dinglebear-ai/yarr`.
 The Rust package and installed binary are both `yarr`. The npm launcher package
 is `yarr-mcp` because the shorter `yarr` name is occupied on npm; installing the
 launcher still gives you a `yarr` command. The MCP registry name is
-`ai.dinglebear/yarr-mcp`, and Docker images use `ghcr.io/dinglebear-ai/yarr`.
+`ai.dinglebear/yarr`, and Docker images use `ghcr.io/dinglebear-ai/yarr`.
 Production Compose deployments select that image by immutable manifest digest.
 
 Plugin naming is intentionally split:
 
 - `yarr` is the full MCP server plugin. It launches the repository-coupled
-  `yarr-mcp` npm package over stdio and includes every per-service fallback
+  `@dinglebear/yarr-mcp` npm package over stdio and includes every per-service fallback
   skill; it does not commit a platform-specific binary.
 - `sonarr`, `radarr`, `prowlarr`, `overseerr`, `sabnzbd`, `qbittorrent`, `plex`,
   `jellyfin`, `tautulli`, `tracearr`, and `bazarr` are skills-only plugins with
@@ -104,16 +104,16 @@ before using it:
 
 ```bash
 YARR_VERSION=2.1.0
-npm view "yarr-mcp@${YARR_VERSION}" version
-npx -y "yarr-mcp@${YARR_VERSION}" mcp
+npm view "@dinglebear/yarr-mcp@${YARR_VERSION}" version
+npx -y "@dinglebear/yarr-mcp@${YARR_VERSION}" mcp
 # Or, after the same availability check:
-npm i -g "yarr-mcp@${YARR_VERSION}"
+npm i -g "@dinglebear/yarr-mcp@${YARR_VERSION}"
 ```
 
-Never use an unpinned `npx yarr-mcp` or `@latest` in an MCP manifest: npm may
+Never use an unpinned `npx @dinglebear/yarr-mcp` or `@latest` in an MCP manifest: npm may
 still point at an older launcher after a partial release. At the time of this
 documentation refresh, GitHub release `v2.1.0` is public but
-`yarr-mcp@2.1.0` is not yet available on npm; recovery is tracked in
+`@dinglebear/yarr-mcp@2.1.0` is not yet available on npm; recovery is tracked in
 [issue #80](https://github.com/dinglebear-ai/yarr/issues/80). Use the native
 installer, a verified release archive, a source build, or the independent
 Unraid package until the exact npm version resolves.
@@ -182,7 +182,7 @@ The full plugin starts the exact launcher pinned in its manifest. Confirm that
 version exists before installing or debugging the plugin:
 
 ```bash
-npm view yarr-mcp@2.1.0 version
+npm view @dinglebear/yarr-mcp@2.1.0 version
 ```
 
 Until issue #80 is resolved, the full plugin cannot start from npm. The
@@ -483,7 +483,7 @@ not patched by hand:
   the git commit SHA.
 - The npm package version and the GitHub Release tag must match.
 - `server.json` must name the exact `yarr-mcp` npm version and stdio launch
-  contract under the `ai.dinglebear/yarr-mcp` registry identity.
+  contract under the `ai.dinglebear/yarr` registry identity.
 - The Docker image path is `ghcr.io/dinglebear-ai/yarr`; production deployment uses a
   promoted immutable `@sha256:` digest.
 
@@ -538,8 +538,8 @@ curl -fsSL https://raw.githubusercontent.com/dinglebear-ai/yarr/main/install.sh 
 yarr --version
 
 YARR_VERSION=2.1.0
-npm view "yarr-mcp@${YARR_VERSION}" version
-npx -y "yarr-mcp@${YARR_VERSION}" mcp
+npm view "@dinglebear/yarr-mcp@${YARR_VERSION}" version
+npx -y "@dinglebear/yarr-mcp@${YARR_VERSION}" mcp
 ```
 
 Documentation changes also require the repository-local link and anchor guard:
@@ -597,7 +597,7 @@ gateway when exposed outside loopback.
   `codemode.describe(...)`; generated names follow upstream OpenAPI operation
   IDs after normalization.
 - `npm` or the full plugin reports `E404`/`ETARGET`: check the exact pinned
-  launcher with `npm view yarr-mcp@2.1.0 version`. Do not fall back to unpinned
+  launcher with `npm view @dinglebear/yarr-mcp@2.1.0 version`. Do not fall back to unpinned
   `latest`; use the native binary while issue #80 is open.
 
 ## Related Servers

--- a/packages/yarr-mcp/dist.targets.json
+++ b/packages/yarr-mcp/dist.targets.json
@@ -4,8 +4,8 @@
   "identity": {
     "binaryName": "yarr",
     "canonicalRepo": "dinglebear-ai/yarr",
-    "npmPackage": "yarr-mcp",
-    "mcpName": "ai.dinglebear/yarr-mcp"
+    "npmPackage": "@dinglebear/yarr-mcp",
+    "mcpName": "ai.dinglebear/yarr"
   },
   "versionContract": {
     "mode": "coupled-release-tag",

--- a/packages/yarr-mcp/dist.targets.json
+++ b/packages/yarr-mcp/dist.targets.json
@@ -4,7 +4,7 @@
   "identity": {
     "binaryName": "yarr",
     "canonicalRepo": "dinglebear-ai/yarr",
-    "npmPackage": "@dinglebear/yarr-mcp",
+    "npmPackage": "@dinglebear/yarr",
     "mcpName": "ai.dinglebear/yarr"
   },
   "versionContract": {

--- a/packages/yarr-mcp/package.json
+++ b/packages/yarr-mcp/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "yarr-mcp",
+  "name": "@dinglebear/yarr-mcp",
   "version": "2.2.1",
   "description": "MCP server and CLI for self-hosted media fleets: Sonarr, Radarr, Prowlarr, Bazarr, Tautulli, Overseerr, SABnzbd, qBittorrent, Plex, Jellyfin, and Tracearr.",
   "license": "MIT",
@@ -57,9 +57,12 @@
     "bazarr",
     "automation"
   ],
-  "mcpName": "ai.dinglebear/yarr-mcp",
+  "mcpName": "ai.dinglebear/yarr",
   "author": {
     "name": "dinglebear.ai",
     "url": "https://dinglebear.ai"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/yarr-mcp/package.json
+++ b/packages/yarr-mcp/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@dinglebear/yarr-mcp",
+  "name": "@dinglebear/yarr",
   "version": "2.2.1",
   "description": "MCP server and CLI for self-hosted media fleets: Sonarr, Radarr, Prowlarr, Bazarr, Tautulli, Overseerr, SABnzbd, qBittorrent, Plex, Jellyfin, and Tracearr.",
   "license": "MIT",

--- a/packages/yarr-mcp/scripts/check-package.js
+++ b/packages/yarr-mcp/scripts/check-package.js
@@ -11,6 +11,7 @@ const packageRoot = path.resolve(__dirname, "..");
 const repoRoot = path.resolve(packageRoot, "..", "..");
 const packageJsonPath = path.join(packageRoot, "package.json");
 const packageJson = readJson(packageJsonPath);
+const expectedPackageName = "@dinglebear/yarr-mcp";
 const releaseMode = process.argv.includes("--release");
 const skipReleaseAssets = process.argv.includes("--skip-release-assets");
 
@@ -118,6 +119,14 @@ function checkMetadata() {
   const serverWebsite = normalizeHomepage(serverJson.websiteUrl);
 
   assert(packageJson.name, "package.json must include name");
+  assert(
+    packageJson.name === expectedPackageName,
+    "package.json name must match the dinglebear organization package",
+  );
+  assert(
+    packageJson.publishConfig && packageJson.publishConfig.access === "public",
+    "scoped npm package must publish with public access",
+  );
   assert(packageJson.version, "package.json must include version");
   assert(packageJson.description, "package.json must include description");
   assert(packageJson.license, "package.json must include license");
@@ -424,7 +433,7 @@ function requestJson(url, token) {
         headers: {
           accept: "application/vnd.github+json",
           authorization: `Bearer ${token}`,
-          "user-agent": "yarr-mcp-package-check",
+          "user-agent": "@dinglebear/yarr-mcp-package-check",
           "x-github-api-version": "2022-11-28",
         },
       },
@@ -550,7 +559,8 @@ async function main() {
   assertRuntimeScriptsDoNotEscapePackage();
   run(process.execPath, [path.join(repoRoot, "scripts", "check-dist-contract.js")], { cwd: repoRoot });
 
-  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), `${packageJson.name}-package-check-`));
+  const packageTempLabel = packageJson.name.replace(/[^A-Za-z0-9._-]/g, "-");
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), `${packageTempLabel}-package-check-`));
   try {
     const tarball = packTarball(tempDir);
     checkPacklist(tarball);

--- a/packages/yarr-mcp/scripts/check-package.js
+++ b/packages/yarr-mcp/scripts/check-package.js
@@ -11,7 +11,7 @@ const packageRoot = path.resolve(__dirname, "..");
 const repoRoot = path.resolve(packageRoot, "..", "..");
 const packageJsonPath = path.join(packageRoot, "package.json");
 const packageJson = readJson(packageJsonPath);
-const expectedPackageName = "@dinglebear/yarr-mcp";
+const expectedPackageName = "@dinglebear/yarr";
 const releaseMode = process.argv.includes("--release");
 const skipReleaseAssets = process.argv.includes("--skip-release-assets");
 
@@ -433,7 +433,7 @@ function requestJson(url, token) {
         headers: {
           accept: "application/vnd.github+json",
           authorization: `Bearer ${token}`,
-          "user-agent": "@dinglebear/yarr-mcp-package-check",
+          "user-agent": "@dinglebear/yarr-package-check",
           "x-github-api-version": "2022-11-28",
         },
       },

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -72,8 +72,8 @@ the `yarr` bundle side by side does not cause them to clobber each other.
 
 In addition to the standalone layout above, `yarr/` ships `.mcp.json` and
 `gemini-extension.json`'s inline `mcpServers.yarr` (stdio through the pinned
-`yarr-mcp@2.2.1` npm launcher, no committed platform binary). Verify that
-exact package with `npm view yarr-mcp@2.2.1 version` before installation.
+`@dinglebear/yarr-mcp@2.2.1` npm launcher, no committed platform binary). Verify that
+exact package with `npm view @dinglebear/yarr-mcp@2.2.1 version` before installation.
 GitHub `v2.1.0` is public while the npm package is currently missing; issue #80
 tracks recovery, and operators must not loosen the pin to `latest`. The package also ships
 `monitors/monitors.json`, the safe local JSON setup script, the consolidated

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -72,8 +72,8 @@ the `yarr` bundle side by side does not cause them to clobber each other.
 
 In addition to the standalone layout above, `yarr/` ships `.mcp.json` and
 `gemini-extension.json`'s inline `mcpServers.yarr` (stdio through the pinned
-`@dinglebear/yarr-mcp@2.2.1` npm launcher, no committed platform binary). Verify that
-exact package with `npm view @dinglebear/yarr-mcp@2.2.1 version` before installation.
+`@dinglebear/yarr@2.2.1` npm launcher, no committed platform binary). Verify that
+exact package with `npm view @dinglebear/yarr@2.2.1 version` before installation.
 GitHub `v2.1.0` is public while the npm package is currently missing; issue #80
 tracks recovery, and operators must not loosen the pin to `latest`. The package also ships
 `monitors/monitors.json`, the safe local JSON setup script, the consolidated

--- a/plugins/yarr/.mcp.json
+++ b/plugins/yarr/.mcp.json
@@ -3,7 +3,7 @@
     "yarr": {
       "type": "stdio",
       "command": "npx",
-      "args": ["-y", "yarr-mcp@2.2.1", "mcp"],
+      "args": ["-y", "@dinglebear/yarr-mcp@2.2.1", "mcp"],
       "env": {
         "YARR_SERVICES": "${user_config.yarr_services}",
         "YARR_SONARR_URL": "${user_config.sonarr_url}",

--- a/plugins/yarr/.mcp.json
+++ b/plugins/yarr/.mcp.json
@@ -3,7 +3,7 @@
     "yarr": {
       "type": "stdio",
       "command": "npx",
-      "args": ["-y", "@dinglebear/yarr-mcp@2.2.1", "mcp"],
+      "args": ["-y", "@dinglebear/yarr@2.2.1", "mcp"],
       "env": {
         "YARR_SERVICES": "${user_config.yarr_services}",
         "YARR_SONARR_URL": "${user_config.sonarr_url}",

--- a/plugins/yarr/CLAUDE.md
+++ b/plugins/yarr/CLAUDE.md
@@ -11,7 +11,7 @@ Multi-platform plugin package for the Yarr MCP server. Contains manifests for Cl
 | `.claude-plugin/plugin.json` | Claude Code manifest — identity, skills, monitors, `userConfig`. Declares no `hooks` key — Claude/Codex auto-discover `hooks/hooks.json` from its default location. |
 | `.codex-plugin/plugin.json` | Codex manifest — same data + Codex UI fields (`interface`) |
 | `gemini-extension.json` | Gemini CLI manifest — `settings` array instead of `userConfig`, plus an inline `mcpServers.yarr` stdio block (see below) |
-| `.mcp.json` | Claude Code / Codex MCP connection — **stdio by default** through `npx -y @dinglebear/yarr-mcp@2.2.1 mcp`, one `YARR_<NAME>_*` env var per `userConfig` field. No committed platform binary or separately-run server is required. |
+| `.mcp.json` | Claude Code / Codex MCP connection — **stdio by default** through `npx -y @dinglebear/yarr@2.2.1 mcp`, one `YARR_<NAME>_*` env var per `userConfig` field. No committed platform binary or separately-run server is required. |
 | `scripts/plugin-setup.sh` | Credential bridge for the bundled fallback skills, run by the SessionStart/ConfigChange hook (also safe to run manually). Persists only allowlisted settings as mode-`0600` JSON; stored values are parsed, never sourced/evaluated. |
 | `monitors/monitors.json` | Background health monitor config (requires Claude Code v2.1.105+) |
 | `skills/yarr/SKILL.md` | Three-tier tool documentation shared by Claude and Codex |
@@ -29,7 +29,7 @@ env-var set changes. `yarr`-package-scoped: the 11 standalone skills-only
 plugins correctly have neither.
 
 `.mcp.json` uses **stdio**, not HTTP: `command` is
-`npx`, `args` starts with `["-y", "@dinglebear/yarr-mcp@2.2.1", "mcp"]`, and `env` maps every
+`npx`, `args` starts with `["-y", "@dinglebear/yarr@2.2.1", "mcp"]`, and `env` maps every
 `YARR_<NAME>_*` variable to `${user_config.<field>}`. There is no `url`/`headers`
 block and no separate server process to stand up — installing the plugin is
 enough. `tests/plugin_contract/manifests.rs::mcp_json_uses_the_pinned_npm_stdio_launcher`

--- a/plugins/yarr/CLAUDE.md
+++ b/plugins/yarr/CLAUDE.md
@@ -11,7 +11,7 @@ Multi-platform plugin package for the Yarr MCP server. Contains manifests for Cl
 | `.claude-plugin/plugin.json` | Claude Code manifest — identity, skills, monitors, `userConfig`. Declares no `hooks` key — Claude/Codex auto-discover `hooks/hooks.json` from its default location. |
 | `.codex-plugin/plugin.json` | Codex manifest — same data + Codex UI fields (`interface`) |
 | `gemini-extension.json` | Gemini CLI manifest — `settings` array instead of `userConfig`, plus an inline `mcpServers.yarr` stdio block (see below) |
-| `.mcp.json` | Claude Code / Codex MCP connection — **stdio by default** through `npx -y yarr-mcp@2.2.1 mcp`, one `YARR_<NAME>_*` env var per `userConfig` field. No committed platform binary or separately-run server is required. |
+| `.mcp.json` | Claude Code / Codex MCP connection — **stdio by default** through `npx -y @dinglebear/yarr-mcp@2.2.1 mcp`, one `YARR_<NAME>_*` env var per `userConfig` field. No committed platform binary or separately-run server is required. |
 | `scripts/plugin-setup.sh` | Credential bridge for the bundled fallback skills, run by the SessionStart/ConfigChange hook (also safe to run manually). Persists only allowlisted settings as mode-`0600` JSON; stored values are parsed, never sourced/evaluated. |
 | `monitors/monitors.json` | Background health monitor config (requires Claude Code v2.1.105+) |
 | `skills/yarr/SKILL.md` | Three-tier tool documentation shared by Claude and Codex |
@@ -29,7 +29,7 @@ env-var set changes. `yarr`-package-scoped: the 11 standalone skills-only
 plugins correctly have neither.
 
 `.mcp.json` uses **stdio**, not HTTP: `command` is
-`npx`, `args` starts with `["-y", "yarr-mcp@2.2.1", "mcp"]`, and `env` maps every
+`npx`, `args` starts with `["-y", "@dinglebear/yarr-mcp@2.2.1", "mcp"]`, and `env` maps every
 `YARR_<NAME>_*` variable to `${user_config.<field>}`. There is no `url`/`headers`
 block and no separate server process to stand up — installing the plugin is
 enough. `tests/plugin_contract/manifests.rs::mcp_json_uses_the_pinned_npm_stdio_launcher`

--- a/plugins/yarr/README.md
+++ b/plugins/yarr/README.md
@@ -23,7 +23,7 @@ plugins/yarr/
 ## Platform manifests
 
 All three platforms connect over **stdio** through the pinned
-`yarr-mcp@2.2.1` npm launcher. No Linux-only binary is committed. Claude Code
+`@dinglebear/yarr-mcp@2.2.1` npm launcher. No Linux-only binary is committed. Claude Code
 and Codex read `.mcp.json`; Gemini CLI declares the equivalent block inline in
 `gemini-extension.json`. All three share the same `skills/` directory.
 
@@ -45,7 +45,7 @@ and Codex read `.mcp.json`; Gemini CLI declares the equivalent block inline in
     "yarr": {
       "type": "stdio",
       "command": "npx",
-      "args": ["-y", "yarr-mcp@2.2.1", "mcp"],
+      "args": ["-y", "@dinglebear/yarr-mcp@2.2.1", "mcp"],
       "env": {
         "YARR_SERVICES": "${user_config.yarr_services}",
         "YARR_SONARR_URL": "${user_config.sonarr_url}",
@@ -65,7 +65,7 @@ and Codex read `.mcp.json`; Gemini CLI declares the equivalent block inline in
   "mcpServers": {
     "yarr": {
       "command": "npx",
-      "args": ["-y", "yarr-mcp@2.2.1", "mcp"],
+      "args": ["-y", "@dinglebear/yarr-mcp@2.2.1", "mcp"],
       "env": {
         "YARR_SONARR_URL": "$YARR_SONARR_URL"
       }
@@ -78,7 +78,7 @@ The full plugin is self-starting only when the exact pinned launcher exists on n
 Verify it before installation or troubleshooting:
 
 ```bash
-npm view yarr-mcp@2.2.1 version
+npm view @dinglebear/yarr-mcp@2.2.1 version
 ```
 
 GitHub release `v2.1.0` is currently public while that npm version is missing;
@@ -132,8 +132,8 @@ Disabling the plugin mid-session does not stop an already-running monitor; it st
 
 ## Packaging checklist
 
-1. Keep the pinned `yarr-mcp@<version>` spec equal to the coupled runtime/package release version.
-2. Verify `npm view yarr-mcp@<version> version`; a manifest pin is not proof of registry availability.
+1. Keep the pinned `@dinglebear/yarr-mcp@<version>` spec equal to the coupled runtime/package release version.
+2. Verify `npm view @dinglebear/yarr-mcp@<version> version`; a manifest pin is not proof of registry availability.
 3. Confirm the native `yarr` binary is installed separately on PATH when testing the optional health monitor (`watch.sh`).
 4. Run `node scripts/test-plugin-distribution.js`, `scripts/validate-plugin-layout.sh`, and `python3 scripts/check-doc-links.py`.
 5. Verify all manifests still omit explicit `version` fields.

--- a/plugins/yarr/README.md
+++ b/plugins/yarr/README.md
@@ -23,7 +23,7 @@ plugins/yarr/
 ## Platform manifests
 
 All three platforms connect over **stdio** through the pinned
-`@dinglebear/yarr-mcp@2.2.1` npm launcher. No Linux-only binary is committed. Claude Code
+`@dinglebear/yarr@2.2.1` npm launcher. No Linux-only binary is committed. Claude Code
 and Codex read `.mcp.json`; Gemini CLI declares the equivalent block inline in
 `gemini-extension.json`. All three share the same `skills/` directory.
 
@@ -45,7 +45,7 @@ and Codex read `.mcp.json`; Gemini CLI declares the equivalent block inline in
     "yarr": {
       "type": "stdio",
       "command": "npx",
-      "args": ["-y", "@dinglebear/yarr-mcp@2.2.1", "mcp"],
+      "args": ["-y", "@dinglebear/yarr@2.2.1", "mcp"],
       "env": {
         "YARR_SERVICES": "${user_config.yarr_services}",
         "YARR_SONARR_URL": "${user_config.sonarr_url}",
@@ -65,7 +65,7 @@ and Codex read `.mcp.json`; Gemini CLI declares the equivalent block inline in
   "mcpServers": {
     "yarr": {
       "command": "npx",
-      "args": ["-y", "@dinglebear/yarr-mcp@2.2.1", "mcp"],
+      "args": ["-y", "@dinglebear/yarr@2.2.1", "mcp"],
       "env": {
         "YARR_SONARR_URL": "$YARR_SONARR_URL"
       }
@@ -78,7 +78,7 @@ The full plugin is self-starting only when the exact pinned launcher exists on n
 Verify it before installation or troubleshooting:
 
 ```bash
-npm view @dinglebear/yarr-mcp@2.2.1 version
+npm view @dinglebear/yarr@2.2.1 version
 ```
 
 GitHub release `v2.1.0` is currently public while that npm version is missing;
@@ -132,8 +132,8 @@ Disabling the plugin mid-session does not stop an already-running monitor; it st
 
 ## Packaging checklist
 
-1. Keep the pinned `@dinglebear/yarr-mcp@<version>` spec equal to the coupled runtime/package release version.
-2. Verify `npm view @dinglebear/yarr-mcp@<version> version`; a manifest pin is not proof of registry availability.
+1. Keep the pinned `@dinglebear/yarr@<version>` spec equal to the coupled runtime/package release version.
+2. Verify `npm view @dinglebear/yarr@<version> version`; a manifest pin is not proof of registry availability.
 3. Confirm the native `yarr` binary is installed separately on PATH when testing the optional health monitor (`watch.sh`).
 4. Run `node scripts/test-plugin-distribution.js`, `scripts/validate-plugin-layout.sh`, and `python3 scripts/check-doc-links.py`.
 5. Verify all manifests still omit explicit `version` fields.

--- a/plugins/yarr/gemini-extension.json
+++ b/plugins/yarr/gemini-extension.json
@@ -22,7 +22,7 @@
   "mcpServers": {
     "yarr": {
       "command": "npx",
-      "args": ["-y", "yarr-mcp@2.2.1", "mcp"],
+      "args": ["-y", "@dinglebear/yarr-mcp@2.2.1", "mcp"],
       "env": {
         "YARR_SERVICES": "$YARR_SERVICES",
         "YARR_SONARR_URL": "$YARR_SONARR_URL",

--- a/plugins/yarr/gemini-extension.json
+++ b/plugins/yarr/gemini-extension.json
@@ -22,7 +22,7 @@
   "mcpServers": {
     "yarr": {
       "command": "npx",
-      "args": ["-y", "@dinglebear/yarr-mcp@2.2.1", "mcp"],
+      "args": ["-y", "@dinglebear/yarr@2.2.1", "mcp"],
       "env": {
         "YARR_SERVICES": "$YARR_SERVICES",
         "YARR_SONARR_URL": "$YARR_SONARR_URL",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -31,7 +31,7 @@ Maintenance and automation scripts for the template. Shell scripts are written f
 | `repair.sh` | Stop, rebuild, and restart the service via systemd or Docker Compose. |
 | `run-ascii-check.sh` | Collect tracked files and run `asciicheck.py`; pass `--fix` to rewrite in place. |
 | `sync-cargo.sh` | Sync `Cargo.lock` into plugin data directories. |
-| `sync-plugin-manifests.js` | Couple every `yarr-mcp@<version>` launcher pin to `packages/yarr-mcp/package.json`; `--check` fails on drift. |
+| `sync-plugin-manifests.js` | Couple every `@dinglebear/yarr-mcp@<version>` launcher pin to `packages/yarr-mcp/package.json`; `--check` fails on drift. |
 | `test-installers.js` | Exercise the install paths shipped with the npm launcher. |
 | `test-mcp-auth.sh` | Smoke-test HTTP MCP bearer auth. |
 | `test-plugin-distribution.js` | Assert standalone/bundled skill parity, pinned launchers, and that every plugin ships its lifecycle hooks. |
@@ -314,7 +314,7 @@ node scripts/sync-plugin-manifests.js          # rewrite pins in place
 node scripts/sync-plugin-manifests.js --check   # fail (non-zero) on drift
 ```
 
-Rewrites every hard-coded `yarr-mcp@<version>` npm launcher pin (in `plugins/yarr/.mcp.json`, `plugins/yarr/gemini-extension.json`, `server.json`, and the plugin docs) plus `server.json`'s `_meta.buildInfo.version` and its `YARR_VERSION` example placeholder (`v<version>`) to match `packages/yarr-mcp/package.json` — the single version release-please bumps. release-please cannot template a version embedded inside a launcher-arg string, so the release workflow runs this on the release PR and CI runs `--check` to block drift on `main`. `validate-plugin-layout.sh` derives the expected pin from `package.json` directly, so it is intentionally not rewritten here.
+Rewrites every hard-coded `@dinglebear/yarr-mcp@<version>` npm launcher pin (in `plugins/yarr/.mcp.json`, `plugins/yarr/gemini-extension.json`, `server.json`, and the plugin docs) plus `server.json`'s `_meta.buildInfo.version` and its `YARR_VERSION` example placeholder (`v<version>`) to match `packages/yarr-mcp/package.json` — the single version release-please bumps. release-please cannot template a version embedded inside a launcher-arg string, so the release workflow runs this on the release PR and CI runs `--check` to block drift on `main`. `validate-plugin-layout.sh` derives the expected pin from `package.json` directly, so it is intentionally not rewritten here.
 
 ### `test-mcp-auth.sh`
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -31,7 +31,7 @@ Maintenance and automation scripts for the template. Shell scripts are written f
 | `repair.sh` | Stop, rebuild, and restart the service via systemd or Docker Compose. |
 | `run-ascii-check.sh` | Collect tracked files and run `asciicheck.py`; pass `--fix` to rewrite in place. |
 | `sync-cargo.sh` | Sync `Cargo.lock` into plugin data directories. |
-| `sync-plugin-manifests.js` | Couple every `@dinglebear/yarr-mcp@<version>` launcher pin to `packages/yarr-mcp/package.json`; `--check` fails on drift. |
+| `sync-plugin-manifests.js` | Couple every `@dinglebear/yarr@<version>` launcher pin to `packages/yarr-mcp/package.json`; `--check` fails on drift. |
 | `test-installers.js` | Exercise the install paths shipped with the npm launcher. |
 | `test-mcp-auth.sh` | Smoke-test HTTP MCP bearer auth. |
 | `test-plugin-distribution.js` | Assert standalone/bundled skill parity, pinned launchers, and that every plugin ships its lifecycle hooks. |
@@ -314,7 +314,7 @@ node scripts/sync-plugin-manifests.js          # rewrite pins in place
 node scripts/sync-plugin-manifests.js --check   # fail (non-zero) on drift
 ```
 
-Rewrites every hard-coded `@dinglebear/yarr-mcp@<version>` npm launcher pin (in `plugins/yarr/.mcp.json`, `plugins/yarr/gemini-extension.json`, `server.json`, and the plugin docs) plus `server.json`'s `_meta.buildInfo.version` and its `YARR_VERSION` example placeholder (`v<version>`) to match `packages/yarr-mcp/package.json` — the single version release-please bumps. release-please cannot template a version embedded inside a launcher-arg string, so the release workflow runs this on the release PR and CI runs `--check` to block drift on `main`. `validate-plugin-layout.sh` derives the expected pin from `package.json` directly, so it is intentionally not rewritten here.
+Rewrites every hard-coded `@dinglebear/yarr@<version>` npm launcher pin (in `plugins/yarr/.mcp.json`, `plugins/yarr/gemini-extension.json`, `server.json`, and the plugin docs) plus `server.json`'s `_meta.buildInfo.version` and its `YARR_VERSION` example placeholder (`v<version>`) to match `packages/yarr-mcp/package.json` — the single version release-please bumps. release-please cannot template a version embedded inside a launcher-arg string, so the release workflow runs this on the release PR and CI runs `--check` to block drift on `main`. `validate-plugin-layout.sh` derives the expected pin from `package.json` directly, so it is intentionally not rewritten here.
 
 ### `test-mcp-auth.sh`
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -157,7 +157,7 @@ just schema-docs
 just schema-docs-check
 ```
 
-Treats the action registry as canonical and verifies schema docs, help text, README, and plugin skill mentions. Generated output lives in `docs/MCP_SCHEMA.md`. Since the descriptor-table refactor, `ACTION_SPECS` lives in `src/actions/registry.rs` (with `src/actions.rs` a thin facade), so the checker scans the `src/actions/` tree recursively rather than the single `src/actions.rs` file. The required-params contract is `service`/`path` for the generic passthroughs: there is no `confirm` param anywhere, and the destructive `api_delete` runs immediately on the CLI/Code Mode — on MCP it's instead gated out-of-band via elicitation (not via a required schema param).
+Treats the action registry as canonical and verifies schema docs, help text, README, and plugin skill mentions. Generated output lives in `docs/MCP_SCHEMA.md` and preserves its required title and created/updated frontmatter. Since the descriptor-table refactor, `ACTION_SPECS` lives in `src/actions/registry.rs` (with `src/actions.rs` a thin facade), so the checker scans the `src/actions/` tree recursively rather than the single `src/actions.rs` file. The required-params contract is `service`/`path` for the generic passthroughs: there is no `confirm` param anywhere, and the destructive `api_delete` runs immediately on the CLI/Code Mode — on MCP it's instead gated out-of-band via elicitation (not via a required schema param).
 
 ### `build-web.sh`
 

--- a/scripts/check-dist-contract.js
+++ b/scripts/check-dist-contract.js
@@ -45,7 +45,7 @@ assert.equal(contract.schemaVersion, 1);
 assert.deepEqual(contract.identity, {
   binaryName: "yarr",
   canonicalRepo: "dinglebear-ai/yarr",
-  npmPackage: "@dinglebear/yarr-mcp",
+  npmPackage: "@dinglebear/yarr",
   mcpName: "ai.dinglebear/yarr",
 });
 assert.equal(contract.versionContract.mode, "coupled-release-tag");

--- a/scripts/check-dist-contract.js
+++ b/scripts/check-dist-contract.js
@@ -45,8 +45,8 @@ assert.equal(contract.schemaVersion, 1);
 assert.deepEqual(contract.identity, {
   binaryName: "yarr",
   canonicalRepo: "dinglebear-ai/yarr",
-  npmPackage: "yarr-mcp",
-  mcpName: "ai.dinglebear/yarr-mcp",
+  npmPackage: "@dinglebear/yarr-mcp",
+  mcpName: "ai.dinglebear/yarr",
 });
 assert.equal(contract.versionContract.mode, "coupled-release-tag");
 assert.equal(contract.versionContract.tagPrefix, "v");

--- a/scripts/check-schema-docs.py
+++ b/scripts/check-schema-docs.py
@@ -91,6 +91,12 @@ def render() -> str:
     actions = extract_actions()
     scopes = extract_scope_for_actions()
     lines = [
+        "---",
+        'title: "MCP Schema Contract"',
+        "created: 2026-05-22",
+        "updated: 2026-07-30",
+        "---",
+        "",
         "# MCP Schema Contract",
         "",
         "Generated from `src/actions/` and checked against the schema, README, skill docs, help text, and scope routing.",

--- a/scripts/sync-plugin-manifests.js
+++ b/scripts/sync-plugin-manifests.js
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 "use strict";
 
-// sync-plugin-manifests.js — keep every hard-coded `yarr-mcp@<version>` launcher
+// sync-plugin-manifests.js — keep every hard-coded `@dinglebear/yarr-mcp@<version>` launcher
 // pin coupled to packages/yarr-mcp/package.json, the single version release-please
 // bumps on a release. release-please can update JSON scalar fields (server.json
 // $.version, package.json $.version) but cannot template a version embedded inside
-// a launcher-arg string such as `["-y", "yarr-mcp@1.1.1", "mcp"]`, so those pins
+// a launcher-arg string such as `["-y", "@dinglebear/yarr-mcp@1.1.1", "mcp"]`, so those pins
 // drift on every release and break the coupled-version contract checks.
 //
 // Usage:
@@ -22,9 +22,9 @@ const packageJson = JSON.parse(
   fs.readFileSync(path.join(root, "packages/yarr-mcp/package.json"), "utf8"),
 );
 const { name, version } = packageJson;
-const spec = `${name}@${version}`; // e.g. yarr-mcp@2.0.0
+const spec = `${name}@${version}`; // e.g. @dinglebear/yarr-mcp@2.0.0
 
-// Files that pin the npm launcher spec `yarr-mcp@<semver>`. Listed explicitly so
+// Files that pin the npm launcher spec `@dinglebear/yarr-mcp@<semver>`. Listed explicitly so
 // an unrelated match can never be rewritten by accident.
 // NB: deliberately excludes scripts/validate-plugin-layout.sh — that checker
 // derives the expected pin from package.json at runtime, so it never needs

--- a/scripts/sync-plugin-manifests.js
+++ b/scripts/sync-plugin-manifests.js
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 "use strict";
 
-// sync-plugin-manifests.js — keep every hard-coded `@dinglebear/yarr-mcp@<version>` launcher
+// sync-plugin-manifests.js — keep every hard-coded `@dinglebear/yarr@<version>` launcher
 // pin coupled to packages/yarr-mcp/package.json, the single version release-please
 // bumps on a release. release-please can update JSON scalar fields (server.json
 // $.version, package.json $.version) but cannot template a version embedded inside
-// a launcher-arg string such as `["-y", "@dinglebear/yarr-mcp@1.1.1", "mcp"]`, so those pins
+// a launcher-arg string such as `["-y", "@dinglebear/yarr@1.1.1", "mcp"]`, so those pins
 // drift on every release and break the coupled-version contract checks.
 //
 // Usage:
@@ -22,9 +22,9 @@ const packageJson = JSON.parse(
   fs.readFileSync(path.join(root, "packages/yarr-mcp/package.json"), "utf8"),
 );
 const { name, version } = packageJson;
-const spec = `${name}@${version}`; // e.g. @dinglebear/yarr-mcp@2.0.0
+const spec = `${name}@${version}`; // e.g. @dinglebear/yarr@2.0.0
 
-// Files that pin the npm launcher spec `@dinglebear/yarr-mcp@<semver>`. Listed explicitly so
+// Files that pin the npm launcher spec `@dinglebear/yarr@<semver>`. Listed explicitly so
 // an unrelated match can never be rewritten by accident.
 // NB: deliberately excludes scripts/validate-plugin-layout.sh — that checker
 // derives the expected pin from package.json at runtime, so it never needs

--- a/scripts/test-plugin-distribution.js
+++ b/scripts/test-plugin-distribution.js
@@ -84,7 +84,7 @@ for (const service of services) {
 }
 
 const packageJson = JSON.parse(fs.readFileSync(path.join(root, "packages", "yarr-mcp", "package.json"), "utf8"));
-const pinned = `yarr-mcp@${packageJson.version}`;
+const pinned = `@dinglebear/yarr-mcp@${packageJson.version}`;
 const mcp = JSON.parse(fs.readFileSync(path.join(root, "plugins", "yarr", ".mcp.json"), "utf8")).mcpServers.yarr;
 const gemini = JSON.parse(fs.readFileSync(path.join(root, "plugins", "yarr", "gemini-extension.json"), "utf8")).mcpServers.yarr;
 assert.equal(mcp.command, "npx");

--- a/scripts/test-plugin-distribution.js
+++ b/scripts/test-plugin-distribution.js
@@ -84,7 +84,7 @@ for (const service of services) {
 }
 
 const packageJson = JSON.parse(fs.readFileSync(path.join(root, "packages", "yarr-mcp", "package.json"), "utf8"));
-const pinned = `@dinglebear/yarr-mcp@${packageJson.version}`;
+const pinned = `@dinglebear/yarr@${packageJson.version}`;
 const mcp = JSON.parse(fs.readFileSync(path.join(root, "plugins", "yarr", ".mcp.json"), "utf8")).mcpServers.yarr;
 const gemini = JSON.parse(fs.readFileSync(path.join(root, "plugins", "yarr", "gemini-extension.json"), "utf8")).mcpServers.yarr;
 assert.equal(mcp.command, "npx");

--- a/scripts/validate-plugin-layout.sh
+++ b/scripts/validate-plugin-layout.sh
@@ -22,7 +22,7 @@ SKILLS_DIR="${PLUGIN_ROOT}/skills"
 # stays coupled without being hand-edited (and without tripping the scripts/ ->
 # scripts/README.md coupled-file guard on the release PR).
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-EXPECTED_LAUNCHER="@dinglebear/yarr-mcp@$(jq -r '.version' "${REPO_ROOT}/packages/yarr-mcp/package.json" 2>/dev/null)"
+EXPECTED_LAUNCHER="@dinglebear/yarr@$(jq -r '.version' "${REPO_ROOT}/packages/yarr-mcp/package.json" 2>/dev/null)"
 
 check() {
   local test_name="$1"

--- a/scripts/validate-plugin-layout.sh
+++ b/scripts/validate-plugin-layout.sh
@@ -22,7 +22,7 @@ SKILLS_DIR="${PLUGIN_ROOT}/skills"
 # stays coupled without being hand-edited (and without tripping the scripts/ ->
 # scripts/README.md coupled-file guard on the release PR).
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-EXPECTED_LAUNCHER="yarr-mcp@$(jq -r '.version' "${REPO_ROOT}/packages/yarr-mcp/package.json" 2>/dev/null)"
+EXPECTED_LAUNCHER="@dinglebear/yarr-mcp@$(jq -r '.version' "${REPO_ROOT}/packages/yarr-mcp/package.json" 2>/dev/null)"
 
 check() {
   local test_name="$1"

--- a/server.json
+++ b/server.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "ai.dinglebear/yarr-mcp",
+  "name": "ai.dinglebear/yarr",
   "title": "Yarr MCP",
   "description": "MCP server and CLI for self-hosted media fleets: Sonarr, Radarr, Prowlarr, Bazarr, Tautulli, Overseerr, SABnzbd, qBittorrent, Plex, Jellyfin, and Tracearr.",
   "version": "2.2.1",
@@ -24,7 +24,7 @@
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
-      "identifier": "yarr-mcp",
+      "identifier": "@dinglebear/yarr-mcp",
       "version": "2.2.1",
       "runtimeHint": "npx",
       "packageArguments": [
@@ -128,8 +128,8 @@
       "namespace": "ai.dinglebear",
       "dnsDomain": "dinglebear.ai",
       "distribution": {
-        "npm": "yarr-mcp@2.2.1",
-        "nodePackage": "yarr-mcp"
+        "npm": "@dinglebear/yarr-mcp@2.2.1",
+        "nodePackage": "@dinglebear/yarr-mcp"
       },
       "buildInfo": {
         "version": "2.2.1",

--- a/server.json
+++ b/server.json
@@ -24,7 +24,7 @@
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
-      "identifier": "@dinglebear/yarr-mcp",
+      "identifier": "@dinglebear/yarr",
       "version": "2.2.1",
       "runtimeHint": "npx",
       "packageArguments": [
@@ -128,8 +128,8 @@
       "namespace": "ai.dinglebear",
       "dnsDomain": "dinglebear.ai",
       "distribution": {
-        "npm": "@dinglebear/yarr-mcp@2.2.1",
-        "nodePackage": "@dinglebear/yarr-mcp"
+        "npm": "@dinglebear/yarr@2.2.1",
+        "nodePackage": "@dinglebear/yarr"
       },
       "buildInfo": {
         "version": "2.2.1",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,9 @@
 // torrent row) are single `serde_json::json!` literals that exceed the default
 // macro recursion limit of 128.
 #![recursion_limit = "256"]
+// This internal application crate predates Clippy's documentation style lints.
+// Keep new code warning-clean without requiring a bulk public-API documentation rewrite.
+#![allow(clippy::doc_markdown, clippy::missing_errors_doc)]
 
 mod actions;
 mod app;

--- a/src/main.rs
+++ b/src/main.rs
@@ -124,8 +124,8 @@ async fn serve_mcp(config: Config) -> Result<()> {
 
 /// Start the MCP stdio transport (for local/subprocess MCP clients).
 ///
-/// Stdio is always LoopbackDev — it's a local trusted pipe between parent and
-/// child process. HTTP auth middleware doesn't apply; forcing Mounted here
+/// Stdio is always `LoopbackDev` — it's a local trusted pipe between parent and
+/// child process. HTTP auth middleware doesn't apply; forcing `Mounted` here
 /// breaks all stdio clients with "forbidden: missing http context".
 async fn serve_stdio_mcp(config: Config) -> Result<()> {
     let mut service = YarrService::new(YarrClient::new(&config.yarr)?, config.yarr.clone())

--- a/tests/plugin_contract/manifests.rs
+++ b/tests/plugin_contract/manifests.rs
@@ -5,7 +5,7 @@ use serde_json::Value;
 use super::common::{json, package_version};
 
 fn expected_npx_args() -> Value {
-    serde_json::json!(["-y", format!("@dinglebear/yarr-mcp@{}", package_version()), "mcp"])
+    serde_json::json!(["-y", format!("@dinglebear/yarr@{}", package_version()), "mcp"])
 }
 
 #[test]

--- a/tests/plugin_contract/manifests.rs
+++ b/tests/plugin_contract/manifests.rs
@@ -5,7 +5,11 @@ use serde_json::Value;
 use super::common::{json, package_version};
 
 fn expected_npx_args() -> Value {
-    serde_json::json!(["-y", format!("@dinglebear/yarr@{}", package_version()), "mcp"])
+    serde_json::json!([
+        "-y",
+        format!("@dinglebear/yarr@{}", package_version()),
+        "mcp"
+    ])
 }
 
 #[test]

--- a/tests/plugin_contract/manifests.rs
+++ b/tests/plugin_contract/manifests.rs
@@ -5,7 +5,7 @@ use serde_json::Value;
 use super::common::{json, package_version};
 
 fn expected_npx_args() -> Value {
-    serde_json::json!(["-y", format!("yarr-mcp@{}", package_version()), "mcp"])
+    serde_json::json!(["-y", format!("@dinglebear/yarr-mcp@{}", package_version()), "mcp"])
 }
 
 #[test]

--- a/tests/template_invariants.rs
+++ b/tests/template_invariants.rs
@@ -145,7 +145,7 @@ fn plugin_manifests_do_not_have_version_fields() {
 #[test]
 fn registry_and_deploy_metadata_are_yarr_specific() {
     let server = json("server.json");
-    assert_eq!(server["name"], "ai.dinglebear/yarr-mcp");
+    assert_eq!(server["name"], "ai.dinglebear/yarr");
     assert_eq!(
         server["description"],
         "MCP server and CLI for self-hosted media fleets: Sonarr, Radarr, Prowlarr, Bazarr, Tautulli, Overseerr, SABnzbd, qBittorrent, Plex, Jellyfin, and Tracearr."


### PR DESCRIPTION
## Summary
- publish the Node launcher as `@dinglebear/yarr`
- align MCP Registry identity to `ai.dinglebear/yarr`
- enforce public scoped-package metadata and token-backed release authentication
- preserve existing binary, archive, and package-directory contracts

## Verification
- npm tests and package validation
- npm pack dry run and tarball install smoke
- actionlint and JSON/schema checks
- git diff --check