### PR TITLE
feat: add bounded Code Mode fleet fanout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,7 +77,7 @@ YARR_PLEX_TOKEN=change-me
 # Bound Code Mode concurrency, admission wait, and execution time.
 # YARR_MCP_CODEMODE_MAX_CONCURRENT=4
 # YARR_MCP_CODEMODE_QUEUE_TIMEOUT_MS=500
-# YARR_MCP_CODEMODE_TIMEOUT_SECS=30
+# YARR_MCP_CODEMODE_TIMEOUT_SECS=120
 
 # Disable auth entirely. ONLY safe when the server is bound to 127.x.
 # Set to true only for local development when you control the machine.

--- a/.env.example
+++ b/.env.example
@@ -78,6 +78,8 @@ YARR_PLEX_TOKEN=change-me
 # YARR_MCP_CODEMODE_MAX_CONCURRENT=4
 # YARR_MCP_CODEMODE_QUEUE_TIMEOUT_MS=500
 # YARR_MCP_CODEMODE_TIMEOUT_SECS=120
+# YARR_FLEET_MAX_CONCURRENT=8
+# YARR_FLEET_INSTANCE_TIMEOUT_SECS=8
 
 # Disable auth entirely. ONLY safe when the server is bound to 127.x.
 # Set to true only for local development when you control the machine.

--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,10 @@
 # ── Media automation services ────────────────────────────────────────────────
 # List the service instances yarr should expose. Each name expands to
 # YARR_<NAME>_* variables, with non-alphanumeric chars converted to "_".
+# For large fleets, YARR_FLEET_FILE adds reviewable YAML/TOML topology whose
+# token_env/api_key_env fields reference secret variables in this file.
+
+# YARR_FLEET_FILE=/data/fleet.yaml
 
 YARR_SERVICES=sonarr,radarr,prowlarr,plex
 
@@ -34,6 +38,10 @@ YARR_PROWLARR_API_KEY=change-me
 
 YARR_PLEX_URL=http://plex:32400
 YARR_PLEX_TOKEN=change-me
+
+# Example secrets referenced by a fleet file:
+# PLEX_DEN_TOKEN=change-me
+# TAUTULLI_DEN_KEY=change-me
 
 # qBittorrent uses cookie login rather than API-key auth.
 # YARR_QBITTORRENT_URL=http://qbittorrent:8080

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add bounded, failure-isolated `fleet.map`/`fleet.status` Code Mode primitives
+  and four immutable canonical fleet snippets.
 - Add review-only `yarr discover plex` scaffolding with owned-server defaults,
   identifier-pinned drift detection, private token output, and Tautulli pairing.
 - Scale the Code Mode deadline for fleet workloads and preserve per-instance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* **config:** reject reserved Code Mode service names and normalized environment-namespace collisions at startup instead of silently hiding a service
 * **docs:** replace unpinned npm launcher guidance with exact-version availability checks and document the `v2.1.0` partial-release recovery boundary
 * **unraid:** enforce cache-busted page assets and canonical root-owned mode-0755 package directories
 * **auth:** honor explicit bearer/OAuth credentials on loopback binds instead of silently downgrading them to unauthenticated dev mode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* **safety:** classify high-impact generated operations explicitly, elicit non-DELETE Plex session/library mutations, cap destructive fleet targets, and support per-instance `YARR_FLEET_READONLY`
 * **docs:** add role-based navigation, safe multi-path quickstarts, complete Unraid settings/GraphQL/recovery coverage, and a tracked Markdown link/anchor CI guard
 * **unraid:** add canonical settings/dashboard routes, original Yarr artwork, a persistent dashboard toggle, and a compact freshness-aware runtime widget
 * **auth:** add configurable static bearer scopes (`YARR_MCP_STATIC_TOKEN_SCOPES`) and fail closed when Code Mode is served by a read-only static bearer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* **config:** load additive YAML/TOML fleets through `YARR_FLEET_FILE` with strict environment-only secret indirection and environment-over-file precedence
 * **safety:** classify high-impact generated operations explicitly, elicit non-DELETE Plex session/library mutations, cap destructive fleet targets, and support per-instance `YARR_FLEET_READONLY`
 * **docs:** add role-based navigation, safe multi-path quickstarts, complete Unraid settings/GraphQL/recovery coverage, and a tracked Markdown link/anchor CI guard
 * **unraid:** add canonical settings/dashboard routes, original Yarr artwork, a persistent dashboard toggle, and a compact freshness-aware runtime widget

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add review-only `yarr discover plex` scaffolding with owned-server defaults,
+  identifier-pinned drift detection, private token output, and Tautulli pairing.
 - Scale the Code Mode deadline for fleet workloads and preserve per-instance
   truncation signals instead of silently cutting a multi-server result.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Scale the Code Mode deadline for fleet workloads and preserve per-instance
+  truncation signals instead of silently cutting a multi-server result.
+
 ### Changed
 
 * **deps:** pin `rmcp` to an exact `=3.0.0-beta.2` (was a caret `"2.1.0"` that had already drifted to `2.2.0` in the lockfile). `ServerHandler::call_tool`/`read_resource`/`get_prompt` now return the `CallToolResponse`/`ReadResourceResponse`/`GetPromptResponse` wrappers, and `StreamableHttpServerConfig::with_stateful_mode` is now `with_legacy_session_mode`; both are behaviour-preserving. The elicitation API is unchanged, so destructive-delete gating stays fail-closed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4274,6 +4274,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2 0.10.9",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4266,6 +4266,7 @@ dependencies = [
  "chrono",
  "dirs",
  "fs2",
+ "futures-util",
  "labby-auth",
  "reqwest",
  "rmcp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2826,6 +2826,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3457,6 +3470,12 @@ dependencies = [
  "crypto-common 0.1.6",
  "subtle",
 ]
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
@@ -4254,6 +4273,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "serde_yaml",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,7 @@ chrono = { version = "0.4", features = ["serde"] }
 
 # Config
 toml = "1.1"
+serde_yaml = "0.9"
 
 # OAuth + JWT
 lab-auth = { git = "https://github.com/dinglebear-ai/labby.git", rev = "53dbc4798567f3cacc0f740b3b4de5839ca39133", package = "labby-auth", features = ["http-axum"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,6 +123,7 @@ rquickjs = "0.12"
 anyhow = "1"
 thiserror = "2"
 sha2 = "0.10"
+futures-util = "0.3"
 
 [profile.release]
 lto = "thin"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,6 +122,7 @@ rquickjs = "0.12"
 # Errors
 anyhow = "1"
 thiserror = "2"
+sha2 = "0.10"
 
 [profile.release]
 lto = "thin"

--- a/README.md
+++ b/README.md
@@ -397,6 +397,10 @@ login. Plex and Jellyfin token headers are handled separately.
 `YARR_MCP_TOOL_MODE=flat` only when a gateway should see separate per-service
 tools.
 
+See [Multiple instances of one kind](docs/CONFIG.md#multiple-instances-of-one-kind)
+for named Plex/Tautulli fleets, `YARR_<NAME>_KIND`, environment-namespace
+mapping, Code Mode naming, ambiguity behavior, and reserved globals.
+
 ## Authentication
 
 `YARR_MCP_TOKEN` authenticates `/mcp` on any HTTP bind, including loopback.

--- a/README.md
+++ b/README.md
@@ -430,11 +430,18 @@ bearer or OAuth transport auth. `service_status` requires `yarr:read`.
 Credentialed passthrough, generated operations, curated write operations, and
 Code Mode require `yarr:write`; write satisfies read.
 
-Generated DELETE operations, `api_delete`, `download_remove`,
+Generated operations use a reviewed safety classification: every DELETE plus
+high-impact non-DELETE operations such as Plex session termination, metadata
+edits, section changes, and scans are destructive. `api_delete`, `download_remove`,
 `stats_delete_image_cache`, and `trace_terminate_stream` are destructive. CLI
 commands dispatch them immediately. MCP callers get an interactive elicitation
 prompt at the actual dispatch point, including inside Code Mode, with no call
 argument or nested `callTool` path that can skip it.
+
+`YARR_FLEET_READONLY` rejects all mutations for named instances regardless of
+scope or transport. Destructive fleet dispatch is capped by
+`YARR_MCP_DESTRUCTIVE_FANOUT_MAX` (default `3`) and uses one confirmation naming
+all targets.
 
 Responses are capped by the shared token-limit layer before they are returned to
 MCP clients.

--- a/README.md
+++ b/README.md
@@ -400,6 +400,8 @@ tools.
 See [Multiple instances of one kind](docs/CONFIG.md#multiple-instances-of-one-kind)
 for named Plex/Tautulli fleets, `YARR_<NAME>_KIND`, environment-namespace
 mapping, Code Mode naming, ambiguity behavior, and reserved globals.
+For account-scaffolded fleets, see
+[Plex account discovery](docs/CONFIG.md#plex-account-discovery).
 
 ## Authentication
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -52,6 +52,56 @@ YARR_PLEX_TOKEN=...
 
 Supported kinds: `sonarr`, `radarr`, `prowlarr`, `tautulli`, `overseerr`, `bazarr`, `tracearr`, `sabnzbd`, `qbittorrent`, `plex`, and `jellyfin`.
 
+### Multiple instances of one kind
+
+Each item in `YARR_SERVICES` is a configured **name**, not necessarily a service
+kind. Set `YARR_<NAME>_KIND` when the name differs from its kind:
+
+```bash
+YARR_SERVICES=plex_den,tautulli_den,plex_4k,tautulli_4k,sonarr,radarr
+
+YARR_PLEX_DEN_KIND=plex
+YARR_PLEX_DEN_URL=http://10.0.0.11:32400
+YARR_PLEX_DEN_TOKEN=...
+
+YARR_TAUTULLI_DEN_KIND=tautulli
+YARR_TAUTULLI_DEN_URL=http://10.0.0.11:8181
+YARR_TAUTULLI_DEN_API_KEY=...
+
+YARR_PLEX_4K_KIND=plex
+YARR_PLEX_4K_URL=http://10.0.0.12:32400
+YARR_PLEX_4K_TOKEN=...
+
+YARR_TAUTULLI_4K_KIND=tautulli
+YARR_TAUTULLI_4K_URL=http://10.0.0.12:8181
+YARR_TAUTULLI_4K_API_KEY=...
+
+YARR_SONARR_URL=http://10.0.0.20:8989
+YARR_SONARR_API_KEY=...
+YARR_RADARR_URL=http://10.0.0.20:7878
+YARR_RADARR_API_KEY=...
+```
+
+Configured names determine both environment namespaces and Code Mode globals:
+
+- Environment mapping uppercases the name and replaces every non-ASCII
+  alphanumeric character with `_`. Both `plex-den` and `plex_den` map to
+  `YARR_PLEX_DEN_*`, so configuring both fails with a duplicate-namespace error.
+- Prefer lowercase names with underscores. `plex_den` is a valid JavaScript
+  identifier and supports `plex_den.get_sessions()`. A name such as `plex-den`
+  requires bracket access: `globalThis["plex-den"].get_sessions()`.
+- Exact configured names always win during service resolution. A bare kind such
+  as `plex` is a convenience only while exactly one Plex instance exists. With
+  two Plex instances it is intentionally ambiguous, and the error lists the
+  configured names to use instead.
+- The Code Mode runtime owns these reserved globals: `api`, `callTool`,
+  `codemode`, `console`, `globalThis`, `input`, and `writeArtifact`. A service
+  name colliding with one of them fails startup and lists the reserved names.
+
+Names are matched case-insensitively for identity and must be unique. These
+rules are validated at startup so a configured service can never disappear
+silently from Code Mode.
+
 ### Fleet write safety
 
 Set `YARR_FLEET_READONLY` to configured instance names that must never accept a

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -172,6 +172,40 @@ Optional `client_identifier`, `plex`, and `relay_only` fields retain discovery
 identity, Tautulli pairing, and relay-selection metadata. They do not affect
 authentication.
 
+### Plex account discovery
+
+Scaffold owned Plex servers from a plex.tv account token without putting that
+token or any per-server token in a tool argument:
+
+```bash
+export PLEX_ACCOUNT_TOKEN=...
+yarr discover plex --owned-only --output fleet.yaml --env-output fleet.env
+```
+
+Owned servers are the default; use `--include-shared` only after reviewing the
+authority implications. Discovery filters resources to those whose `provides`
+list contains `server`, selects a local connection first, then direct HTTPS,
+then relay, and flags relay-only instances. Names are deterministic
+`plex_<server_slug>` identifiers; colliding slugs receive a stable short hash of
+the Plex `clientIdentifier`. The fleet file pins that identifier and contains
+only `token_env` references. `fleet.env` contains the per-resource tokens and is
+created with mode 0600 on Unix.
+
+Discovery never overwrites either output. Review and commit the fleet YAML, then
+load the companion secrets into the process environment (or merge them into
+your existing secret-managed `.env`). On subsequent runs use:
+
+```bash
+yarr discover plex --diff --output fleet.yaml
+```
+
+The diff is keyed by `clientIdentifier`, reports added, removed, renamed, and
+URL-changed servers, and exits 2 when drift exists. Configured Tautulli
+instances are queried with `get_server_info`; matches on `pms_identifier` are
+emitted as `plex: <name>` pairing hints, and the report names unpaired instances
+on both sides. An environment-declared Tautulli of the same name still
+overrides its URL and credential while retaining the file's pairing metadata.
+
 ### Fleet write safety
 
 Set `YARR_FLEET_READONLY` to configured instance names that must never accept a

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -25,6 +25,8 @@ Configuration can come from `config.toml`, environment variables, or `.env` file
 | `YARR_MCP_CODEMODE_MAX_CONCURRENT` | `4` | Maximum concurrently executing Code Mode runtimes; must be at least 1 |
 | `YARR_MCP_CODEMODE_QUEUE_TIMEOUT_MS` | `500` | Maximum admission-queue wait before failing busy; must be non-zero |
 | `YARR_MCP_CODEMODE_TIMEOUT_SECS` | `30` | Execution deadline for one Code Mode run; must be non-zero |
+| `YARR_MCP_DESTRUCTIVE_FANOUT_MAX` | `3` | Maximum instances in one destructive fleet dispatch; must be at least 1 |
+| `YARR_FLEET_READONLY` | unset | Comma-separated configured service names that reject every mutation on CLI and MCP |
 
 ## Unauthenticated endpoints
 
@@ -49,6 +51,24 @@ YARR_PLEX_TOKEN=...
 ```
 
 Supported kinds: `sonarr`, `radarr`, `prowlarr`, `tautulli`, `overseerr`, `bazarr`, `tracearr`, `sabnzbd`, `qbittorrent`, `plex`, and `jellyfin`.
+
+### Fleet write safety
+
+Set `YARR_FLEET_READONLY` to configured instance names that must never accept a
+mutation, even when the caller has `yarr:write` or uses the trusted local CLI:
+
+```bash
+YARR_FLEET_READONLY=plex_prod,tautulli_prod
+```
+
+Unknown names fail startup. Generated operations are classified from a reviewed
+operation table: every HTTP DELETE is destructive, and high-impact non-DELETE
+operations such as Plex `terminate_session`, metadata edits, section changes,
+and scans are also destructive. MCP dispatch elicits once with every affected
+instance named. A destructive fleet call above
+`YARR_MCP_DESTRUCTIVE_FANOUT_MAX` is refused; target smaller groups explicitly.
+The generated classification report is in
+[Tools, Actions, Params, and Endpoints](TOOLS_ACTIONS_ENDPOINTS.md).
 
 ## Auth Policy
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -102,6 +102,61 @@ Names are matched case-insensitively for identity and must be unique. These
 rules are validated at startup so a configured service can never disappear
 silently from Code Mode.
 
+### Fleet configuration file
+
+For larger fleets, set `YARR_FLEET_FILE` to a `.yaml`, `.yml`, or `.toml` file.
+The file is additive: its entries are combined with `config.toml` and
+`YARR_SERVICES`. Environment-declared entries replace a same-named file entry;
+unique entries from both sources remain. The final union is sorted by configured
+name and passes the same duplicate-name, namespace-collision, reserved-global,
+and read-only validation as environment-only configuration.
+
+YAML example:
+
+```yaml
+services:
+  - name: plex_den
+    kind: plex
+    url: http://10.0.0.11:32400
+    token_env: PLEX_DEN_TOKEN
+    client_identifier: 0123456789abcdef
+  - name: tautulli_den
+    kind: tautulli
+    url: http://10.0.0.11:8181
+    api_key_env: TAUTULLI_DEN_KEY
+    plex: plex_den
+```
+
+Equivalent TOML:
+
+```toml
+[[services]]
+name = "plex_den"
+kind = "plex"
+url = "http://10.0.0.11:32400"
+token_env = "PLEX_DEN_TOKEN"
+client_identifier = "0123456789abcdef"
+
+[[services]]
+name = "tautulli_den"
+kind = "tautulli"
+url = "http://10.0.0.11:8181"
+api_key_env = "TAUTULLI_DEN_KEY"
+plex = "plex_den"
+```
+
+Fleet files never contain credential values. They may reference only
+`token_env`, `api_key_env`, `username_env`, and `password_env`; each value is an
+environment variable name resolved at startup. Inline fields such as `token`,
+`api_key`, `username`, or `password` are rejected with the source file, entry
+name, and line. A referenced variable that is unset or empty also fails startup.
+This keeps reviewable topology in the fleet file and secrets in `.env` or the
+process environment.
+
+Optional `client_identifier`, `plex`, and `relay_only` fields retain discovery
+identity, Tautulli pairing, and relay-selection metadata. They do not affect
+authentication.
+
 ### Fleet write safety
 
 Set `YARR_FLEET_READONLY` to configured instance names that must never accept a

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -22,11 +22,26 @@ Configuration can come from `config.toml`, environment variables, or `.env` file
 | `YARR_MCP_ALLOWED_ORIGINS` | unset | Extra CORS origins |
 | `YARR_MCP_AUTH_MODE` | `bearer` | `bearer` or `oauth` |
 | `YARR_MCP_TOOL_MODE` | `codemode` | `codemode` (one `yarr` tool; the fleet is reached inside a Code Mode script) or `flat` (one action-dispatched tool per configured service, no Code Mode layer; useful behind gateways that already provide dynamic discovery/Code Mode) |
-| `YARR_MCP_CODEMODE_MAX_CONCURRENT` | `4` | Maximum concurrently executing Code Mode runtimes; must be at least 1 |
+| `YARR_MCP_CODEMODE_MAX_CONCURRENT` | `4` | Maximum concurrently executing Code Mode runtimes (whole scripts, not requests within one script); must be at least 1 |
 | `YARR_MCP_CODEMODE_QUEUE_TIMEOUT_MS` | `500` | Maximum admission-queue wait before failing busy; must be non-zero |
-| `YARR_MCP_CODEMODE_TIMEOUT_SECS` | `30` | Execution deadline for one Code Mode run; must be non-zero |
+| `YARR_MCP_CODEMODE_TIMEOUT_SECS` | `120` | Execution deadline for one Code Mode run; fleet fanout must fit inside it; must be non-zero |
 | `YARR_MCP_DESTRUCTIVE_FANOUT_MAX` | `3` | Maximum instances in one destructive fleet dispatch; must be at least 1 |
 | `YARR_FLEET_READONLY` | unset | Comma-separated configured service names that reject every mutation on CLI and MCP |
+
+### Fleet runtime sizing
+
+`YARR_MCP_CODEMODE_MAX_CONCURRENT` limits whole QuickJS runtimes admitted by the
+server; it does not throttle calls made inside one script. Fleet fanout has its
+own bounded concurrency and per-instance timeout (see Fleet Code Mode below),
+and every wave must finish inside `YARR_MCP_CODEMODE_TIMEOUT_SECS`.
+
+The shared HTTP client maintains a pool per upstream host (up to eight idle
+connections per host), so a slow Plex server does not consume a global
+connection pool. The QuickJS heap remains 64 MiB: fleet responses are bounded
+and summarized before they can be returned to the client. If one instance's
+value exceeds its share of the response budget, that instance is returned with
+`truncated: true`, a type/item-count/byte summary, and `value: null`; other
+instances retain independent completeness flags.
 
 ## Unauthenticated endpoints
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -26,6 +26,8 @@ Configuration can come from `config.toml`, environment variables, or `.env` file
 | `YARR_MCP_CODEMODE_QUEUE_TIMEOUT_MS` | `500` | Maximum admission-queue wait before failing busy; must be non-zero |
 | `YARR_MCP_CODEMODE_TIMEOUT_SECS` | `120` | Execution deadline for one Code Mode run; fleet fanout must fit inside it; must be non-zero |
 | `YARR_MCP_DESTRUCTIVE_FANOUT_MAX` | `3` | Maximum instances in one destructive fleet dispatch; must be at least 1 |
+| `YARR_FLEET_MAX_CONCURRENT` | `8` | Maximum upstream calls running concurrently inside one `fleet.map`; must be at least 1 |
+| `YARR_FLEET_INSTANCE_TIMEOUT_SECS` | `8` | Independent deadline for each instance in a fleet operation; must be at least 1 |
 | `YARR_FLEET_READONLY` | unset | Comma-separated configured service names that reject every mutation on CLI and MCP |
 
 ### Fleet runtime sizing
@@ -42,6 +44,38 @@ and summarized before they can be returned to the client. If one instance's
 value exceeds its share of the response budget, that instance is returned with
 `truncated: true`, a type/item-count/byte summary, and `value: null`; other
 instances retain independent completeness flags.
+
+### Fleet Code Mode
+
+The Code Mode preamble exposes configured names and bounded host-backed fanout:
+
+```js
+fleet.of("plex")
+// ["plex_4k", "plex_den"]
+
+fleet.all()
+// [{ name: "plex_4k", kind: "plex" }, ...]
+
+await fleet.map("plex", server => server.list_sessions())
+// [{ name, ok: true, value, truncated: false, elapsed_ms },
+//  { name, ok: false, error, truncated: false, elapsed_ms }]
+
+await fleet.status()
+```
+
+`fleet.map` records exactly one service method from its callback and dispatches
+that method in Rust with bounded parallelism. An individual failure or timeout
+never rejects the map; results are sorted by configured name. Invalid kinds or
+methods reject before dispatch. Destructive methods are classified before any
+request begins: MCP elicits once with every target named, and the destructive
+fanout cap is enforced before the prompt. Read-only instances still reject
+mutations independently.
+
+Four built-in snippets are always listed by `codemode.snippets()` and run with
+`codemode.run(name)`: `fleet_activity`, `fleet_health`,
+`fleet_library_sizes`, and `fleet_transcode_load`. Built-ins cannot be
+overwritten or deleted and work even when no writable snippet directory is
+configured.
 
 ## Unauthenticated endpoints
 

--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -64,6 +64,8 @@ access, ambiguity errors, and reserved globals.
 | `YARR_MCP_CODEMODE_QUEUE_TIMEOUT_MS` | `500` | Admission wait in milliseconds before returning busy. |
 | `YARR_MCP_CODEMODE_TIMEOUT_SECS` | `120` | Per-run Code Mode execution deadline, including all fleet fanout waves. |
 | `YARR_MCP_DESTRUCTIVE_FANOUT_MAX` | `3` | Hard maximum instance count for one destructive fleet call. Larger calls fail closed and must be targeted in smaller groups. |
+| `YARR_FLEET_MAX_CONCURRENT` | `8` | Bounded concurrency for one host-backed `fleet.map`. |
+| `YARR_FLEET_INSTANCE_TIMEOUT_SECS` | `8` | Per-instance fleet deadline; one timeout becomes that instance's `ok:false` result. |
 
 ## OAuth mode
 

--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -34,6 +34,7 @@ access, ambiguity errors, and reserved globals.
 |---|---|
 | `YARR_SERVICES` | Comma-separated configured service names, for example `sonarr,radarr,plex`. |
 | `YARR_FLEET_FILE` | Additive `.yaml`, `.yml`, or `.toml` fleet definition. File entries use credential `*_env` references; environment services override same-named entries. |
+| `PLEX_ACCOUNT_TOKEN` | Account token used only by `yarr discover plex`; override the variable name with `--token-env`. It is never written to fleet YAML. |
 | `YARR_<SERVICE>_KIND` | Optional service kind override. Defaults to the service name. |
 | `YARR_<SERVICE>_URL` | Upstream service base URL. Required for each configured service. |
 | `YARR_<SERVICE>_API_KEY` | API key for services that use `X-Api-Key`, query API keys, or token-compatible auth. |

--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -25,6 +25,11 @@ The template uses `YARR_*` variables. Rename the prefix when adapting the templa
 
 ## Upstream services
 
+For two or more instances of the same kind, see
+[Multiple instances of one kind](CONFIG.md#multiple-instances-of-one-kind). That
+section documents configured-name mapping, namespace collisions, Code Mode
+access, ambiguity errors, and reserved globals.
+
 | Variable | Purpose |
 |---|---|
 | `YARR_SERVICES` | Comma-separated configured service names, for example `sonarr,radarr,plex`. |

--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -36,6 +36,7 @@ The template uses `YARR_*` variables. Rename the prefix when adapting the templa
 | `YARR_<SERVICE>_TOKEN` | Bearer/token auth for services such as Plex or Jellyfin. |
 | `YARR_HTTP_TIMEOUT_SECS` | Per-request upstream timeout in seconds (default `30`). Raise for stacks with slow upstreams (e.g. a Prowlarr `/indexer` read that fans out to many trackers). `0`/unparseable falls back to `30`. |
 | `YARR_HOME` | Runtime data root. Defaults to `/data` in a container and `~/.yarr` otherwise. |
+| `YARR_FLEET_READONLY` | Comma-separated configured instance names that reject every mutating action on every transport. Unknown names fail startup. |
 
 ## MCP HTTP server
 
@@ -55,6 +56,7 @@ The template uses `YARR_*` variables. Rename the prefix when adapting the templa
 | `YARR_MCP_CODEMODE_MAX_CONCURRENT` | `4` | Maximum active Code Mode runtimes. |
 | `YARR_MCP_CODEMODE_QUEUE_TIMEOUT_MS` | `500` | Admission wait in milliseconds before returning busy. |
 | `YARR_MCP_CODEMODE_TIMEOUT_SECS` | `30` | Per-run Code Mode execution deadline. |
+| `YARR_MCP_DESTRUCTIVE_FANOUT_MAX` | `3` | Hard maximum instance count for one destructive fleet call. Larger calls fail closed and must be targeted in smaller groups. |
 
 ## OAuth mode
 

--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -33,6 +33,7 @@ access, ambiguity errors, and reserved globals.
 | Variable | Purpose |
 |---|---|
 | `YARR_SERVICES` | Comma-separated configured service names, for example `sonarr,radarr,plex`. |
+| `YARR_FLEET_FILE` | Additive `.yaml`, `.yml`, or `.toml` fleet definition. File entries use credential `*_env` references; environment services override same-named entries. |
 | `YARR_<SERVICE>_KIND` | Optional service kind override. Defaults to the service name. |
 | `YARR_<SERVICE>_URL` | Upstream service base URL. Required for each configured service. |
 | `YARR_<SERVICE>_API_KEY` | API key for services that use `X-Api-Key`, query API keys, or token-compatible auth. |
@@ -101,6 +102,8 @@ Only required when `YARR_MCP_AUTH_MODE=oauth`:
 ```bash
 # .env — secrets and URLs ONLY
 YARR_SERVICES=sonarr,radarr,plex
+# Optional reviewable topology file; secrets referenced by it remain below.
+# YARR_FLEET_FILE=/data/fleet.yaml
 YARR_SONARR_URL=https://sonarr.internal
 YARR_SONARR_API_KEY=your_sonarr_key_here
 YARR_RADARR_URL=https://radarr.internal

--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -61,7 +61,7 @@ access, ambiguity errors, and reserved globals.
 | `YARR_MCP_TOOL_MODE` | `codemode` | `codemode` or `flat`. See [CONFIG.md](CONFIG.md) for the tradeoff. |
 | `YARR_MCP_CODEMODE_MAX_CONCURRENT` | `4` | Maximum active Code Mode runtimes. |
 | `YARR_MCP_CODEMODE_QUEUE_TIMEOUT_MS` | `500` | Admission wait in milliseconds before returning busy. |
-| `YARR_MCP_CODEMODE_TIMEOUT_SECS` | `30` | Per-run Code Mode execution deadline. |
+| `YARR_MCP_CODEMODE_TIMEOUT_SECS` | `120` | Per-run Code Mode execution deadline, including all fleet fanout waves. |
 | `YARR_MCP_DESTRUCTIVE_FANOUT_MAX` | `3` | Hard maximum instance count for one destructive fleet call. Larger calls fail closed and must be targeted in smaller groups. |
 
 ## OAuth mode

--- a/docs/TOOLS_ACTIONS_ENDPOINTS.md
+++ b/docs/TOOLS_ACTIONS_ENDPOINTS.md
@@ -1,11 +1,5 @@
 ---
 title: "Tools, Actions, Params, and Endpoints"
-created: 2026-06-18
-updated: 2026-07-30
----
-
----
-title: "Tools, Actions, Params, and Endpoints"
 doc_type: "reference"
 status: "active"
 owner: "yarr"
@@ -108,6 +102,1365 @@ client elicitation for DELETEs; clients without elicitation support fail closed.
 | `jellyfin` | 346 | none |
 
 The generator omits an operation only when its OpenAPI serialization cannot be represented losslessly. Omitted rows are not callable through `op`; use a reviewed generic passthrough only when the service path allowlist permits it.
+
+### Generated-operation safety coverage
+
+Every generated operation is classified below. `destructive (elicited)` includes every DELETE plus explicitly audited high-impact non-DELETE operations. `cargo xtask tool-docs --check` fails when the reviewed write inventory changes.
+
+| Operation | Method | Safety |
+|---|---|---|
+| `sonarr.delete_autotagging_by_id` | `DELETE` | destructive (elicited) |
+| `sonarr.delete_blocklist_bulk` | `DELETE` | destructive (elicited) |
+| `sonarr.delete_blocklist_by_id` | `DELETE` | destructive (elicited) |
+| `sonarr.delete_command_by_id` | `DELETE` | destructive (elicited) |
+| `sonarr.delete_customfilter_by_id` | `DELETE` | destructive (elicited) |
+| `sonarr.delete_customformat_bulk` | `DELETE` | destructive (elicited) |
+| `sonarr.delete_customformat_by_id` | `DELETE` | destructive (elicited) |
+| `sonarr.delete_delayprofile_by_id` | `DELETE` | destructive (elicited) |
+| `sonarr.delete_downloadclient_bulk` | `DELETE` | destructive (elicited) |
+| `sonarr.delete_downloadclient_by_id` | `DELETE` | destructive (elicited) |
+| `sonarr.delete_episodefile_bulk` | `DELETE` | destructive (elicited) |
+| `sonarr.delete_episodefile_by_id` | `DELETE` | destructive (elicited) |
+| `sonarr.delete_importlist_bulk` | `DELETE` | destructive (elicited) |
+| `sonarr.delete_importlist_by_id` | `DELETE` | destructive (elicited) |
+| `sonarr.delete_importlistexclusion_bulk` | `DELETE` | destructive (elicited) |
+| `sonarr.delete_importlistexclusion_by_id` | `DELETE` | destructive (elicited) |
+| `sonarr.delete_indexer_bulk` | `DELETE` | destructive (elicited) |
+| `sonarr.delete_indexer_by_id` | `DELETE` | destructive (elicited) |
+| `sonarr.delete_languageprofile_by_id` | `DELETE` | destructive (elicited) |
+| `sonarr.delete_metadata_by_id` | `DELETE` | destructive (elicited) |
+| `sonarr.delete_notification_by_id` | `DELETE` | destructive (elicited) |
+| `sonarr.delete_qualityprofile_by_id` | `DELETE` | destructive (elicited) |
+| `sonarr.delete_queue_bulk` | `DELETE` | destructive (elicited) |
+| `sonarr.delete_queue_by_id` | `DELETE` | destructive (elicited) |
+| `sonarr.delete_releaseprofile_by_id` | `DELETE` | destructive (elicited) |
+| `sonarr.delete_remotepathmapping_by_id` | `DELETE` | destructive (elicited) |
+| `sonarr.delete_rootfolder_by_id` | `DELETE` | destructive (elicited) |
+| `sonarr.delete_series_by_id` | `DELETE` | destructive (elicited) |
+| `sonarr.delete_series_editor` | `DELETE` | destructive (elicited) |
+| `sonarr.delete_system_backup_by_id` | `DELETE` | destructive (elicited) |
+| `sonarr.delete_tag_by_id` | `DELETE` | destructive (elicited) |
+| `sonarr.get` | `GET` | read |
+| `sonarr.get_autotagging` | `GET` | read |
+| `sonarr.get_autotagging_by_id` | `GET` | read |
+| `sonarr.get_autotagging_schema` | `GET` | read |
+| `sonarr.get_blocklist` | `GET` | read |
+| `sonarr.get_by_path_2` | `GET` | read |
+| `sonarr.get_calendar` | `GET` | read |
+| `sonarr.get_calendar_by_id` | `GET` | read |
+| `sonarr.get_command` | `GET` | read |
+| `sonarr.get_command_by_id` | `GET` | read |
+| `sonarr.get_config_downloadclient` | `GET` | read |
+| `sonarr.get_config_downloadclient_by_id` | `GET` | read |
+| `sonarr.get_config_host` | `GET` | read |
+| `sonarr.get_config_host_by_id` | `GET` | read |
+| `sonarr.get_config_importlist` | `GET` | read |
+| `sonarr.get_config_importlist_by_id` | `GET` | read |
+| `sonarr.get_config_indexer` | `GET` | read |
+| `sonarr.get_config_indexer_by_id` | `GET` | read |
+| `sonarr.get_config_mediamanagement` | `GET` | read |
+| `sonarr.get_config_mediamanagement_by_id` | `GET` | read |
+| `sonarr.get_config_naming` | `GET` | read |
+| `sonarr.get_config_naming_by_id` | `GET` | read |
+| `sonarr.get_config_naming_examples` | `GET` | read |
+| `sonarr.get_config_ui` | `GET` | read |
+| `sonarr.get_config_ui_by_id` | `GET` | read |
+| `sonarr.get_content_by_path` | `GET` | read |
+| `sonarr.get_customfilter` | `GET` | read |
+| `sonarr.get_customfilter_by_id` | `GET` | read |
+| `sonarr.get_customformat` | `GET` | read |
+| `sonarr.get_customformat_by_id` | `GET` | read |
+| `sonarr.get_customformat_schema` | `GET` | read |
+| `sonarr.get_delayprofile` | `GET` | read |
+| `sonarr.get_delayprofile_by_id` | `GET` | read |
+| `sonarr.get_diskspace` | `GET` | read |
+| `sonarr.get_downloadclient` | `GET` | read |
+| `sonarr.get_downloadclient_by_id` | `GET` | read |
+| `sonarr.get_downloadclient_schema` | `GET` | read |
+| `sonarr.get_episode` | `GET` | read |
+| `sonarr.get_episode_by_id` | `GET` | read |
+| `sonarr.get_episodefile` | `GET` | read |
+| `sonarr.get_episodefile_by_id` | `GET` | read |
+| `sonarr.get_feed_calendar_sonarr_ics` | `GET` | read |
+| `sonarr.get_filesystem` | `GET` | read |
+| `sonarr.get_filesystem_mediafiles` | `GET` | read |
+| `sonarr.get_filesystem_type` | `GET` | read |
+| `sonarr.get_health` | `GET` | read |
+| `sonarr.get_history` | `GET` | read |
+| `sonarr.get_history_series` | `GET` | read |
+| `sonarr.get_history_since` | `GET` | read |
+| `sonarr.get_importlist` | `GET` | read |
+| `sonarr.get_importlist_by_id` | `GET` | read |
+| `sonarr.get_importlist_schema` | `GET` | read |
+| `sonarr.get_importlistexclusion` | `GET` | read |
+| `sonarr.get_importlistexclusion_by_id` | `GET` | read |
+| `sonarr.get_importlistexclusion_paged` | `GET` | read |
+| `sonarr.get_indexer` | `GET` | read |
+| `sonarr.get_indexer_by_id` | `GET` | read |
+| `sonarr.get_indexer_schema` | `GET` | read |
+| `sonarr.get_indexerflag` | `GET` | read |
+| `sonarr.get_language` | `GET` | read |
+| `sonarr.get_language_by_id` | `GET` | read |
+| `sonarr.get_languageprofile` | `GET` | read |
+| `sonarr.get_languageprofile_by_id` | `GET` | read |
+| `sonarr.get_languageprofile_schema` | `GET` | read |
+| `sonarr.get_localization` | `GET` | read |
+| `sonarr.get_localization_by_id` | `GET` | read |
+| `sonarr.get_localization_language` | `GET` | read |
+| `sonarr.get_log` | `GET` | read |
+| `sonarr.get_log_file` | `GET` | read |
+| `sonarr.get_log_file_by_filename` | `GET` | read |
+| `sonarr.get_log_file_update` | `GET` | read |
+| `sonarr.get_log_file_update_by_filename` | `GET` | read |
+| `sonarr.get_login` | `GET` | read |
+| `sonarr.get_logout` | `GET` | read |
+| `sonarr.get_manualimport` | `GET` | read |
+| `sonarr.get_mediacover_by_filename_series_id` | `GET` | read |
+| `sonarr.get_metadata` | `GET` | read |
+| `sonarr.get_metadata_by_id` | `GET` | read |
+| `sonarr.get_metadata_schema` | `GET` | read |
+| `sonarr.get_notification` | `GET` | read |
+| `sonarr.get_notification_by_id` | `GET` | read |
+| `sonarr.get_notification_schema` | `GET` | read |
+| `sonarr.get_parse` | `GET` | read |
+| `sonarr.get_ping` | `GET` | read |
+| `sonarr.get_qualitydefinition` | `GET` | read |
+| `sonarr.get_qualitydefinition_by_id` | `GET` | read |
+| `sonarr.get_qualitydefinition_limits` | `GET` | read |
+| `sonarr.get_qualityprofile` | `GET` | read |
+| `sonarr.get_qualityprofile_by_id` | `GET` | read |
+| `sonarr.get_qualityprofile_schema` | `GET` | read |
+| `sonarr.get_queue` | `GET` | read |
+| `sonarr.get_queue_details` | `GET` | read |
+| `sonarr.get_queue_status` | `GET` | read |
+| `sonarr.get_release` | `GET` | read |
+| `sonarr.get_releaseprofile` | `GET` | read |
+| `sonarr.get_releaseprofile_by_id` | `GET` | read |
+| `sonarr.get_remotepathmapping` | `GET` | read |
+| `sonarr.get_remotepathmapping_by_id` | `GET` | read |
+| `sonarr.get_rename` | `GET` | read |
+| `sonarr.get_rootfolder` | `GET` | read |
+| `sonarr.get_rootfolder_by_id` | `GET` | read |
+| `sonarr.get_series` | `GET` | read |
+| `sonarr.get_series_by_id` | `GET` | read |
+| `sonarr.get_series_folder_by_id` | `GET` | read |
+| `sonarr.get_series_lookup` | `GET` | read |
+| `sonarr.get_system_backup` | `GET` | read |
+| `sonarr.get_system_routes` | `GET` | read |
+| `sonarr.get_system_routes_duplicate` | `GET` | read |
+| `sonarr.get_system_status` | `GET` | read |
+| `sonarr.get_system_task` | `GET` | read |
+| `sonarr.get_system_task_by_id` | `GET` | read |
+| `sonarr.get_tag` | `GET` | read |
+| `sonarr.get_tag_by_id` | `GET` | read |
+| `sonarr.get_tag_detail` | `GET` | read |
+| `sonarr.get_tag_detail_by_id` | `GET` | read |
+| `sonarr.get_update` | `GET` | read |
+| `sonarr.get_wanted_cutoff` | `GET` | read |
+| `sonarr.get_wanted_cutoff_by_id` | `GET` | read |
+| `sonarr.get_wanted_missing` | `GET` | read |
+| `sonarr.get_wanted_missing_by_id` | `GET` | read |
+| `sonarr.post_autotagging` | `POST` | mutating |
+| `sonarr.post_command` | `POST` | destructive (elicited) |
+| `sonarr.post_customfilter` | `POST` | mutating |
+| `sonarr.post_customformat` | `POST` | mutating |
+| `sonarr.post_delayprofile` | `POST` | mutating |
+| `sonarr.post_downloadclient` | `POST` | mutating |
+| `sonarr.post_downloadclient_action_by_name` | `POST` | mutating |
+| `sonarr.post_downloadclient_test` | `POST` | mutating |
+| `sonarr.post_downloadclient_testall` | `POST` | mutating |
+| `sonarr.post_history_failed_by_id` | `POST` | mutating |
+| `sonarr.post_importlist` | `POST` | mutating |
+| `sonarr.post_importlist_action_by_name` | `POST` | mutating |
+| `sonarr.post_importlist_test` | `POST` | mutating |
+| `sonarr.post_importlist_testall` | `POST` | mutating |
+| `sonarr.post_importlistexclusion` | `POST` | mutating |
+| `sonarr.post_indexer` | `POST` | mutating |
+| `sonarr.post_indexer_action_by_name` | `POST` | mutating |
+| `sonarr.post_indexer_test` | `POST` | mutating |
+| `sonarr.post_indexer_testall` | `POST` | mutating |
+| `sonarr.post_languageprofile` | `POST` | mutating |
+| `sonarr.post_login` | `POST` | mutating |
+| `sonarr.post_manualimport` | `POST` | mutating |
+| `sonarr.post_metadata` | `POST` | mutating |
+| `sonarr.post_metadata_action_by_name` | `POST` | mutating |
+| `sonarr.post_metadata_test` | `POST` | mutating |
+| `sonarr.post_metadata_testall` | `POST` | mutating |
+| `sonarr.post_notification` | `POST` | mutating |
+| `sonarr.post_notification_action_by_name` | `POST` | mutating |
+| `sonarr.post_notification_test` | `POST` | mutating |
+| `sonarr.post_notification_testall` | `POST` | mutating |
+| `sonarr.post_qualityprofile` | `POST` | mutating |
+| `sonarr.post_queue_grab_bulk` | `POST` | mutating |
+| `sonarr.post_queue_grab_by_id` | `POST` | mutating |
+| `sonarr.post_release` | `POST` | mutating |
+| `sonarr.post_release_push` | `POST` | mutating |
+| `sonarr.post_releaseprofile` | `POST` | mutating |
+| `sonarr.post_remotepathmapping` | `POST` | mutating |
+| `sonarr.post_rootfolder` | `POST` | mutating |
+| `sonarr.post_seasonpass` | `POST` | mutating |
+| `sonarr.post_series` | `POST` | mutating |
+| `sonarr.post_series_import` | `POST` | mutating |
+| `sonarr.post_system_backup_restore_by_id` | `POST` | destructive (elicited) |
+| `sonarr.post_system_backup_restore_upload` | `POST` | destructive (elicited) |
+| `sonarr.post_system_restart` | `POST` | destructive (elicited) |
+| `sonarr.post_system_shutdown` | `POST` | destructive (elicited) |
+| `sonarr.post_tag` | `POST` | mutating |
+| `sonarr.put_autotagging_by_id` | `PUT` | mutating |
+| `sonarr.put_config_downloadclient_by_id` | `PUT` | mutating |
+| `sonarr.put_config_host_by_id` | `PUT` | mutating |
+| `sonarr.put_config_importlist_by_id` | `PUT` | mutating |
+| `sonarr.put_config_indexer_by_id` | `PUT` | mutating |
+| `sonarr.put_config_mediamanagement_by_id` | `PUT` | mutating |
+| `sonarr.put_config_naming_by_id` | `PUT` | mutating |
+| `sonarr.put_config_ui_by_id` | `PUT` | mutating |
+| `sonarr.put_customfilter_by_id` | `PUT` | mutating |
+| `sonarr.put_customformat_bulk` | `PUT` | mutating |
+| `sonarr.put_customformat_by_id` | `PUT` | mutating |
+| `sonarr.put_delayprofile_by_id` | `PUT` | mutating |
+| `sonarr.put_delayprofile_reorder_by_id` | `PUT` | mutating |
+| `sonarr.put_downloadclient_bulk` | `PUT` | mutating |
+| `sonarr.put_downloadclient_by_id` | `PUT` | mutating |
+| `sonarr.put_episode_by_id` | `PUT` | mutating |
+| `sonarr.put_episode_monitor` | `PUT` | mutating |
+| `sonarr.put_episodefile_bulk` | `PUT` | mutating |
+| `sonarr.put_episodefile_by_id` | `PUT` | mutating |
+| `sonarr.put_episodefile_editor` | `PUT` | mutating |
+| `sonarr.put_importlist_bulk` | `PUT` | mutating |
+| `sonarr.put_importlist_by_id` | `PUT` | mutating |
+| `sonarr.put_importlistexclusion_by_id` | `PUT` | mutating |
+| `sonarr.put_indexer_bulk` | `PUT` | mutating |
+| `sonarr.put_indexer_by_id` | `PUT` | mutating |
+| `sonarr.put_languageprofile_by_id` | `PUT` | mutating |
+| `sonarr.put_metadata_by_id` | `PUT` | mutating |
+| `sonarr.put_notification_by_id` | `PUT` | mutating |
+| `sonarr.put_qualitydefinition_by_id` | `PUT` | mutating |
+| `sonarr.put_qualitydefinition_update` | `PUT` | mutating |
+| `sonarr.put_qualityprofile_by_id` | `PUT` | mutating |
+| `sonarr.put_releaseprofile_by_id` | `PUT` | mutating |
+| `sonarr.put_remotepathmapping_by_id` | `PUT` | mutating |
+| `sonarr.put_series_by_id` | `PUT` | mutating |
+| `sonarr.put_series_editor` | `PUT` | destructive (elicited) |
+| `sonarr.put_tag_by_id` | `PUT` | mutating |
+| `radarr.delete_autotagging_by_id` | `DELETE` | destructive (elicited) |
+| `radarr.delete_blocklist_bulk` | `DELETE` | destructive (elicited) |
+| `radarr.delete_blocklist_by_id` | `DELETE` | destructive (elicited) |
+| `radarr.delete_command_by_id` | `DELETE` | destructive (elicited) |
+| `radarr.delete_customfilter_by_id` | `DELETE` | destructive (elicited) |
+| `radarr.delete_customformat_bulk` | `DELETE` | destructive (elicited) |
+| `radarr.delete_customformat_by_id` | `DELETE` | destructive (elicited) |
+| `radarr.delete_delayprofile_by_id` | `DELETE` | destructive (elicited) |
+| `radarr.delete_downloadclient_bulk` | `DELETE` | destructive (elicited) |
+| `radarr.delete_downloadclient_by_id` | `DELETE` | destructive (elicited) |
+| `radarr.delete_exclusions_bulk` | `DELETE` | destructive (elicited) |
+| `radarr.delete_exclusions_by_id` | `DELETE` | destructive (elicited) |
+| `radarr.delete_importlist_bulk` | `DELETE` | destructive (elicited) |
+| `radarr.delete_importlist_by_id` | `DELETE` | destructive (elicited) |
+| `radarr.delete_indexer_bulk` | `DELETE` | destructive (elicited) |
+| `radarr.delete_indexer_by_id` | `DELETE` | destructive (elicited) |
+| `radarr.delete_metadata_by_id` | `DELETE` | destructive (elicited) |
+| `radarr.delete_movie_by_id` | `DELETE` | destructive (elicited) |
+| `radarr.delete_movie_editor` | `DELETE` | destructive (elicited) |
+| `radarr.delete_moviefile_bulk` | `DELETE` | destructive (elicited) |
+| `radarr.delete_moviefile_by_id` | `DELETE` | destructive (elicited) |
+| `radarr.delete_notification_by_id` | `DELETE` | destructive (elicited) |
+| `radarr.delete_qualityprofile_by_id` | `DELETE` | destructive (elicited) |
+| `radarr.delete_queue_bulk` | `DELETE` | destructive (elicited) |
+| `radarr.delete_queue_by_id` | `DELETE` | destructive (elicited) |
+| `radarr.delete_releaseprofile_by_id` | `DELETE` | destructive (elicited) |
+| `radarr.delete_remotepathmapping_by_id` | `DELETE` | destructive (elicited) |
+| `radarr.delete_rootfolder_by_id` | `DELETE` | destructive (elicited) |
+| `radarr.delete_system_backup_by_id` | `DELETE` | destructive (elicited) |
+| `radarr.delete_tag_by_id` | `DELETE` | destructive (elicited) |
+| `radarr.get` | `GET` | read |
+| `radarr.get_alttitle` | `GET` | read |
+| `radarr.get_alttitle_by_id` | `GET` | read |
+| `radarr.get_autotagging` | `GET` | read |
+| `radarr.get_autotagging_by_id` | `GET` | read |
+| `radarr.get_autotagging_schema` | `GET` | read |
+| `radarr.get_blocklist` | `GET` | read |
+| `radarr.get_blocklist_movie` | `GET` | read |
+| `radarr.get_by_path_2` | `GET` | read |
+| `radarr.get_calendar` | `GET` | read |
+| `radarr.get_collection` | `GET` | read |
+| `radarr.get_collection_by_id` | `GET` | read |
+| `radarr.get_command` | `GET` | read |
+| `radarr.get_command_by_id` | `GET` | read |
+| `radarr.get_config_downloadclient` | `GET` | read |
+| `radarr.get_config_downloadclient_by_id` | `GET` | read |
+| `radarr.get_config_host` | `GET` | read |
+| `radarr.get_config_host_by_id` | `GET` | read |
+| `radarr.get_config_importlist` | `GET` | read |
+| `radarr.get_config_importlist_by_id` | `GET` | read |
+| `radarr.get_config_indexer` | `GET` | read |
+| `radarr.get_config_indexer_by_id` | `GET` | read |
+| `radarr.get_config_mediamanagement` | `GET` | read |
+| `radarr.get_config_mediamanagement_by_id` | `GET` | read |
+| `radarr.get_config_metadata` | `GET` | read |
+| `radarr.get_config_metadata_by_id` | `GET` | read |
+| `radarr.get_config_naming` | `GET` | read |
+| `radarr.get_config_naming_by_id` | `GET` | read |
+| `radarr.get_config_naming_examples` | `GET` | read |
+| `radarr.get_config_ui` | `GET` | read |
+| `radarr.get_config_ui_by_id` | `GET` | read |
+| `radarr.get_content_by_path` | `GET` | read |
+| `radarr.get_credit` | `GET` | read |
+| `radarr.get_credit_by_id` | `GET` | read |
+| `radarr.get_customfilter` | `GET` | read |
+| `radarr.get_customfilter_by_id` | `GET` | read |
+| `radarr.get_customformat` | `GET` | read |
+| `radarr.get_customformat_by_id` | `GET` | read |
+| `radarr.get_customformat_schema` | `GET` | read |
+| `radarr.get_delayprofile` | `GET` | read |
+| `radarr.get_delayprofile_by_id` | `GET` | read |
+| `radarr.get_diskspace` | `GET` | read |
+| `radarr.get_downloadclient` | `GET` | read |
+| `radarr.get_downloadclient_by_id` | `GET` | read |
+| `radarr.get_downloadclient_schema` | `GET` | read |
+| `radarr.get_exclusions` | `GET` | read |
+| `radarr.get_exclusions_by_id` | `GET` | read |
+| `radarr.get_exclusions_paged` | `GET` | read |
+| `radarr.get_extrafile` | `GET` | read |
+| `radarr.get_feed_calendar_radarr_ics` | `GET` | read |
+| `radarr.get_filesystem` | `GET` | read |
+| `radarr.get_filesystem_mediafiles` | `GET` | read |
+| `radarr.get_filesystem_type` | `GET` | read |
+| `radarr.get_health` | `GET` | read |
+| `radarr.get_history` | `GET` | read |
+| `radarr.get_history_movie` | `GET` | read |
+| `radarr.get_history_since` | `GET` | read |
+| `radarr.get_importlist` | `GET` | read |
+| `radarr.get_importlist_by_id` | `GET` | read |
+| `radarr.get_importlist_movie` | `GET` | read |
+| `radarr.get_importlist_schema` | `GET` | read |
+| `radarr.get_indexer` | `GET` | read |
+| `radarr.get_indexer_by_id` | `GET` | read |
+| `radarr.get_indexer_schema` | `GET` | read |
+| `radarr.get_indexerflag` | `GET` | read |
+| `radarr.get_language` | `GET` | read |
+| `radarr.get_language_by_id` | `GET` | read |
+| `radarr.get_localization` | `GET` | read |
+| `radarr.get_localization_language` | `GET` | read |
+| `radarr.get_log` | `GET` | read |
+| `radarr.get_log_file` | `GET` | read |
+| `radarr.get_log_file_by_filename` | `GET` | read |
+| `radarr.get_log_file_update` | `GET` | read |
+| `radarr.get_log_file_update_by_filename` | `GET` | read |
+| `radarr.get_login` | `GET` | read |
+| `radarr.get_logout` | `GET` | read |
+| `radarr.get_manualimport` | `GET` | read |
+| `radarr.get_mediacover_by_filename_movie_id` | `GET` | read |
+| `radarr.get_metadata` | `GET` | read |
+| `radarr.get_metadata_by_id` | `GET` | read |
+| `radarr.get_metadata_schema` | `GET` | read |
+| `radarr.get_movie` | `GET` | read |
+| `radarr.get_movie_by_id` | `GET` | read |
+| `radarr.get_movie_folder_by_id` | `GET` | read |
+| `radarr.get_movie_lookup` | `GET` | read |
+| `radarr.get_movie_lookup_imdb` | `GET` | read |
+| `radarr.get_movie_lookup_tmdb` | `GET` | read |
+| `radarr.get_moviefile` | `GET` | read |
+| `radarr.get_moviefile_by_id` | `GET` | read |
+| `radarr.get_notification` | `GET` | read |
+| `radarr.get_notification_by_id` | `GET` | read |
+| `radarr.get_notification_schema` | `GET` | read |
+| `radarr.get_parse` | `GET` | read |
+| `radarr.get_ping` | `GET` | read |
+| `radarr.get_qualitydefinition` | `GET` | read |
+| `radarr.get_qualitydefinition_by_id` | `GET` | read |
+| `radarr.get_qualitydefinition_limits` | `GET` | read |
+| `radarr.get_qualityprofile` | `GET` | read |
+| `radarr.get_qualityprofile_by_id` | `GET` | read |
+| `radarr.get_qualityprofile_schema` | `GET` | read |
+| `radarr.get_queue` | `GET` | read |
+| `radarr.get_queue_details` | `GET` | read |
+| `radarr.get_queue_status` | `GET` | read |
+| `radarr.get_release` | `GET` | read |
+| `radarr.get_releaseprofile` | `GET` | read |
+| `radarr.get_releaseprofile_by_id` | `GET` | read |
+| `radarr.get_remotepathmapping` | `GET` | read |
+| `radarr.get_remotepathmapping_by_id` | `GET` | read |
+| `radarr.get_rename` | `GET` | read |
+| `radarr.get_rootfolder` | `GET` | read |
+| `radarr.get_rootfolder_by_id` | `GET` | read |
+| `radarr.get_system_backup` | `GET` | read |
+| `radarr.get_system_routes` | `GET` | read |
+| `radarr.get_system_routes_duplicate` | `GET` | read |
+| `radarr.get_system_status` | `GET` | read |
+| `radarr.get_system_task` | `GET` | read |
+| `radarr.get_system_task_by_id` | `GET` | read |
+| `radarr.get_tag` | `GET` | read |
+| `radarr.get_tag_by_id` | `GET` | read |
+| `radarr.get_tag_detail` | `GET` | read |
+| `radarr.get_tag_detail_by_id` | `GET` | read |
+| `radarr.get_update` | `GET` | read |
+| `radarr.get_wanted_cutoff` | `GET` | read |
+| `radarr.get_wanted_missing` | `GET` | read |
+| `radarr.post_autotagging` | `POST` | mutating |
+| `radarr.post_command` | `POST` | destructive (elicited) |
+| `radarr.post_customfilter` | `POST` | mutating |
+| `radarr.post_customformat` | `POST` | mutating |
+| `radarr.post_delayprofile` | `POST` | mutating |
+| `radarr.post_downloadclient` | `POST` | mutating |
+| `radarr.post_downloadclient_action_by_name` | `POST` | mutating |
+| `radarr.post_downloadclient_test` | `POST` | mutating |
+| `radarr.post_downloadclient_testall` | `POST` | mutating |
+| `radarr.post_exclusions` | `POST` | mutating |
+| `radarr.post_exclusions_bulk` | `POST` | mutating |
+| `radarr.post_history_failed_by_id` | `POST` | mutating |
+| `radarr.post_importlist` | `POST` | mutating |
+| `radarr.post_importlist_action_by_name` | `POST` | mutating |
+| `radarr.post_importlist_movie` | `POST` | mutating |
+| `radarr.post_importlist_test` | `POST` | mutating |
+| `radarr.post_importlist_testall` | `POST` | mutating |
+| `radarr.post_indexer` | `POST` | mutating |
+| `radarr.post_indexer_action_by_name` | `POST` | mutating |
+| `radarr.post_indexer_test` | `POST` | mutating |
+| `radarr.post_indexer_testall` | `POST` | mutating |
+| `radarr.post_login` | `POST` | mutating |
+| `radarr.post_manualimport` | `POST` | mutating |
+| `radarr.post_metadata` | `POST` | mutating |
+| `radarr.post_metadata_action_by_name` | `POST` | mutating |
+| `radarr.post_metadata_test` | `POST` | mutating |
+| `radarr.post_metadata_testall` | `POST` | mutating |
+| `radarr.post_movie` | `POST` | mutating |
+| `radarr.post_movie_import` | `POST` | mutating |
+| `radarr.post_notification` | `POST` | mutating |
+| `radarr.post_notification_action_by_name` | `POST` | mutating |
+| `radarr.post_notification_test` | `POST` | mutating |
+| `radarr.post_notification_testall` | `POST` | mutating |
+| `radarr.post_qualityprofile` | `POST` | mutating |
+| `radarr.post_queue_grab_bulk` | `POST` | mutating |
+| `radarr.post_queue_grab_by_id` | `POST` | mutating |
+| `radarr.post_release` | `POST` | mutating |
+| `radarr.post_release_push` | `POST` | mutating |
+| `radarr.post_releaseprofile` | `POST` | mutating |
+| `radarr.post_remotepathmapping` | `POST` | mutating |
+| `radarr.post_rootfolder` | `POST` | mutating |
+| `radarr.post_system_backup_restore_by_id` | `POST` | destructive (elicited) |
+| `radarr.post_system_backup_restore_upload` | `POST` | destructive (elicited) |
+| `radarr.post_system_restart` | `POST` | destructive (elicited) |
+| `radarr.post_system_shutdown` | `POST` | destructive (elicited) |
+| `radarr.post_tag` | `POST` | mutating |
+| `radarr.put_autotagging_by_id` | `PUT` | mutating |
+| `radarr.put_collection` | `PUT` | mutating |
+| `radarr.put_collection_by_id` | `PUT` | mutating |
+| `radarr.put_config_downloadclient_by_id` | `PUT` | mutating |
+| `radarr.put_config_host_by_id` | `PUT` | mutating |
+| `radarr.put_config_importlist_by_id` | `PUT` | mutating |
+| `radarr.put_config_indexer_by_id` | `PUT` | mutating |
+| `radarr.put_config_mediamanagement_by_id` | `PUT` | mutating |
+| `radarr.put_config_metadata_by_id` | `PUT` | mutating |
+| `radarr.put_config_naming_by_id` | `PUT` | mutating |
+| `radarr.put_config_ui_by_id` | `PUT` | mutating |
+| `radarr.put_customfilter_by_id` | `PUT` | mutating |
+| `radarr.put_customformat_bulk` | `PUT` | mutating |
+| `radarr.put_customformat_by_id` | `PUT` | mutating |
+| `radarr.put_delayprofile_by_id` | `PUT` | mutating |
+| `radarr.put_delayprofile_reorder_by_id` | `PUT` | mutating |
+| `radarr.put_downloadclient_bulk` | `PUT` | mutating |
+| `radarr.put_downloadclient_by_id` | `PUT` | mutating |
+| `radarr.put_exclusions_by_id` | `PUT` | mutating |
+| `radarr.put_importlist_bulk` | `PUT` | mutating |
+| `radarr.put_importlist_by_id` | `PUT` | mutating |
+| `radarr.put_indexer_bulk` | `PUT` | mutating |
+| `radarr.put_indexer_by_id` | `PUT` | mutating |
+| `radarr.put_metadata_by_id` | `PUT` | mutating |
+| `radarr.put_movie_by_id` | `PUT` | mutating |
+| `radarr.put_movie_editor` | `PUT` | destructive (elicited) |
+| `radarr.put_moviefile_bulk` | `PUT` | mutating |
+| `radarr.put_moviefile_by_id` | `PUT` | mutating |
+| `radarr.put_moviefile_editor` | `PUT` | mutating |
+| `radarr.put_notification_by_id` | `PUT` | mutating |
+| `radarr.put_qualitydefinition_by_id` | `PUT` | mutating |
+| `radarr.put_qualitydefinition_update` | `PUT` | mutating |
+| `radarr.put_qualityprofile_by_id` | `PUT` | mutating |
+| `radarr.put_releaseprofile_by_id` | `PUT` | mutating |
+| `radarr.put_remotepathmapping_by_id` | `PUT` | mutating |
+| `radarr.put_tag_by_id` | `PUT` | mutating |
+| `prowlarr.delete_applications_bulk` | `DELETE` | destructive (elicited) |
+| `prowlarr.delete_applications_by_id` | `DELETE` | destructive (elicited) |
+| `prowlarr.delete_appprofile_by_id` | `DELETE` | destructive (elicited) |
+| `prowlarr.delete_command_by_id` | `DELETE` | destructive (elicited) |
+| `prowlarr.delete_customfilter_by_id` | `DELETE` | destructive (elicited) |
+| `prowlarr.delete_downloadclient_bulk` | `DELETE` | destructive (elicited) |
+| `prowlarr.delete_downloadclient_by_id` | `DELETE` | destructive (elicited) |
+| `prowlarr.delete_indexer_bulk` | `DELETE` | destructive (elicited) |
+| `prowlarr.delete_indexer_by_id` | `DELETE` | destructive (elicited) |
+| `prowlarr.delete_indexerproxy_by_id` | `DELETE` | destructive (elicited) |
+| `prowlarr.delete_notification_by_id` | `DELETE` | destructive (elicited) |
+| `prowlarr.delete_system_backup_by_id` | `DELETE` | destructive (elicited) |
+| `prowlarr.delete_tag_by_id` | `DELETE` | destructive (elicited) |
+| `prowlarr.get` | `GET` | read |
+| `prowlarr.get_applications` | `GET` | read |
+| `prowlarr.get_applications_by_id` | `GET` | read |
+| `prowlarr.get_applications_schema` | `GET` | read |
+| `prowlarr.get_appprofile` | `GET` | read |
+| `prowlarr.get_appprofile_by_id` | `GET` | read |
+| `prowlarr.get_appprofile_schema` | `GET` | read |
+| `prowlarr.get_by_id` | `GET` | read |
+| `prowlarr.get_by_path_2` | `GET` | read |
+| `prowlarr.get_command` | `GET` | read |
+| `prowlarr.get_command_by_id` | `GET` | read |
+| `prowlarr.get_config_development` | `GET` | read |
+| `prowlarr.get_config_development_by_id` | `GET` | read |
+| `prowlarr.get_config_downloadclient` | `GET` | read |
+| `prowlarr.get_config_downloadclient_by_id` | `GET` | read |
+| `prowlarr.get_config_host` | `GET` | read |
+| `prowlarr.get_config_host_by_id` | `GET` | read |
+| `prowlarr.get_config_ui` | `GET` | read |
+| `prowlarr.get_config_ui_by_id` | `GET` | read |
+| `prowlarr.get_content_by_path` | `GET` | read |
+| `prowlarr.get_customfilter` | `GET` | read |
+| `prowlarr.get_customfilter_by_id` | `GET` | read |
+| `prowlarr.get_download_by_id` | `GET` | read |
+| `prowlarr.get_downloadclient` | `GET` | read |
+| `prowlarr.get_downloadclient_by_id` | `GET` | read |
+| `prowlarr.get_downloadclient_schema` | `GET` | read |
+| `prowlarr.get_filesystem` | `GET` | read |
+| `prowlarr.get_filesystem_type` | `GET` | read |
+| `prowlarr.get_health` | `GET` | read |
+| `prowlarr.get_history` | `GET` | read |
+| `prowlarr.get_history_indexer` | `GET` | read |
+| `prowlarr.get_history_since` | `GET` | read |
+| `prowlarr.get_indexer` | `GET` | read |
+| `prowlarr.get_indexer_by_id` | `GET` | read |
+| `prowlarr.get_indexer_categories` | `GET` | read |
+| `prowlarr.get_indexer_download_by_id` | `GET` | read |
+| `prowlarr.get_indexer_newznab_by_id` | `GET` | read |
+| `prowlarr.get_indexer_schema` | `GET` | read |
+| `prowlarr.get_indexerproxy` | `GET` | read |
+| `prowlarr.get_indexerproxy_by_id` | `GET` | read |
+| `prowlarr.get_indexerproxy_schema` | `GET` | read |
+| `prowlarr.get_indexerstats` | `GET` | read |
+| `prowlarr.get_indexerstatus` | `GET` | read |
+| `prowlarr.get_localization` | `GET` | read |
+| `prowlarr.get_localization_options` | `GET` | read |
+| `prowlarr.get_log` | `GET` | read |
+| `prowlarr.get_log_file` | `GET` | read |
+| `prowlarr.get_log_file_by_filename` | `GET` | read |
+| `prowlarr.get_log_file_update` | `GET` | read |
+| `prowlarr.get_log_file_update_by_filename` | `GET` | read |
+| `prowlarr.get_login` | `GET` | read |
+| `prowlarr.get_logout` | `GET` | read |
+| `prowlarr.get_notification` | `GET` | read |
+| `prowlarr.get_notification_by_id` | `GET` | read |
+| `prowlarr.get_notification_schema` | `GET` | read |
+| `prowlarr.get_ping` | `GET` | read |
+| `prowlarr.get_search` | `GET` | read |
+| `prowlarr.get_system_backup` | `GET` | read |
+| `prowlarr.get_system_routes` | `GET` | read |
+| `prowlarr.get_system_routes_duplicate` | `GET` | read |
+| `prowlarr.get_system_status` | `GET` | read |
+| `prowlarr.get_system_task` | `GET` | read |
+| `prowlarr.get_system_task_by_id` | `GET` | read |
+| `prowlarr.get_tag` | `GET` | read |
+| `prowlarr.get_tag_by_id` | `GET` | read |
+| `prowlarr.get_tag_detail` | `GET` | read |
+| `prowlarr.get_tag_detail_by_id` | `GET` | read |
+| `prowlarr.get_update` | `GET` | read |
+| `prowlarr.post_applications` | `POST` | mutating |
+| `prowlarr.post_applications_action_by_name` | `POST` | mutating |
+| `prowlarr.post_applications_test` | `POST` | mutating |
+| `prowlarr.post_applications_testall` | `POST` | mutating |
+| `prowlarr.post_appprofile` | `POST` | mutating |
+| `prowlarr.post_command` | `POST` | mutating |
+| `prowlarr.post_customfilter` | `POST` | mutating |
+| `prowlarr.post_downloadclient` | `POST` | mutating |
+| `prowlarr.post_downloadclient_action_by_name` | `POST` | mutating |
+| `prowlarr.post_downloadclient_test` | `POST` | mutating |
+| `prowlarr.post_downloadclient_testall` | `POST` | mutating |
+| `prowlarr.post_indexer` | `POST` | mutating |
+| `prowlarr.post_indexer_action_by_name` | `POST` | mutating |
+| `prowlarr.post_indexer_test` | `POST` | mutating |
+| `prowlarr.post_indexer_testall` | `POST` | mutating |
+| `prowlarr.post_indexerproxy` | `POST` | mutating |
+| `prowlarr.post_indexerproxy_action_by_name` | `POST` | mutating |
+| `prowlarr.post_indexerproxy_test` | `POST` | mutating |
+| `prowlarr.post_indexerproxy_testall` | `POST` | mutating |
+| `prowlarr.post_login` | `POST` | mutating |
+| `prowlarr.post_notification` | `POST` | mutating |
+| `prowlarr.post_notification_action_by_name` | `POST` | mutating |
+| `prowlarr.post_notification_test` | `POST` | mutating |
+| `prowlarr.post_notification_testall` | `POST` | mutating |
+| `prowlarr.post_search` | `POST` | mutating |
+| `prowlarr.post_search_bulk` | `POST` | mutating |
+| `prowlarr.post_system_backup_restore_by_id` | `POST` | mutating |
+| `prowlarr.post_system_backup_restore_upload` | `POST` | mutating |
+| `prowlarr.post_system_restart` | `POST` | mutating |
+| `prowlarr.post_system_shutdown` | `POST` | mutating |
+| `prowlarr.post_tag` | `POST` | mutating |
+| `prowlarr.put_applications_bulk` | `PUT` | mutating |
+| `prowlarr.put_applications_by_id` | `PUT` | mutating |
+| `prowlarr.put_appprofile_by_id` | `PUT` | mutating |
+| `prowlarr.put_config_development_by_id` | `PUT` | mutating |
+| `prowlarr.put_config_downloadclient_by_id` | `PUT` | mutating |
+| `prowlarr.put_config_host_by_id` | `PUT` | mutating |
+| `prowlarr.put_config_ui_by_id` | `PUT` | mutating |
+| `prowlarr.put_customfilter_by_id` | `PUT` | mutating |
+| `prowlarr.put_downloadclient_bulk` | `PUT` | mutating |
+| `prowlarr.put_downloadclient_by_id` | `PUT` | mutating |
+| `prowlarr.put_indexer_bulk` | `PUT` | mutating |
+| `prowlarr.put_indexer_by_id` | `PUT` | mutating |
+| `prowlarr.put_indexerproxy_by_id` | `PUT` | mutating |
+| `prowlarr.put_notification_by_id` | `PUT` | mutating |
+| `prowlarr.put_tag_by_id` | `PUT` | mutating |
+| `overseerr.delete_issue_by_issue_id` | `DELETE` | destructive (elicited) |
+| `overseerr.delete_issue_comment_by_comment_id` | `DELETE` | destructive (elicited) |
+| `overseerr.delete_media_by_media_id` | `DELETE` | destructive (elicited) |
+| `overseerr.delete_request_by_request_id` | `DELETE` | destructive (elicited) |
+| `overseerr.delete_settings_discover_by_slider_id` | `DELETE` | destructive (elicited) |
+| `overseerr.delete_settings_radarr_by_radarr_id` | `DELETE` | destructive (elicited) |
+| `overseerr.delete_settings_sonarr_by_sonarr_id` | `DELETE` | destructive (elicited) |
+| `overseerr.delete_user_by_user_id` | `DELETE` | destructive (elicited) |
+| `overseerr.delete_user_push_subscription_by_endpoint_user_id` | `DELETE` | destructive (elicited) |
+| `overseerr.get_auth_me` | `GET` | read |
+| `overseerr.get_backdrops` | `GET` | read |
+| `overseerr.get_collection_by_collection_id` | `GET` | read |
+| `overseerr.get_discover_genreslider_movie` | `GET` | read |
+| `overseerr.get_discover_genreslider_tv` | `GET` | read |
+| `overseerr.get_discover_keyword_movies_by_keyword_id` | `GET` | read |
+| `overseerr.get_discover_movies` | `GET` | read |
+| `overseerr.get_discover_movies_genre_by_genre_id` | `GET` | read |
+| `overseerr.get_discover_movies_language_by_language` | `GET` | read |
+| `overseerr.get_discover_movies_studio_by_studio_id` | `GET` | read |
+| `overseerr.get_discover_movies_upcoming` | `GET` | read |
+| `overseerr.get_discover_trending` | `GET` | read |
+| `overseerr.get_discover_tv` | `GET` | read |
+| `overseerr.get_discover_tv_genre_by_genre_id` | `GET` | read |
+| `overseerr.get_discover_tv_language_by_language` | `GET` | read |
+| `overseerr.get_discover_tv_network_by_network_id` | `GET` | read |
+| `overseerr.get_discover_tv_upcoming` | `GET` | read |
+| `overseerr.get_discover_watchlist` | `GET` | read |
+| `overseerr.get_genres_movie` | `GET` | read |
+| `overseerr.get_genres_tv` | `GET` | read |
+| `overseerr.get_issue` | `GET` | read |
+| `overseerr.get_issue_by_issue_id` | `GET` | read |
+| `overseerr.get_issue_comment_by_comment_id` | `GET` | read |
+| `overseerr.get_issue_count` | `GET` | read |
+| `overseerr.get_keyword_by_keyword_id` | `GET` | read |
+| `overseerr.get_languages` | `GET` | read |
+| `overseerr.get_media` | `GET` | read |
+| `overseerr.get_media_watch_data_by_media_id` | `GET` | read |
+| `overseerr.get_movie_by_movie_id` | `GET` | read |
+| `overseerr.get_movie_ratings_by_movie_id` | `GET` | read |
+| `overseerr.get_movie_ratingscombined_by_movie_id` | `GET` | read |
+| `overseerr.get_movie_recommendations_by_movie_id` | `GET` | read |
+| `overseerr.get_movie_similar_by_movie_id` | `GET` | read |
+| `overseerr.get_network_by_network_id` | `GET` | read |
+| `overseerr.get_person_by_person_id` | `GET` | read |
+| `overseerr.get_person_combined_credits_by_person_id` | `GET` | read |
+| `overseerr.get_regions` | `GET` | read |
+| `overseerr.get_request` | `GET` | read |
+| `overseerr.get_request_by_request_id` | `GET` | read |
+| `overseerr.get_request_count` | `GET` | read |
+| `overseerr.get_search` | `GET` | read |
+| `overseerr.get_search_company` | `GET` | read |
+| `overseerr.get_search_keyword` | `GET` | read |
+| `overseerr.get_service_radarr` | `GET` | read |
+| `overseerr.get_service_radarr_by_radarr_id` | `GET` | read |
+| `overseerr.get_service_sonarr` | `GET` | read |
+| `overseerr.get_service_sonarr_by_sonarr_id` | `GET` | read |
+| `overseerr.get_service_sonarr_lookup_by_tmdb_id` | `GET` | read |
+| `overseerr.get_settings_about` | `GET` | read |
+| `overseerr.get_settings_cache` | `GET` | read |
+| `overseerr.get_settings_discover` | `GET` | read |
+| `overseerr.get_settings_discover_reset` | `GET` | read |
+| `overseerr.get_settings_jobs` | `GET` | read |
+| `overseerr.get_settings_logs` | `GET` | read |
+| `overseerr.get_settings_main` | `GET` | read |
+| `overseerr.get_settings_notifications_discord` | `GET` | read |
+| `overseerr.get_settings_notifications_email` | `GET` | read |
+| `overseerr.get_settings_notifications_gotify` | `GET` | read |
+| `overseerr.get_settings_notifications_lunasea` | `GET` | read |
+| `overseerr.get_settings_notifications_pushbullet` | `GET` | read |
+| `overseerr.get_settings_notifications_pushover` | `GET` | read |
+| `overseerr.get_settings_notifications_pushover_sounds` | `GET` | read |
+| `overseerr.get_settings_notifications_slack` | `GET` | read |
+| `overseerr.get_settings_notifications_telegram` | `GET` | read |
+| `overseerr.get_settings_notifications_webhook` | `GET` | read |
+| `overseerr.get_settings_notifications_webpush` | `GET` | read |
+| `overseerr.get_settings_plex` | `GET` | read |
+| `overseerr.get_settings_plex_devices_servers` | `GET` | read |
+| `overseerr.get_settings_plex_sync` | `GET` | read |
+| `overseerr.get_settings_plex_users` | `GET` | read |
+| `overseerr.get_settings_public` | `GET` | read |
+| `overseerr.get_settings_radarr` | `GET` | read |
+| `overseerr.get_settings_radarr_profiles_by_radarr_id` | `GET` | read |
+| `overseerr.get_settings_sonarr` | `GET` | read |
+| `overseerr.get_settings_tautulli` | `GET` | read |
+| `overseerr.get_status` | `GET` | read |
+| `overseerr.get_status_appdata` | `GET` | read |
+| `overseerr.get_studio_by_studio_id` | `GET` | read |
+| `overseerr.get_tv_by_tv_id` | `GET` | read |
+| `overseerr.get_tv_ratings_by_tv_id` | `GET` | read |
+| `overseerr.get_tv_recommendations_by_tv_id` | `GET` | read |
+| `overseerr.get_tv_season_by_season_id_tv_id` | `GET` | read |
+| `overseerr.get_tv_similar_by_tv_id` | `GET` | read |
+| `overseerr.get_user` | `GET` | read |
+| `overseerr.get_user_by_user_id` | `GET` | read |
+| `overseerr.get_user_push_subscription_by_endpoint_user_id` | `GET` | read |
+| `overseerr.get_user_push_subscriptions_by_user_id` | `GET` | read |
+| `overseerr.get_user_quota_by_user_id` | `GET` | read |
+| `overseerr.get_user_requests_by_user_id` | `GET` | read |
+| `overseerr.get_user_settings_main_by_user_id` | `GET` | read |
+| `overseerr.get_user_settings_notifications_by_user_id` | `GET` | read |
+| `overseerr.get_user_settings_password_by_user_id` | `GET` | read |
+| `overseerr.get_user_settings_permissions_by_user_id` | `GET` | read |
+| `overseerr.get_user_watch_data_by_user_id` | `GET` | read |
+| `overseerr.get_user_watchlist_by_user_id` | `GET` | read |
+| `overseerr.get_watchproviders_movies` | `GET` | read |
+| `overseerr.get_watchproviders_regions` | `GET` | read |
+| `overseerr.get_watchproviders_tv` | `GET` | read |
+| `overseerr.post_auth_local` | `POST` | mutating |
+| `overseerr.post_auth_logout` | `POST` | mutating |
+| `overseerr.post_auth_plex` | `POST` | mutating |
+| `overseerr.post_auth_reset_password` | `POST` | mutating |
+| `overseerr.post_auth_reset_password_by_guid` | `POST` | mutating |
+| `overseerr.post_issue` | `POST` | mutating |
+| `overseerr.post_issue_by_issue_id_status` | `POST` | mutating |
+| `overseerr.post_issue_comment_by_issue_id` | `POST` | mutating |
+| `overseerr.post_media_by_media_id_status` | `POST` | mutating |
+| `overseerr.post_request` | `POST` | mutating |
+| `overseerr.post_request_by_request_id_status` | `POST` | mutating |
+| `overseerr.post_request_retry_by_request_id` | `POST` | mutating |
+| `overseerr.post_settings_cache_flush_by_cache_id` | `POST` | mutating |
+| `overseerr.post_settings_discover` | `POST` | mutating |
+| `overseerr.post_settings_discover_add` | `POST` | mutating |
+| `overseerr.post_settings_initialize` | `POST` | mutating |
+| `overseerr.post_settings_jobs_cancel_by_job_id` | `POST` | destructive (elicited) |
+| `overseerr.post_settings_jobs_run_by_job_id` | `POST` | destructive (elicited) |
+| `overseerr.post_settings_jobs_schedule_by_job_id` | `POST` | destructive (elicited) |
+| `overseerr.post_settings_main` | `POST` | mutating |
+| `overseerr.post_settings_main_regenerate` | `POST` | mutating |
+| `overseerr.post_settings_notifications_discord` | `POST` | mutating |
+| `overseerr.post_settings_notifications_discord_test` | `POST` | mutating |
+| `overseerr.post_settings_notifications_email` | `POST` | mutating |
+| `overseerr.post_settings_notifications_email_test` | `POST` | mutating |
+| `overseerr.post_settings_notifications_gotify` | `POST` | mutating |
+| `overseerr.post_settings_notifications_gotify_test` | `POST` | mutating |
+| `overseerr.post_settings_notifications_lunasea` | `POST` | mutating |
+| `overseerr.post_settings_notifications_lunasea_test` | `POST` | mutating |
+| `overseerr.post_settings_notifications_pushbullet` | `POST` | mutating |
+| `overseerr.post_settings_notifications_pushbullet_test` | `POST` | mutating |
+| `overseerr.post_settings_notifications_pushover` | `POST` | mutating |
+| `overseerr.post_settings_notifications_pushover_test` | `POST` | mutating |
+| `overseerr.post_settings_notifications_slack` | `POST` | mutating |
+| `overseerr.post_settings_notifications_slack_test` | `POST` | mutating |
+| `overseerr.post_settings_notifications_telegram` | `POST` | mutating |
+| `overseerr.post_settings_notifications_telegram_test` | `POST` | mutating |
+| `overseerr.post_settings_notifications_webhook` | `POST` | mutating |
+| `overseerr.post_settings_notifications_webhook_test` | `POST` | mutating |
+| `overseerr.post_settings_notifications_webpush` | `POST` | mutating |
+| `overseerr.post_settings_notifications_webpush_test` | `POST` | mutating |
+| `overseerr.post_settings_plex` | `POST` | mutating |
+| `overseerr.post_settings_plex_sync` | `POST` | destructive (elicited) |
+| `overseerr.post_settings_radarr` | `POST` | mutating |
+| `overseerr.post_settings_radarr_test` | `POST` | mutating |
+| `overseerr.post_settings_sonarr` | `POST` | mutating |
+| `overseerr.post_settings_sonarr_test` | `POST` | mutating |
+| `overseerr.post_settings_tautulli` | `POST` | mutating |
+| `overseerr.post_user` | `POST` | mutating |
+| `overseerr.post_user_import_from_plex` | `POST` | mutating |
+| `overseerr.post_user_register_push_subscription` | `POST` | mutating |
+| `overseerr.post_user_settings_main_by_user_id` | `POST` | mutating |
+| `overseerr.post_user_settings_notifications_by_user_id` | `POST` | mutating |
+| `overseerr.post_user_settings_password_by_user_id` | `POST` | mutating |
+| `overseerr.post_user_settings_permissions_by_user_id` | `POST` | mutating |
+| `overseerr.put_issue_comment_by_comment_id` | `PUT` | mutating |
+| `overseerr.put_request_by_request_id` | `PUT` | mutating |
+| `overseerr.put_settings_discover_by_slider_id` | `PUT` | mutating |
+| `overseerr.put_settings_radarr_by_radarr_id` | `PUT` | mutating |
+| `overseerr.put_settings_sonarr_by_sonarr_id` | `PUT` | mutating |
+| `overseerr.put_user` | `PUT` | mutating |
+| `overseerr.put_user_by_user_id` | `PUT` | mutating |
+| `plex.add_collection_items` | `PUT` | mutating |
+| `plex.add_device` | `POST` | mutating |
+| `plex.add_device_to_dvr` | `PUT` | mutating |
+| `plex.add_download_queue_items` | `POST` | mutating |
+| `plex.add_extras` | `POST` | mutating |
+| `plex.add_lineup` | `PUT` | mutating |
+| `plex.add_playlist_items` | `PUT` | mutating |
+| `plex.add_provider` | `POST` | mutating |
+| `plex.add_section` | `POST` | destructive (elicited) |
+| `plex.add_subtitles` | `GET` | mutating |
+| `plex.add_to_play_queue` | `PUT` | mutating |
+| `plex.analyze_metadata` | `PUT` | mutating |
+| `plex.apply_updates` | `PUT` | mutating |
+| `plex.autocomplete` | `GET` | read |
+| `plex.cancel_activity` | `DELETE` | destructive (elicited) |
+| `plex.cancel_grab` | `DELETE` | destructive (elicited) |
+| `plex.cancel_refresh` | `DELETE` | destructive (elicited) |
+| `plex.check_updates` | `PUT` | mutating |
+| `plex.clean_bundles` | `PUT` | destructive (elicited) |
+| `plex.clear_play_queue` | `DELETE` | destructive (elicited) |
+| `plex.clear_playlist_items` | `DELETE` | destructive (elicited) |
+| `plex.compute_channel_map` | `GET` | read |
+| `plex.connect_web_socket` | `GET` | read |
+| `plex.create_collection` | `POST` | mutating |
+| `plex.create_custom_hub` | `POST` | mutating |
+| `plex.create_download_queue` | `POST` | mutating |
+| `plex.create_dvr` | `POST` | mutating |
+| `plex.create_marker` | `POST` | mutating |
+| `plex.create_play_queue` | `POST` | mutating |
+| `plex.create_playlist` | `POST` | mutating |
+| `plex.create_subscription` | `POST` | mutating |
+| `plex.delete_caches` | `DELETE` | destructive (elicited) |
+| `plex.delete_collection` | `DELETE` | destructive (elicited) |
+| `plex.delete_collection_item` | `PUT` | mutating |
+| `plex.delete_custom_hub` | `DELETE` | destructive (elicited) |
+| `plex.delete_dvr` | `DELETE` | destructive (elicited) |
+| `plex.delete_history` | `DELETE` | destructive (elicited) |
+| `plex.delete_indexes` | `DELETE` | destructive (elicited) |
+| `plex.delete_intros` | `DELETE` | destructive (elicited) |
+| `plex.delete_library_section` | `DELETE` | destructive (elicited) |
+| `plex.delete_lineup` | `DELETE` | destructive (elicited) |
+| `plex.delete_marker` | `DELETE` | destructive (elicited) |
+| `plex.delete_media_item` | `DELETE` | destructive (elicited) |
+| `plex.delete_media_provider` | `DELETE` | destructive (elicited) |
+| `plex.delete_metadata_item` | `DELETE` | destructive (elicited) |
+| `plex.delete_play_queue_item` | `DELETE` | destructive (elicited) |
+| `plex.delete_playlist` | `DELETE` | destructive (elicited) |
+| `plex.delete_playlist_item` | `DELETE` | destructive (elicited) |
+| `plex.delete_stream` | `DELETE` | destructive (elicited) |
+| `plex.delete_subscription` | `DELETE` | destructive (elicited) |
+| `plex.detect_ads` | `PUT` | mutating |
+| `plex.detect_credits` | `PUT` | mutating |
+| `plex.detect_intros` | `PUT` | mutating |
+| `plex.detect_voice_activity` | `PUT` | mutating |
+| `plex.discover_devices` | `POST` | mutating |
+| `plex.edit_marker` | `PUT` | mutating |
+| `plex.edit_metadata_item` | `PUT` | destructive (elicited) |
+| `plex.edit_section` | `PUT` | destructive (elicited) |
+| `plex.edit_subscription_preferences` | `PUT` | mutating |
+| `plex.empty_trash` | `PUT` | destructive (elicited) |
+| `plex.enable_papertrail` | `POST` | mutating |
+| `plex.generate_thumbs` | `PUT` | mutating |
+| `plex.get_albums` | `GET` | read |
+| `plex.get_all_hubs` | `GET` | read |
+| `plex.get_all_item_leaves` | `GET` | read |
+| `plex.get_all_languages` | `GET` | read |
+| `plex.get_all_leaves` | `GET` | read |
+| `plex.get_all_preferences` | `GET` | read |
+| `plex.get_all_subscriptions` | `GET` | read |
+| `plex.get_arts` | `GET` | read |
+| `plex.get_augmentation_status` | `GET` | read |
+| `plex.get_available_grabbers` | `GET` | read |
+| `plex.get_available_sorts` | `GET` | read |
+| `plex.get_background_tasks` | `GET` | read |
+| `plex.get_categories` | `GET` | read |
+| `plex.get_channels` | `GET` | read |
+| `plex.get_chapter_image` | `GET` | read |
+| `plex.get_cluster` | `GET` | read |
+| `plex.get_collection_image` | `GET` | read |
+| `plex.get_collection_items` | `GET` | read |
+| `plex.get_collections` | `GET` | read |
+| `plex.get_colors` | `GET` | read |
+| `plex.get_common` | `GET` | read |
+| `plex.get_continue_watching` | `GET` | read |
+| `plex.get_countries` | `GET` | read |
+| `plex.get_countries_lineups` | `GET` | read |
+| `plex.get_country_regions` | `GET` | read |
+| `plex.get_device_details` | `GET` | read |
+| `plex.get_devices_channels` | `GET` | read |
+| `plex.get_download_queue` | `GET` | read |
+| `plex.get_download_queue_items` | `GET` | read |
+| `plex.get_download_queue_media` | `GET` | read |
+| `plex.get_dvr` | `GET` | read |
+| `plex.get_extras` | `GET` | read |
+| `plex.get_file` | `GET` | read |
+| `plex.get_first_characters` | `GET` | read |
+| `plex.get_folders` | `GET` | read |
+| `plex.get_history_item` | `GET` | read |
+| `plex.get_hub_items` | `GET` | read |
+| `plex.get_identity` | `GET` | read |
+| `plex.get_image` | `GET` | read |
+| `plex.get_image_from_bif` | `GET` | read |
+| `plex.get_item_artwork` | `GET` | read |
+| `plex.get_item_decision` | `GET` | read |
+| `plex.get_item_tree` | `GET` | read |
+| `plex.get_library_details` | `GET` | read |
+| `plex.get_library_items` | `GET` | read |
+| `plex.get_library_matches` | `GET` | read |
+| `plex.get_lineup` | `GET` | read |
+| `plex.get_lineup_channels` | `GET` | read |
+| `plex.get_live_tv_session` | `GET` | read |
+| `plex.get_media_part` | `GET` | read |
+| `plex.get_metadata_hubs` | `GET` | read |
+| `plex.get_metadata_item` | `GET` | read |
+| `plex.get_notifications` | `GET` | read |
+| `plex.get_part_index` | `GET` | read |
+| `plex.get_person` | `GET` | read |
+| `plex.get_play_queue` | `GET` | read |
+| `plex.get_playlist` | `GET` | read |
+| `plex.get_playlist_generator` | `GET` | read |
+| `plex.get_playlist_generator_items` | `GET` | read |
+| `plex.get_playlist_generators` | `GET` | read |
+| `plex.get_playlist_items` | `GET` | read |
+| `plex.get_postplay_hubs` | `GET` | read |
+| `plex.get_preference` | `GET` | read |
+| `plex.get_promoted_hubs` | `GET` | read |
+| `plex.get_random_artwork` | `GET` | read |
+| `plex.get_related_hubs` | `GET` | read |
+| `plex.get_related_items` | `GET` | read |
+| `plex.get_scheduled_recordings` | `GET` | read |
+| `plex.get_section_filters` | `GET` | read |
+| `plex.get_section_hubs` | `GET` | read |
+| `plex.get_section_image` | `GET` | read |
+| `plex.get_section_preferences` | `GET` | read |
+| `plex.get_sections` | `GET` | read |
+| `plex.get_sections_prefs` | `GET` | read |
+| `plex.get_server_info` | `GET` | read |
+| `plex.get_server_resources` | `GET` | read |
+| `plex.get_session_playlist_index` | `GET` | read |
+| `plex.get_session_segment` | `GET` | read |
+| `plex.get_sessions` | `GET` | read |
+| `plex.get_sonic_path` | `GET` | read |
+| `plex.get_sonically_similar` | `GET` | read |
+| `plex.get_source_connection_information` | `GET` | read |
+| `plex.get_stream` | `GET` | read |
+| `plex.get_stream_levels` | `GET` | read |
+| `plex.get_stream_loudness` | `GET` | read |
+| `plex.get_subscription` | `GET` | read |
+| `plex.get_tags` | `GET` | read |
+| `plex.get_tasks` | `GET` | read |
+| `plex.get_template` | `GET` | read |
+| `plex.get_thumb` | `GET` | read |
+| `plex.get_token_details` | `GET` | read |
+| `plex.get_transient_token` | `POST` | mutating |
+| `plex.get_updates_status` | `GET` | read |
+| `plex.get_users` | `GET` | read |
+| `plex.ingest_transient_item` | `POST` | mutating |
+| `plex.list_activities` | `GET` | read |
+| `plex.list_content` | `GET` | read |
+| `plex.list_devices` | `GET` | read |
+| `plex.list_download_queue_items` | `GET` | read |
+| `plex.list_dv_rs` | `GET` | read |
+| `plex.list_hubs` | `GET` | read |
+| `plex.list_lineups` | `GET` | read |
+| `plex.list_matches` | `PUT` | mutating |
+| `plex.list_moments` | `GET` | read |
+| `plex.list_person_media` | `GET` | read |
+| `plex.list_playback_history` | `GET` | read |
+| `plex.list_playlists` | `GET` | read |
+| `plex.list_providers` | `GET` | read |
+| `plex.list_sessions` | `GET` | read |
+| `plex.list_similar` | `GET` | read |
+| `plex.list_sonically_similar` | `GET` | read |
+| `plex.list_top_users` | `GET` | read |
+| `plex.make_decision` | `GET` | read |
+| `plex.mark_played` | `PUT` | mutating |
+| `plex.match_item` | `PUT` | mutating |
+| `plex.merge_items` | `PUT` | mutating |
+| `plex.modify_device` | `PUT` | mutating |
+| `plex.modify_playlist_generator` | `PUT` | mutating |
+| `plex.move_collection_item` | `PUT` | mutating |
+| `plex.move_hub` | `PUT` | mutating |
+| `plex.move_play_queue_item` | `PUT` | mutating |
+| `plex.move_playlist_item` | `PUT` | mutating |
+| `plex.optimize_database` | `PUT` | destructive (elicited) |
+| `plex.post_users_sign_in_data` | `POST` | mutating |
+| `plex.process_subscriptions` | `POST` | mutating |
+| `plex.refresh_items_metadata` | `PUT` | mutating |
+| `plex.refresh_playlist` | `PUT` | mutating |
+| `plex.refresh_providers` | `POST` | mutating |
+| `plex.refresh_section` | `POST` | destructive (elicited) |
+| `plex.refresh_sections_metadata` | `POST` | destructive (elicited) |
+| `plex.reload_guide` | `POST` | mutating |
+| `plex.remove_device` | `DELETE` | destructive (elicited) |
+| `plex.remove_device_from_dvr` | `DELETE` | destructive (elicited) |
+| `plex.remove_download_queue_items` | `DELETE` | destructive (elicited) |
+| `plex.reorder_subscription` | `PUT` | mutating |
+| `plex.report` | `POST` | mutating |
+| `plex.reset_play_queue` | `PUT` | mutating |
+| `plex.reset_section_defaults` | `DELETE` | destructive (elicited) |
+| `plex.restart_processing_download_queue_items` | `POST` | mutating |
+| `plex.scan` | `POST` | destructive (elicited) |
+| `plex.search_hubs` | `GET` | read |
+| `plex.set_channelmap` | `PUT` | mutating |
+| `plex.set_device_preferences` | `PUT` | mutating |
+| `plex.set_dvr_preferences` | `PUT` | mutating |
+| `plex.set_item_artwork` | `POST` | mutating |
+| `plex.set_item_preferences` | `PUT` | mutating |
+| `plex.set_preferences` | `PUT` | mutating |
+| `plex.set_rating` | `PUT` | mutating |
+| `plex.set_section_preferences` | `PUT` | mutating |
+| `plex.set_stream_offset` | `PUT` | mutating |
+| `plex.set_stream_selection` | `PUT` | mutating |
+| `plex.shuffle` | `PUT` | mutating |
+| `plex.split_item` | `PUT` | mutating |
+| `plex.start_analysis` | `PUT` | mutating |
+| `plex.start_bif_generation` | `PUT` | mutating |
+| `plex.start_task` | `POST` | mutating |
+| `plex.start_tasks` | `POST` | mutating |
+| `plex.start_transcode_session` | `GET` | mutating |
+| `plex.stop_all_refreshes` | `DELETE` | destructive (elicited) |
+| `plex.stop_dvr_reload` | `DELETE` | destructive (elicited) |
+| `plex.stop_scan` | `DELETE` | destructive (elicited) |
+| `plex.stop_task` | `DELETE` | destructive (elicited) |
+| `plex.stop_tasks` | `DELETE` | destructive (elicited) |
+| `plex.terminate_session` | `POST` | destructive (elicited) |
+| `plex.transcode_image` | `GET` | read |
+| `plex.transcode_subtitles` | `GET` | read |
+| `plex.trigger_fallback` | `POST` | mutating |
+| `plex.tune_channel` | `POST` | mutating |
+| `plex.unmatch` | `PUT` | mutating |
+| `plex.unscrobble` | `PUT` | mutating |
+| `plex.unshuffle` | `PUT` | mutating |
+| `plex.update_hub_visibility` | `PUT` | mutating |
+| `plex.update_item_artwork` | `PUT` | mutating |
+| `plex.update_items` | `PUT` | mutating |
+| `plex.update_playlist` | `PUT` | mutating |
+| `plex.upload_playlist` | `POST` | mutating |
+| `plex.voice_search_hubs` | `GET` | read |
+| `plex.write_log` | `POST` | mutating |
+| `plex.write_message` | `PUT` | mutating |
+| `jellyfin.add_item_to_playlist` | `POST` | mutating |
+| `jellyfin.add_listing_provider` | `POST` | mutating |
+| `jellyfin.add_media_path` | `POST` | mutating |
+| `jellyfin.add_to_collection` | `POST` | mutating |
+| `jellyfin.add_tuner_host` | `POST` | mutating |
+| `jellyfin.add_user_to_session` | `POST` | mutating |
+| `jellyfin.add_virtual_folder` | `POST` | mutating |
+| `jellyfin.apply_search_criteria` | `POST` | mutating |
+| `jellyfin.authenticate_user_by_name` | `POST` | mutating |
+| `jellyfin.authenticate_with_quick_connect` | `POST` | mutating |
+| `jellyfin.authorize_quick_connect` | `POST` | mutating |
+| `jellyfin.cancel_package_installation` | `DELETE` | destructive (elicited) |
+| `jellyfin.cancel_series_timer` | `DELETE` | destructive (elicited) |
+| `jellyfin.cancel_timer` | `DELETE` | destructive (elicited) |
+| `jellyfin.close_live_stream` | `POST` | mutating |
+| `jellyfin.complete_wizard` | `POST` | mutating |
+| `jellyfin.create_backup` | `POST` | mutating |
+| `jellyfin.create_collection` | `POST` | mutating |
+| `jellyfin.create_key` | `POST` | mutating |
+| `jellyfin.create_playlist` | `POST` | mutating |
+| `jellyfin.create_series_timer` | `POST` | mutating |
+| `jellyfin.create_timer` | `POST` | mutating |
+| `jellyfin.create_user_by_name` | `POST` | mutating |
+| `jellyfin.delete_alternate_sources` | `DELETE` | destructive (elicited) |
+| `jellyfin.delete_custom_splashscreen` | `DELETE` | destructive (elicited) |
+| `jellyfin.delete_device` | `DELETE` | destructive (elicited) |
+| `jellyfin.delete_item` | `DELETE` | destructive (elicited) |
+| `jellyfin.delete_item_image` | `DELETE` | destructive (elicited) |
+| `jellyfin.delete_item_image_by_index` | `DELETE` | destructive (elicited) |
+| `jellyfin.delete_items` | `DELETE` | destructive (elicited) |
+| `jellyfin.delete_listing_provider` | `DELETE` | destructive (elicited) |
+| `jellyfin.delete_lyrics` | `DELETE` | destructive (elicited) |
+| `jellyfin.delete_recording` | `DELETE` | destructive (elicited) |
+| `jellyfin.delete_subtitle` | `DELETE` | destructive (elicited) |
+| `jellyfin.delete_tuner_host` | `DELETE` | destructive (elicited) |
+| `jellyfin.delete_user` | `DELETE` | destructive (elicited) |
+| `jellyfin.delete_user_image` | `DELETE` | destructive (elicited) |
+| `jellyfin.delete_user_item_rating` | `DELETE` | destructive (elicited) |
+| `jellyfin.disable_plugin` | `POST` | mutating |
+| `jellyfin.discover_tuners` | `GET` | read |
+| `jellyfin.discvover_tuners` | `GET` | read |
+| `jellyfin.display_content` | `POST` | mutating |
+| `jellyfin.download_remote_image` | `POST` | mutating |
+| `jellyfin.download_remote_lyrics` | `POST` | mutating |
+| `jellyfin.download_remote_subtitles` | `POST` | mutating |
+| `jellyfin.enable_plugin` | `POST` | mutating |
+| `jellyfin.forgot_password` | `POST` | mutating |
+| `jellyfin.forgot_password_pin` | `POST` | mutating |
+| `jellyfin.get_additional_part` | `GET` | read |
+| `jellyfin.get_album_artists` | `GET` | read |
+| `jellyfin.get_all_channel_features` | `GET` | read |
+| `jellyfin.get_ancestors` | `GET` | read |
+| `jellyfin.get_artist_by_name` | `GET` | read |
+| `jellyfin.get_artist_image` | `GET` | read |
+| `jellyfin.get_artists` | `GET` | read |
+| `jellyfin.get_attachment` | `GET` | read |
+| `jellyfin.get_audio_stream` | `GET` | read |
+| `jellyfin.get_audio_stream_by_container` | `GET` | read |
+| `jellyfin.get_auth_providers` | `GET` | read |
+| `jellyfin.get_backup` | `GET` | read |
+| `jellyfin.get_bitrate_test_bytes` | `GET` | read |
+| `jellyfin.get_book_remote_search_results` | `POST` | mutating |
+| `jellyfin.get_box_set_remote_search_results` | `POST` | mutating |
+| `jellyfin.get_branding_css` | `GET` | read |
+| `jellyfin.get_branding_css_2` | `GET` | read |
+| `jellyfin.get_branding_options` | `GET` | read |
+| `jellyfin.get_channel` | `GET` | read |
+| `jellyfin.get_channel_features` | `GET` | read |
+| `jellyfin.get_channel_items` | `GET` | read |
+| `jellyfin.get_channel_mapping_options` | `GET` | read |
+| `jellyfin.get_channels` | `GET` | read |
+| `jellyfin.get_configuration` | `GET` | read |
+| `jellyfin.get_configuration_pages` | `GET` | read |
+| `jellyfin.get_countries` | `GET` | read |
+| `jellyfin.get_cultures` | `GET` | read |
+| `jellyfin.get_current_user` | `GET` | read |
+| `jellyfin.get_dashboard_configuration_page` | `GET` | read |
+| `jellyfin.get_default_directory_browser` | `GET` | read |
+| `jellyfin.get_default_listing_provider` | `GET` | read |
+| `jellyfin.get_default_metadata_options` | `GET` | read |
+| `jellyfin.get_default_timer` | `GET` | read |
+| `jellyfin.get_device_info` | `GET` | read |
+| `jellyfin.get_device_options` | `GET` | read |
+| `jellyfin.get_devices` | `GET` | read |
+| `jellyfin.get_directory_contents` | `GET` | read |
+| `jellyfin.get_display_preferences` | `GET` | read |
+| `jellyfin.get_download` | `GET` | read |
+| `jellyfin.get_drives` | `GET` | read |
+| `jellyfin.get_endpoint_info` | `GET` | read |
+| `jellyfin.get_episodes` | `GET` | read |
+| `jellyfin.get_external_id_infos` | `GET` | read |
+| `jellyfin.get_fallback_font` | `GET` | read |
+| `jellyfin.get_fallback_font_list` | `GET` | read |
+| `jellyfin.get_file` | `GET` | read |
+| `jellyfin.get_first_user` | `GET` | read |
+| `jellyfin.get_first_user_2` | `GET` | read |
+| `jellyfin.get_genre` | `GET` | read |
+| `jellyfin.get_genre_image` | `GET` | read |
+| `jellyfin.get_genre_image_by_index` | `GET` | read |
+| `jellyfin.get_genres` | `GET` | read |
+| `jellyfin.get_grouping_options` | `GET` | read |
+| `jellyfin.get_guide_info` | `GET` | read |
+| `jellyfin.get_instant_mix_from_album` | `GET` | read |
+| `jellyfin.get_instant_mix_from_artists` | `GET` | read |
+| `jellyfin.get_instant_mix_from_item` | `GET` | read |
+| `jellyfin.get_instant_mix_from_music_genre_by_id` | `GET` | read |
+| `jellyfin.get_instant_mix_from_music_genre_by_name` | `GET` | read |
+| `jellyfin.get_instant_mix_from_playlist` | `GET` | read |
+| `jellyfin.get_instant_mix_from_song` | `GET` | read |
+| `jellyfin.get_intros` | `GET` | read |
+| `jellyfin.get_item` | `GET` | read |
+| `jellyfin.get_item_collections` | `GET` | read |
+| `jellyfin.get_item_counts` | `GET` | read |
+| `jellyfin.get_item_image` | `GET` | read |
+| `jellyfin.get_item_image2` | `GET` | read |
+| `jellyfin.get_item_image_by_index` | `GET` | read |
+| `jellyfin.get_item_image_infos` | `GET` | read |
+| `jellyfin.get_item_segments` | `GET` | read |
+| `jellyfin.get_item_user_data` | `GET` | read |
+| `jellyfin.get_items` | `GET` | read |
+| `jellyfin.get_keys` | `GET` | read |
+| `jellyfin.get_latest_channel_items` | `GET` | read |
+| `jellyfin.get_latest_media` | `GET` | read |
+| `jellyfin.get_library_options_info` | `GET` | read |
+| `jellyfin.get_lineups` | `GET` | read |
+| `jellyfin.get_live_recording_file` | `GET` | read |
+| `jellyfin.get_live_stream_file` | `GET` | read |
+| `jellyfin.get_live_tv_channels` | `GET` | read |
+| `jellyfin.get_live_tv_info` | `GET` | read |
+| `jellyfin.get_live_tv_programs` | `GET` | read |
+| `jellyfin.get_local_trailers` | `GET` | read |
+| `jellyfin.get_localization_options` | `GET` | read |
+| `jellyfin.get_log_entries` | `GET` | read |
+| `jellyfin.get_log_file` | `GET` | read |
+| `jellyfin.get_lyrics` | `GET` | read |
+| `jellyfin.get_media_folders` | `GET` | read |
+| `jellyfin.get_metadata_editor_info` | `GET` | read |
+| `jellyfin.get_movie_recommendations` | `GET` | read |
+| `jellyfin.get_movie_remote_search_results` | `POST` | mutating |
+| `jellyfin.get_music_album_remote_search_results` | `POST` | mutating |
+| `jellyfin.get_music_artist_remote_search_results` | `POST` | mutating |
+| `jellyfin.get_music_genre` | `GET` | read |
+| `jellyfin.get_music_genre_image` | `GET` | read |
+| `jellyfin.get_music_genre_image_by_index` | `GET` | read |
+| `jellyfin.get_music_video_remote_search_results` | `POST` | mutating |
+| `jellyfin.get_named_configuration` | `GET` | read |
+| `jellyfin.get_next_up` | `GET` | read |
+| `jellyfin.get_package_info` | `GET` | read |
+| `jellyfin.get_packages` | `GET` | read |
+| `jellyfin.get_parent_path` | `GET` | read |
+| `jellyfin.get_parental_ratings` | `GET` | read |
+| `jellyfin.get_password_reset_providers` | `GET` | read |
+| `jellyfin.get_person` | `GET` | read |
+| `jellyfin.get_person_image` | `GET` | read |
+| `jellyfin.get_person_image_by_index` | `GET` | read |
+| `jellyfin.get_person_remote_search_results` | `POST` | mutating |
+| `jellyfin.get_persons` | `GET` | read |
+| `jellyfin.get_physical_paths` | `GET` | read |
+| `jellyfin.get_ping_system` | `GET` | read |
+| `jellyfin.get_playback_info` | `GET` | read |
+| `jellyfin.get_playlist` | `GET` | read |
+| `jellyfin.get_playlist_items` | `GET` | read |
+| `jellyfin.get_playlist_user` | `GET` | read |
+| `jellyfin.get_playlist_users` | `GET` | read |
+| `jellyfin.get_plugin_configuration` | `GET` | read |
+| `jellyfin.get_plugin_image` | `GET` | read |
+| `jellyfin.get_plugin_manifest` | `POST` | mutating |
+| `jellyfin.get_plugins` | `GET` | read |
+| `jellyfin.get_posted_playback_info` | `POST` | mutating |
+| `jellyfin.get_program` | `GET` | read |
+| `jellyfin.get_programs` | `POST` | mutating |
+| `jellyfin.get_public_system_info` | `GET` | read |
+| `jellyfin.get_public_users` | `GET` | read |
+| `jellyfin.get_query_filters` | `GET` | read |
+| `jellyfin.get_query_filters_legacy` | `GET` | read |
+| `jellyfin.get_quick_connect_enabled` | `GET` | read |
+| `jellyfin.get_quick_connect_state` | `GET` | read |
+| `jellyfin.get_recommended_programs` | `GET` | read |
+| `jellyfin.get_recording` | `GET` | read |
+| `jellyfin.get_recording_folders` | `GET` | read |
+| `jellyfin.get_recordings` | `GET` | read |
+| `jellyfin.get_remote_image_providers` | `GET` | read |
+| `jellyfin.get_remote_images` | `GET` | read |
+| `jellyfin.get_remote_lyrics` | `GET` | read |
+| `jellyfin.get_remote_subtitles` | `GET` | read |
+| `jellyfin.get_repositories` | `GET` | read |
+| `jellyfin.get_resume_items` | `GET` | read |
+| `jellyfin.get_root_folder` | `GET` | read |
+| `jellyfin.get_schedules_direct_countries` | `GET` | read |
+| `jellyfin.get_search_hints` | `GET` | read |
+| `jellyfin.get_seasons` | `GET` | read |
+| `jellyfin.get_series_remote_search_results` | `POST` | mutating |
+| `jellyfin.get_series_timer` | `GET` | read |
+| `jellyfin.get_series_timers` | `GET` | read |
+| `jellyfin.get_server_logs` | `GET` | read |
+| `jellyfin.get_sessions` | `GET` | read |
+| `jellyfin.get_similar_albums` | `GET` | read |
+| `jellyfin.get_similar_artists` | `GET` | read |
+| `jellyfin.get_similar_items` | `GET` | read |
+| `jellyfin.get_similar_movies` | `GET` | read |
+| `jellyfin.get_similar_shows` | `GET` | read |
+| `jellyfin.get_similar_trailers` | `GET` | read |
+| `jellyfin.get_special_features` | `GET` | read |
+| `jellyfin.get_splashscreen` | `GET` | read |
+| `jellyfin.get_startup_configuration` | `GET` | read |
+| `jellyfin.get_studio` | `GET` | read |
+| `jellyfin.get_studio_image` | `GET` | read |
+| `jellyfin.get_studio_image_by_index` | `GET` | read |
+| `jellyfin.get_studios` | `GET` | read |
+| `jellyfin.get_subtitle` | `GET` | read |
+| `jellyfin.get_subtitle_playlist` | `GET` | read |
+| `jellyfin.get_subtitle_with_ticks` | `GET` | read |
+| `jellyfin.get_suggestions` | `GET` | read |
+| `jellyfin.get_system_info` | `GET` | read |
+| `jellyfin.get_system_storage` | `GET` | read |
+| `jellyfin.get_task` | `GET` | read |
+| `jellyfin.get_tasks` | `GET` | read |
+| `jellyfin.get_theme_media` | `GET` | read |
+| `jellyfin.get_theme_songs` | `GET` | read |
+| `jellyfin.get_theme_videos` | `GET` | read |
+| `jellyfin.get_timer` | `GET` | read |
+| `jellyfin.get_timers` | `GET` | read |
+| `jellyfin.get_trailer_remote_search_results` | `POST` | mutating |
+| `jellyfin.get_trailers` | `GET` | read |
+| `jellyfin.get_trickplay_hls_playlist` | `GET` | read |
+| `jellyfin.get_trickplay_tile_image` | `GET` | read |
+| `jellyfin.get_tuner_host_types` | `GET` | read |
+| `jellyfin.get_universal_audio_stream` | `GET` | read |
+| `jellyfin.get_upcoming_episodes` | `GET` | read |
+| `jellyfin.get_user_by_id` | `GET` | read |
+| `jellyfin.get_user_image` | `GET` | read |
+| `jellyfin.get_user_views` | `GET` | read |
+| `jellyfin.get_users` | `GET` | read |
+| `jellyfin.get_utc_time` | `GET` | read |
+| `jellyfin.get_video_stream` | `GET` | read |
+| `jellyfin.get_video_stream_by_container` | `GET` | read |
+| `jellyfin.get_virtual_folders` | `GET` | read |
+| `jellyfin.get_year` | `GET` | read |
+| `jellyfin.get_years` | `GET` | read |
+| `jellyfin.initiate_quick_connect` | `POST` | mutating |
+| `jellyfin.install_package` | `POST` | mutating |
+| `jellyfin.list_backups` | `GET` | read |
+| `jellyfin.log_file` | `POST` | mutating |
+| `jellyfin.mark_favorite_item` | `POST` | mutating |
+| `jellyfin.mark_played_item` | `POST` | mutating |
+| `jellyfin.mark_unplayed_item` | `DELETE` | destructive (elicited) |
+| `jellyfin.merge_versions` | `POST` | mutating |
+| `jellyfin.move_item` | `POST` | mutating |
+| `jellyfin.open_live_stream` | `POST` | mutating |
+| `jellyfin.ping_playback_session` | `POST` | mutating |
+| `jellyfin.play` | `POST` | mutating |
+| `jellyfin.post_added_movies` | `POST` | mutating |
+| `jellyfin.post_added_series` | `POST` | mutating |
+| `jellyfin.post_capabilities` | `POST` | mutating |
+| `jellyfin.post_full_capabilities` | `POST` | mutating |
+| `jellyfin.post_ping_system` | `POST` | mutating |
+| `jellyfin.post_updated_media` | `POST` | mutating |
+| `jellyfin.post_updated_movies` | `POST` | mutating |
+| `jellyfin.post_updated_series` | `POST` | mutating |
+| `jellyfin.post_user_image` | `POST` | mutating |
+| `jellyfin.refresh_item` | `POST` | mutating |
+| `jellyfin.refresh_library` | `POST` | destructive (elicited) |
+| `jellyfin.remove_from_collection` | `DELETE` | destructive (elicited) |
+| `jellyfin.remove_item_from_playlist` | `DELETE` | destructive (elicited) |
+| `jellyfin.remove_media_path` | `DELETE` | destructive (elicited) |
+| `jellyfin.remove_user_from_playlist` | `DELETE` | destructive (elicited) |
+| `jellyfin.remove_user_from_session` | `DELETE` | destructive (elicited) |
+| `jellyfin.remove_virtual_folder` | `DELETE` | destructive (elicited) |
+| `jellyfin.rename_virtual_folder` | `POST` | mutating |
+| `jellyfin.report_playback_progress` | `POST` | mutating |
+| `jellyfin.report_playback_start` | `POST` | mutating |
+| `jellyfin.report_playback_stopped` | `POST` | mutating |
+| `jellyfin.report_session_ended` | `POST` | mutating |
+| `jellyfin.report_viewing` | `POST` | mutating |
+| `jellyfin.reset_tuner` | `POST` | mutating |
+| `jellyfin.restart_application` | `POST` | destructive (elicited) |
+| `jellyfin.revoke_key` | `DELETE` | destructive (elicited) |
+| `jellyfin.search_remote_lyrics` | `GET` | read |
+| `jellyfin.search_remote_subtitles` | `GET` | read |
+| `jellyfin.send_full_general_command` | `POST` | destructive (elicited) |
+| `jellyfin.send_general_command` | `POST` | destructive (elicited) |
+| `jellyfin.send_message_command` | `POST` | mutating |
+| `jellyfin.send_playstate_command` | `POST` | destructive (elicited) |
+| `jellyfin.send_system_command` | `POST` | destructive (elicited) |
+| `jellyfin.set_channel_mapping` | `POST` | mutating |
+| `jellyfin.set_item_image` | `POST` | mutating |
+| `jellyfin.set_item_image_by_index` | `POST` | mutating |
+| `jellyfin.set_remote_access` | `POST` | mutating |
+| `jellyfin.set_repositories` | `POST` | mutating |
+| `jellyfin.shutdown_application` | `POST` | destructive (elicited) |
+| `jellyfin.start_restore_backup` | `POST` | destructive (elicited) |
+| `jellyfin.start_task` | `POST` | destructive (elicited) |
+| `jellyfin.stop_task` | `DELETE` | destructive (elicited) |
+| `jellyfin.sync_play_buffering` | `POST` | mutating |
+| `jellyfin.sync_play_create_group` | `POST` | mutating |
+| `jellyfin.sync_play_get_group` | `GET` | read |
+| `jellyfin.sync_play_get_groups` | `GET` | read |
+| `jellyfin.sync_play_join_group` | `POST` | mutating |
+| `jellyfin.sync_play_leave_group` | `POST` | mutating |
+| `jellyfin.sync_play_move_playlist_item` | `POST` | mutating |
+| `jellyfin.sync_play_next_item` | `POST` | mutating |
+| `jellyfin.sync_play_pause` | `POST` | mutating |
+| `jellyfin.sync_play_ping` | `POST` | mutating |
+| `jellyfin.sync_play_previous_item` | `POST` | mutating |
+| `jellyfin.sync_play_queue` | `POST` | mutating |
+| `jellyfin.sync_play_ready` | `POST` | mutating |
+| `jellyfin.sync_play_remove_from_playlist` | `POST` | mutating |
+| `jellyfin.sync_play_seek` | `POST` | mutating |
+| `jellyfin.sync_play_set_ignore_wait` | `POST` | mutating |
+| `jellyfin.sync_play_set_new_queue` | `POST` | mutating |
+| `jellyfin.sync_play_set_playlist_item` | `POST` | mutating |
+| `jellyfin.sync_play_set_repeat_mode` | `POST` | mutating |
+| `jellyfin.sync_play_set_shuffle_mode` | `POST` | mutating |
+| `jellyfin.sync_play_stop` | `POST` | destructive (elicited) |
+| `jellyfin.sync_play_unpause` | `POST` | mutating |
+| `jellyfin.uninstall_plugin` | `DELETE` | destructive (elicited) |
+| `jellyfin.uninstall_plugin_by_version` | `DELETE` | destructive (elicited) |
+| `jellyfin.unmark_favorite_item` | `DELETE` | destructive (elicited) |
+| `jellyfin.update_branding_configuration` | `POST` | mutating |
+| `jellyfin.update_configuration` | `POST` | mutating |
+| `jellyfin.update_device_options` | `POST` | mutating |
+| `jellyfin.update_display_preferences` | `POST` | mutating |
+| `jellyfin.update_initial_configuration` | `POST` | mutating |
+| `jellyfin.update_item` | `POST` | mutating |
+| `jellyfin.update_item_content_type` | `POST` | mutating |
+| `jellyfin.update_item_image_index` | `POST` | mutating |
+| `jellyfin.update_item_user_data` | `POST` | mutating |
+| `jellyfin.update_library_options` | `POST` | mutating |
+| `jellyfin.update_media_path` | `POST` | mutating |
+| `jellyfin.update_named_configuration` | `POST` | mutating |
+| `jellyfin.update_playlist` | `POST` | mutating |
+| `jellyfin.update_playlist_user` | `POST` | mutating |
+| `jellyfin.update_plugin_configuration` | `POST` | mutating |
+| `jellyfin.update_series_timer` | `POST` | mutating |
+| `jellyfin.update_startup_user` | `POST` | mutating |
+| `jellyfin.update_task` | `POST` | mutating |
+| `jellyfin.update_timer` | `POST` | mutating |
+| `jellyfin.update_user` | `POST` | mutating |
+| `jellyfin.update_user_configuration` | `POST` | mutating |
+| `jellyfin.update_user_item_rating` | `POST` | mutating |
+| `jellyfin.update_user_password` | `POST` | mutating |
+| `jellyfin.update_user_policy` | `POST` | mutating |
+| `jellyfin.upload_custom_splashscreen` | `POST` | mutating |
+| `jellyfin.upload_lyrics` | `POST` | mutating |
+| `jellyfin.upload_subtitle` | `POST` | mutating |
+| `jellyfin.validate_path` | `POST` | mutating |
 
 
 ## Tautulli Actions

--- a/docs/superpowers/plans/2026-08-03-yarr-fleet-support.md
+++ b/docs/superpowers/plans/2026-08-03-yarr-fleet-support.md
@@ -1,0 +1,509 @@
+# yarr Fleet Support Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deliver seven stacked pull requests that make yarr safe and practical for a 20-instance Plex/Tautulli fleet without increasing its single-tool MCP schema cost.
+
+**Architecture:** Keep configuration, authorization, discovery, fanout, and observability as separate application-layer units. Generated-operation mutation metadata becomes the common safety source; fleet Code Mode calls compile to host-dispatched plans so authorization, bounded concurrency, timeout, truncation, and stable ordering happen outside QuickJS.
+
+**Tech Stack:** Rust 2024, MSRV 1.97.1, `rmcp = "=3.0.0-beta.2"`, Tokio, reqwest, rquickjs, serde, TOML/YAML, axum-prometheus, sibling `*_tests.rs` modules.
+
+## Global Constraints
+
+- Preserve one `yarr` MCP tool in Code Mode and flat MCP parity.
+- Keep environment configuration authoritative for secret values.
+- Never accept or write inline fleet-file credentials.
+- Preserve CLI/MCP thin shims; business logic belongs in `src/app*`.
+- Every destructive fleet authorization completes before the first upstream call.
+- Results and generated artifacts must be deterministic and credential-redacted.
+- Run `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test`, `cargo test --test parity`, and `python3 scripts/check-doc-links.py` on every stacked head.
+
+---
+
+### Task 1: PR 1 — Generated-operation safety and fleet authority policy
+
+**Files:**
+- Create: `src/openapi/safety.rs`
+- Create: `src/openapi/safety_tests.rs`
+- Modify: `src/openapi.rs`
+- Modify: `src/config/mcp.rs`
+- Modify: `src/config.rs`
+- Modify: `src/config/services.rs`
+- Modify: `src/mcp/rmcp_server.rs`
+- Modify: `src/mcp/rmcp_server_definitions.rs`
+- Modify: `src/mcp/tools.rs`
+- Modify: `src/mcp/elicit.rs`
+- Modify: `src/mcp/*_tests.rs`
+- Modify: `xtask/src/tool_docs.rs`
+- Modify: `docs/TOOLS_ACTIONS_ENDPOINTS.md`
+- Modify: `docs/CONFIG.md`
+- Modify: `docs/ENV.md`
+- Modify: `CHANGELOG.md`
+
+**Interfaces:**
+- Produces: `OperationSafety`, `operation_safety(kind, op)`, `classify_operation(kind, spec)`, `validate_generated_write_classification()`.
+- Produces: `YarrConfig::is_readonly(name)`, `McpConfig.destructive_fanout_max: usize`.
+- Produces: `gate_destructive(peer, action, services: &[String])` with one aggregate prompt.
+
+- [ ] **Step 1: Add failing table-driven classification tests**
+
+```rust
+#[test]
+fn plex_non_delete_high_impact_ops_are_destructive() {
+    for op in ["terminate_session", "edit_metadata_item", "refresh_section",
+        "scan", "stop_all_refreshes", "add_section", "edit_section"] {
+        assert_eq!(classify_operation(ServiceKind::Plex, op), OperationSafety::Destructive);
+    }
+}
+
+#[test]
+fn every_generated_write_has_an_explicit_decision() {
+    assert_eq!(validate_generated_write_classification(), Ok(()));
+}
+```
+
+- [ ] **Step 2: Run the focused tests and confirm the new symbols are absent**
+
+Run: `cargo test openapi::safety_tests -- --nocapture`
+Expected: compilation fails because `OperationSafety` and classification functions do not exist.
+
+- [ ] **Step 3: Implement declarative safety rows and DELETE fallback**
+
+```rust
+pub enum OperationSafety { Read, Mutating, Destructive }
+pub struct OperationSafetyRow { pub kind: ServiceKind, pub op: &'static str, pub safety: OperationSafety }
+
+pub fn operation_safety(kind: ServiceKind, spec: &OperationSpec) -> Option<OperationSafety> {
+    if spec.method.is_delete() { return Some(OperationSafety::Destructive); }
+    OPERATION_SAFETY_ROWS.iter().find(|row| row.kind == kind && row.op == spec.name).map(|row| row.safety)
+}
+```
+
+Populate rows by auditing every non-GET/HEAD operation for Plex, Sonarr, Radarr,
+Overseerr, and Jellyfin. Treat DELETE as destructive even when absent from rows;
+require all other writes to have a row.
+
+- [ ] **Step 4: Add failing read-only and aggregate-elicitation tests**
+
+```rust
+#[test]
+fn readonly_names_are_case_insensitive() {
+    let cfg = config_with_readonly(["plex_den"]);
+    assert!(cfg.is_readonly("PLEX_DEN"));
+}
+
+#[test]
+fn aggregate_prompt_names_every_target() {
+    let message = confirm_message("terminate_session", &["plex_4k".into(), "plex_den".into()]);
+    assert!(message.contains("2 instances"));
+    assert!(message.contains("plex_4k, plex_den"));
+}
+```
+
+- [ ] **Step 5: Implement instance write policy and fanout cap configuration**
+
+Parse `YARR_FLEET_READONLY` as normalized configured names and
+`YARR_MCP_DESTRUCTIVE_FANOUT_MAX` as a positive integer defaulting to `3`.
+Reject unknown read-only names after merged service validation. Apply read-only
+checks to generic writes, curated mutating actions, and generated writes before
+dispatch.
+
+- [ ] **Step 6: Replace method-only MCP checks with safety classification**
+
+Both outer flat-mode and inner Code Mode operation checks call the same
+`operation_safety` function. Pass a sorted target slice to elicitation; reject a
+destructive target list larger than the cap before prompting.
+
+- [ ] **Step 7: Generate and verify the write-classification report**
+
+Extend `cargo xtask tool-docs` with columns for method, mutation class, and
+elicitation. Make `--check` return an error containing kind and operation for any
+unclassified generated write.
+
+Run: `cargo xtask tool-docs && cargo xtask tool-docs --check`
+Expected: generated docs are current and the classification coverage check passes.
+
+- [ ] **Step 8: Run PR 1 gates and commit**
+
+```bash
+cargo fmt --check
+cargo clippy -- -D warnings
+cargo test
+cargo test --test parity
+python3 scripts/check-doc-links.py
+git add src xtask docs CHANGELOG.md
+git commit -m "feat: gate destructive generated operations"
+```
+
+---
+
+### Task 2: PR 2 — Multi-instance validation and documentation
+
+**Files:**
+- Modify: `src/config/services.rs`
+- Modify: `src/config/services_tests.rs`
+- Modify: `src/codemode/proxy.rs`
+- Modify: `src/codemode/proxy_tests.rs`
+- Modify: `README.md`
+- Modify: `docs/CONFIG.md`
+- Modify: `docs/ENV.md`
+- Modify: `CHANGELOG.md`
+
+**Interfaces:**
+- Produces: `validate_service_identities(&[ServiceConfig]) -> anyhow::Result<()>`.
+- Produces: public crate-private `CODEMODE_RESERVED_GLOBALS` used by config and proxy generation.
+
+- [ ] **Step 1: Write reserved-name and environment-namespace collision tests**
+
+```rust
+#[test]
+fn reserved_codemode_global_fails_configuration() {
+    let error = validate_service_identities(&[service("console", ServiceKind::Plex)]).unwrap_err();
+    assert!(error.to_string().contains("reserved Code Mode global"));
+}
+
+#[test]
+fn normalized_env_names_must_be_unique() {
+    let error = validate_service_identities(&[service("plex-den", ServiceKind::Plex), service("plex_den", ServiceKind::Plex)]).unwrap_err();
+    assert!(error.to_string().contains("YARR_PLEX_DEN_*"));
+}
+```
+
+- [ ] **Step 2: Run focused tests and observe failure**
+
+Run: `cargo test config::services::tests`
+Expected: failure because startup-wide identity validation is absent.
+
+- [ ] **Step 3: Centralize validation and remove proxy's silent skip**
+
+Call `validate_service_identities` after all configuration sources load. Keep a
+defensive assertion in `render_service_namespaces`, because invalid service names
+must never reach preamble generation.
+
+- [ ] **Step 4: Add complete multi-instance documentation**
+
+Document explicit kind override, normalization collisions, underscore preference,
+`globalThis["plex-den"]`, ambiguous bare-kind errors, and every reserved global.
+Cross-link README and ENV to the CONFIG section.
+
+- [ ] **Step 5: Verify and commit PR 2**
+
+Run the global gates, then commit with `docs: document and validate service identities`.
+
+---
+
+### Task 3: PR 3 — Additive fleet configuration files
+
+**Files:**
+- Create: `src/config/fleet_file.rs`
+- Create: `src/config/fleet_file_tests.rs`
+- Modify: `src/config.rs`
+- Modify: `src/config/services.rs`
+- Modify: `Cargo.toml`
+- Modify: `docs/CONFIG.md`
+- Modify: `docs/ENV.md`
+- Modify: `.env.example`
+- Modify: `CHANGELOG.md`
+
+**Interfaces:**
+- Produces: `FleetDocument { services: Vec<FleetServiceEntry> }`.
+- Produces: `load_fleet_file(path: &Path) -> Result<Vec<ServiceConfig>>`.
+- Produces: `merge_service_sources(file, env) -> Result<Vec<ServiceConfig>>`.
+- Preserves discovery metadata: `client_identifier`, `plex`, and `relay_only`.
+
+- [ ] **Step 1: Add YAML/TOML parse and inline-secret rejection tests**
+
+```rust
+#[test]
+fn yaml_resolves_token_indirection() {
+    let doc = "services:\n  - name: plex_den\n    kind: plex\n    url: http://plex:32400\n    token_env: PLEX_DEN_TOKEN\n";
+    assert_eq!(parse_fleet(doc, FleetFormat::Yaml).unwrap().services[0].token_env.as_deref(), Some("PLEX_DEN_TOKEN"));
+}
+
+#[test]
+fn inline_secret_is_rejected_with_entry_location() {
+    let error = parse_fleet("services:\n  - name: plex_den\n    kind: plex\n    url: x\n    token: secret\n", FleetFormat::Yaml).unwrap_err();
+    assert!(error.to_string().contains("plex_den"));
+    assert!(error.to_string().contains("token"));
+}
+```
+
+- [ ] **Step 2: Add dependencies and strict models**
+
+Use `serde_yaml` for YAML and existing `toml` for TOML. Apply
+`#[serde(deny_unknown_fields)]` to entries so inline credential names are
+rejected. Validate environment reference names with `[A-Za-z_][A-Za-z0-9_]*`.
+
+- [ ] **Step 3: Add merge-precedence and 24-instance tests**
+
+Assert environment entries replace file entries by case-insensitive configured
+name, all unique entries remain, duplicates within a source fail, and the final
+list is deterministically sorted by name.
+
+- [ ] **Step 4: Load the fleet file before environment service overlay**
+
+Read `YARR_FLEET_FILE` after the environment overlay is installed. Resolve
+`*_env` references through `env_value`, merge environment-declared services, and
+run shared identity/read-only validation once on the final list.
+
+- [ ] **Step 5: Verify secret redaction and documentation**
+
+Add a status serialization regression test proving resolved keys/tokens never
+appear. Document union semantics and environment same-name precedence.
+
+- [ ] **Step 6: Run gates and commit PR 3**
+
+Commit with `feat: load additive fleet configuration files`.
+
+---
+
+### Task 4: PR 4 — Fleet-scale runtime limits and explicit truncation
+
+**Files:**
+- Modify: `src/codemode.rs`
+- Modify: `src/config/mcp.rs`
+- Modify: `src/token_limit.rs`
+- Modify: `src/token_limit_tests.rs`
+- Modify: `src/yarr.rs`
+- Modify: `docs/CONFIG.md`
+- Modify: `docs/ENV.md`
+- Create: `benches/fleet_runtime.rs`
+- Modify: `Cargo.toml`
+- Modify: `CHANGELOG.md`
+
+**Interfaces:**
+- Produces: default `codemode_timeout_secs = 120`.
+- Produces: `bound_fleet_value(value, max_bytes) -> FleetBoundedValue` where the result always states `truncated`.
+
+- [ ] **Step 1: Pin the 120-second default and runtime-concurrency meaning**
+
+Update config tests to assert `120`; document that `codemode_max_concurrent`
+counts QuickJS runtimes and does not throttle dispatches inside one runtime.
+
+- [ ] **Step 2: Add per-instance bounding tests**
+
+```rust
+#[test]
+fn fleet_value_marks_only_oversized_instance_truncated() {
+    let bounded = bound_fleet_value(json!({"rows": vec!["long"; 100]}), 80);
+    assert!(bounded.truncated);
+    assert!(bounded.value.is_some());
+}
+```
+
+- [ ] **Step 3: Implement valid-JSON per-instance summaries**
+
+Return `{truncated:false,value}` for complete values and
+`{truncated:true,summary:{type,item_count,observed_bytes},value:null}` for
+oversized values. Do not embed a syntactically sliced JSON prefix.
+
+- [ ] **Step 4: Audit and benchmark heap/pool behavior**
+
+The benchmark constructs twenty representative session arrays, applies result
+bounding, and runs the Code Mode serialization path. Keep 64 MiB only when the
+benchmark and unit test complete below the cap. Document reqwest's shared client
+and per-host idle pool of eight.
+
+- [ ] **Step 5: Run gates and commit PR 4**
+
+Commit with `perf: scale Code Mode limits for fleet fanout`.
+
+---
+
+### Task 5: PR 5 — Plex account discovery and Tautulli pairing
+
+**Files:**
+- Create: `src/discovery.rs`
+- Create: `src/discovery/plex.rs`
+- Create: `src/discovery/plex_tests.rs`
+- Create: `src/discovery/reconcile.rs`
+- Create: `src/discovery/reconcile_tests.rs`
+- Create: `src/app/discovery.rs`
+- Create: `src/app/discovery_tests.rs`
+- Modify: `src/lib.rs`
+- Modify: `src/app.rs`
+- Modify: `src/cli/command.rs`
+- Modify: `src/cli/router_infra.rs`
+- Modify: `src/cli/router_infra_tests.rs`
+- Modify: `src/cli/usage.rs`
+- Modify: `src/cli.rs`
+- Modify: `src/main.rs`
+- Modify: `docs/CONFIG.md`
+- Modify: `CHANGELOG.md`
+
+**Interfaces:**
+- Produces: `PlexResource`, `PlexConnection`, `DiscoveredPlexServer`.
+- Produces: `discover_plex(options: DiscoverPlexOptions) -> Result<DiscoveryReport>`.
+- Produces: `reconcile(existing, discovered) -> FleetDrift`.
+- Produces: atomic `write_discovery_outputs(fleet_path, env_path, report)`.
+
+- [ ] **Step 1: Verify the live plex.tv shape without persisting secrets**
+
+If `PLEX_ACCOUNT_TOKEN` exists, request `/api/v2/resources` and inspect only key
+names, JSON types, and counts using a redacting transform. Otherwise verify
+against current authoritative Plex API material and record the missing live-token
+gate in the PR validation notes. Do not print resource access tokens.
+
+- [ ] **Step 2: Add mocked resource filtering/selection tests**
+
+Cover players/controllers, owned/shared resources, local/direct HTTPS/relay
+preference, malformed resources, and relay-only flags.
+
+- [ ] **Step 3: Implement strict-enough, forward-compatible response models**
+
+Deserialize required identity/name/access-token fields and default optional
+arrays/booleans. Filter `provides.split(',')` by exact trimmed `server` token.
+
+- [ ] **Step 4: Add deterministic naming and drift tests**
+
+Slug to lowercase ASCII `[a-z0-9_]`, prefix `plex_`, collapse separators, and
+append the first eight lowercase hex characters of SHA-256(clientIdentifier) on
+collision. Compare by client identifier, never list position.
+
+- [ ] **Step 5: Implement CLI parsing and non-mutating `--diff`**
+
+Support `yarr discover plex --fleet-file PATH --env-file PATH --token-env NAME
+[--include-shared] [--diff]`. Owned-only is implicit and remains the default.
+Return exit code 2 when `--diff` finds drift, 0 for no drift, and 1 for errors.
+
+- [ ] **Step 6: Implement atomic mode-0600 outputs**
+
+Create both temporary files beside their targets, set the env temporary file to
+0600 before writing, flush and persist, and preserve existing files on any
+failure. Fleet output contains only `token_env`; env output contains access
+tokens.
+
+- [ ] **Step 7: Add Tautulli identifier pairing tests and implementation**
+
+Call existing Tautulli `get_server_info` logic per configured instance, extract
+`pms_identifier`, pair exact identifiers, and report unpaired instances on both
+sides plus duplicate identifiers.
+
+- [ ] **Step 8: Run gates and commit PR 5**
+
+Commit with `feat: discover Plex fleets from plex.tv`.
+
+---
+
+### Task 6: PR 6 — Host-backed fleet fanout and canonical snippets
+
+**Files:**
+- Create: `src/fleet.rs`
+- Create: `src/fleet_tests.rs`
+- Create: `src/app/fleet.rs`
+- Create: `src/app/fleet_tests.rs`
+- Modify: `src/app.rs`
+- Modify: `src/app/codemode.rs`
+- Modify: `src/codemode/proxy.rs`
+- Modify: `src/codemode/proxy_tests.rs`
+- Modify: `src/codemode/store.rs`
+- Modify: `src/codemode/store_tests.rs`
+- Modify: `docs/CONFIG.md`
+- Modify: `CHANGELOG.md`
+
+**Interfaces:**
+- Produces: `FleetTarget`, `FleetCall`, `FleetResult`.
+- Produces: `YarrService::fleet_map(kind, operation, args, options, guard)`.
+- Produces JS: `fleet.of`, `fleet.all`, `fleet.map`, and `fleet.status`.
+
+- [ ] **Step 1: Add ordering, partial-failure, timeout, and cap tests**
+
+Use local mock servers: nineteen return JSON, one refuses connections; assert
+twenty name-sorted results, nineteen successes, one useful error, and elapsed
+time below ten seconds. Add a delayed server to prove per-instance timeout.
+
+- [ ] **Step 2: Implement the bounded host dispatcher**
+
+Use `tokio::sync::Semaphore` with default parallelism eight and
+`tokio::time::timeout` around each call. Collect all join results and sort by
+configured name. Convert errors to sanitized strings.
+
+- [ ] **Step 3: Compile the JS fleet callback into a declarative call**
+
+`fleet.map("plex", s => s.get_sessions())` receives proxy objects that record one
+method name and JSON argument object instead of dispatching immediately. Reject
+callbacks that make zero/multiple calls, access another service, or return a
+non-call-plan value. Send one `fleet_map` bridge request to Rust.
+
+- [ ] **Step 4: Authorize before dispatch and apply result bounds**
+
+Resolve every target, classify mutation/destruction once, enforce read-only and
+destructive caps, elicit once when required, then start calls. Wrap every success
+with the per-instance truncation result from PR 4.
+
+- [ ] **Step 5: Add immutable built-in snippets**
+
+Expose `fleet_activity`, `fleet_health`, `fleet_library_sizes`, and
+`fleet_transcode_load` through snippet listing/running. User save/delete returns a
+clear error for built-in names.
+
+- [ ] **Step 6: Run gates and commit PR 6**
+
+Commit with `feat: add bounded Code Mode fleet fanout`.
+
+---
+
+### Task 7: PR 7 — Fleet status and observability
+
+**Files:**
+- Modify: `src/app/fleet.rs`
+- Modify: `src/app/fleet_tests.rs`
+- Modify: `src/cli/command.rs`
+- Modify: `src/cli/router_infra.rs`
+- Modify: `src/cli/router_infra_tests.rs`
+- Modify: `src/cli/usage.rs`
+- Modify: `src/cli.rs`
+- Modify: `src/yarr.rs`
+- Modify: `src/yarr/response.rs`
+- Modify: `src/yarr/response_tests.rs`
+- Modify: `src/server/routes_tests/metrics_tests.rs`
+- Modify: `docs/CONFIG.md`
+- Modify: `docs/ENV.md`
+- Modify: `CHANGELOG.md`
+
+**Interfaces:**
+- Produces: `YarrService::fleet_status() -> Result<Vec<FleetStatus>>`.
+- Produces CLI: `yarr fleet status [--json]`.
+- Produces metrics labeled by bounded configured `service` and `kind`.
+
+- [ ] **Step 1: Add fleet status contract tests**
+
+Assert sorted entries include name, kind, reachable, latency milliseconds, and a
+version string when discoverable. An unreachable instance is a result row, not a
+whole-command error.
+
+- [ ] **Step 2: Implement shared application status and thin CLI routing**
+
+Reuse the bounded dispatcher and each kind's status endpoint. Extract common
+version keys (`version`, `Version`, `MediaContainer.version`) without making
+version absence an error.
+
+- [ ] **Step 3: Add request span and metric label tests**
+
+Instrument every upstream send path through one helper/span carrying
+`service.name`, `service.kind`, HTTP method, and sanitized path template. Record
+latency histograms and counters with configured service and kind labels.
+
+- [ ] **Step 4: Verify credential redaction**
+
+Tests capture logs and metrics while service credentials are configured, then
+assert tokens, API keys, authenticated query strings, and response bodies are
+absent.
+
+- [ ] **Step 5: Run final full gates and commit PR 7**
+
+```bash
+cargo fmt --check
+cargo clippy -- -D warnings
+cargo test
+cargo test --test parity
+python3 scripts/check-doc-links.py
+git add src docs CHANGELOG.md
+git commit -m "feat: add fleet status observability"
+```
+
+- [ ] **Step 6: Publish the stacked pull requests**
+
+Push all seven `codex/fleet-0N-*` branches. Open PR 1 against `main`, each later
+PR against its immediate predecessor, and include dependency, test evidence,
+security behavior, and rebase instructions in every description.

--- a/docs/superpowers/specs/2026-08-03-yarr-fleet-support-design.md
+++ b/docs/superpowers/specs/2026-08-03-yarr-fleet-support-design.md
@@ -1,0 +1,190 @@
+# yarr Fleet Support Design
+
+**Date:** 2026-08-03
+**Status:** Approved
+**Target:** `dinglebear-ai/yarr` on Rust 2024, MSRV 1.97.1, `rmcp = "=3.0.0-beta.2"`
+
+## Objective
+
+Extend yarr's existing multi-instance data model into a safe, discoverable fleet
+control surface for Hermes Agent. The result supports 20 or more Plex and
+Tautulli instances plus shared Sonarr and Radarr while retaining a single MCP
+tool schema and full write authority with explicit destructive-operation gates.
+
+The implementation ships as seven stacked, upstream-reviewable pull requests.
+Each branch builds on its predecessor, contains a coherent workstream, and must
+pass its focused tests plus the full repository gate. Once a predecessor merges,
+the next branch can be rebased onto `main` without changing its logical patch.
+
+## Existing Foundations
+
+The implementation preserves these current capabilities:
+
+- `ServiceConfig.name` and `ServiceConfig.kind` already permit multiple named
+  instances of one kind.
+- `YARR_<NAME>_KIND` explicitly selects the kind independently of the configured
+  name.
+- Exact configured names win during lookup; a bare kind resolves only when
+  unique and otherwise returns the matching configured names.
+- Code Mode exposes one namespace per configured name.
+- Generated Plex operations already include the required read and write calls.
+- Plex and Tautulli credentials are injected by the server-side transport.
+- MCP elicitation fails closed when the client cannot confirm a destructive call.
+
+## PR 1: Generated-Operation Safety
+
+Introduce a declarative generated-operation classification table keyed by
+`(ServiceKind, operation name)`. A generated operation is destructive when its
+HTTP method is DELETE or the explicit table marks it destructive. The initial
+audit covers Plex, Sonarr, Radarr, Overseerr, and Jellyfin, including Plex's
+non-DELETE session termination and high-impact library mutations.
+
+The classification table also records reviewed non-destructive mutations so
+`cargo xtask tool-docs` can report every generated write as classified and fail
+when a newly generated write lacks a decision. Read-only service identities from
+`YARR_FLEET_READONLY` reject every mutation before dispatch, including generated
+operations and generic API writes.
+
+The authorization context represents either one target or a fleet target list.
+A destructive fleet dispatch gets one elicitation message naming all affected
+instances. The configurable destructive fanout maximum defaults to three; a
+larger target set is rejected before elicitation or upstream calls. Single-target
+behavior remains compatible with existing MCP calls. Direct CLI operation
+continues to be a trusted operator surface, except read-only identities still
+reject writes because that is an instance policy rather than an MCP policy.
+
+## PR 2: Multi-Instance Validation and Documentation
+
+Move Code Mode reserved global names into a configuration-visible validation
+contract. Configuration loading rejects reserved identities with an actionable
+error listing the reserved names. It also rejects configured names whose
+uppercased, non-alphanumeric-to-underscore environment namespaces collide.
+
+Document the full multi-instance contract in `docs/CONFIG.md`, cross-link it from
+the README and `docs/ENV.md`, and include complete Plex/Tautulli examples. Explain
+environment namespace normalization, the underscore naming recommendation,
+bracket access for non-JavaScript identifiers, bare-kind ambiguity, and reserved
+names.
+
+## PR 3: Fleet Configuration File
+
+Add `YARR_FLEET_FILE` as an additive YAML or TOML input. A focused fleet-file
+model accepts public connection metadata and credential-variable references such
+as `token_env` and `api_key_env`. It rejects inline secret field names such as
+`token`, `api_key`, `password`, and `username` during deserialization instead of
+silently ignoring them.
+
+The loader retains source path and entry location information for diagnostics,
+resolves each credential reference through the existing environment overlay, and
+then merges fleet-file entries with environment-declared services. Environment
+entries replace same-named file entries; all other entries form a union. Duplicate
+names within either source and normalized environment-namespace collisions across
+the merged result fail startup. Pairing metadata and Plex client identifiers live
+in a separate fleet metadata structure rather than expanding transport auth
+responsibilities.
+
+Status and debug serialization continue to redact resolved credentials.
+
+## PR 4: Fleet Runtime Limits
+
+Raise the default Code Mode deadline from 30 to 120 seconds and document that the
+runtime concurrency setting limits simultaneous QuickJS runtimes, not calls made
+within one script. Preserve the shared reqwest client, whose pool is per host, and
+measure the 64 MiB QuickJS heap with representative 20-instance session payloads
+before changing it.
+
+Add a per-instance result bounding function used by fleet dispatch. If an
+instance result exceeds its budget, return a valid result envelope carrying
+`truncated: true` for that instance. Never rely on the final whole-tool token cap
+to communicate fleet completeness. Complete instances remain distinguishable
+from truncated and failed instances.
+
+## PR 5: Plex Account Discovery
+
+Add `yarr discover plex` as a CLI-only scaffolding command. A dedicated plex.tv
+client sends the account token with the standard Plex client headers and parses
+the live API's verified response shape. Only resources whose `provides` includes
+`server` are candidates; owned-only behavior is the default and shared resources
+require an explicit opt-in.
+
+Connection selection prefers local connections, then direct HTTPS, then relay.
+Relay-only selections are clearly flagged. Names are stable `plex_<slug>` values;
+collisions append a short deterministic hash of `clientIdentifier`. Fleet entries
+pin `clientIdentifier` and reference variables in a companion env file. Secret
+output is written atomically with mode 0600 and never enters YAML/TOML.
+
+Reconciliation compares discovered identity records with the existing fleet
+file. `--diff` reports additions, removals, renames, URL changes, and relay-state
+changes, returns non-zero on drift, and does not mutate either file. Normal output
+writes only after successful discovery and validation.
+
+Tautulli pairing queries each configured Tautulli `get_server_info`, compares its
+`pms_identifier` with Plex client identifiers, persists unambiguous pairing hints,
+and reports every unpaired or multiply matched instance.
+
+## PR 6: Fleet Fanout and Canonical Snippets
+
+Expose a `fleet` Code Mode global backed by a host-side dispatcher:
+
+- `fleet.of(kind)` returns configured names of that kind.
+- `fleet.all()` returns sorted `{name, kind}` descriptors.
+- `fleet.map(kind, callback)` performs bounded parallel work with per-instance
+  timeouts and returns sorted success/error envelopes.
+- `fleet.status()` returns per-instance status through the same dispatcher.
+
+The host dispatcher owns concurrency, deadlines, authorization aggregation,
+result bounding, and stable ordering. The JavaScript callback is constrained to
+one service invocation per selected instance so the host can inspect and
+authorize the complete call plan before dispatch. Individual upstream failures
+never reject the fleet operation.
+
+Ship `fleet_activity`, `fleet_health`, `fleet_library_sizes`, and
+`fleet_transcode_load` as built-in read-only canonical snippets. Built-ins are
+discoverable through the existing snippet API and cannot be overwritten or
+deleted by user snippet operations.
+
+## PR 7: Fleet Observability
+
+Implement `yarr fleet status` and `fleet.status()` on one application-layer
+status service. Results include configured name, kind, reachability, version when
+available, and observed latency.
+
+Every upstream request span carries structured `service.name` and `service.kind`
+fields. Existing request and domain metrics gain a configured service-name label;
+cardinality remains bounded by loaded configuration. Logs and metrics never carry
+credentials, full authenticated URLs, or response bodies.
+
+## Error Handling and Safety Invariants
+
+- Configuration and classification errors fail startup or CI with the offending
+  kind, name, operation, file, and entry location when available.
+- No discovery operation silently expands or mutates a destructive-authority
+  fleet.
+- No individual fleet failure discards successful sibling results.
+- No destructive fleet call dispatches partially: authorization and fanout-cap
+  checks complete before any upstream request.
+- Read-only service identities reject all writes on every surface.
+- Truncation is explicit per instance.
+- Credential values are resolved only at runtime and remain redacted.
+
+## Testing and Release Gates
+
+Tests follow sibling `*_tests.rs` conventions. Add a 20-instance mixed-kind
+fixture and table-driven coverage for safety classification, configuration merge
+and validation, discovery payloads and drift, fanout failure isolation and
+timeouts, destructive aggregation, read-only policy, result truncation, and
+observability labels.
+
+Each PR runs its focused tests and the final stacked head runs:
+
+```text
+cargo fmt --check
+cargo clippy -- -D warnings
+cargo test
+cargo test --test parity
+python3 scripts/check-doc-links.py
+```
+
+The discovery parser additionally requires a live, redacted plex.tv shape check
+before its model is finalized. Live credentials and returned tokens must not be
+captured in tests, logs, commits, or command output.

--- a/src/actions/dispatch.rs
+++ b/src/actions/dispatch.rs
@@ -82,6 +82,12 @@ pub async fn execute_service_action(service: &YarrService, action: &YarrAction) 
     // on both the CLI and MCP paths. No-op for generic/infra actions.
     if let Some(service_name) = target_service(action) {
         validate_action_for_service(service, action.name(), service_name)?;
+        if action_mutates(service, action)? && service.is_read_only(service_name)? {
+            anyhow::bail!(
+                "service `{service_name}` is read-only via YARR_FLEET_READONLY; mutating action `{}` was refused",
+                action.name()
+            );
+        }
     }
     match action {
         YarrAction::ServiceStatus { service: name } => service.service_status(name).await,
@@ -144,6 +150,24 @@ pub async fn execute_service_action(service: &YarrService, action: &YarrAction) 
             (cmd.handler)(service, params).await
         }
     }
+}
+
+fn action_mutates(service: &YarrService, action: &YarrAction) -> Result<bool> {
+    Ok(match action {
+        YarrAction::ApiPost { .. } | YarrAction::ApiPut { .. } | YarrAction::ApiDelete { .. } => {
+            true
+        }
+        YarrAction::Op {
+            service: service_name,
+            op,
+            ..
+        } => service
+            .kind_of(service_name)?
+            .and_then(|kind| crate::openapi::classify_operation(kind, op))
+            .is_some_and(|safety| safety != crate::openapi::OperationSafety::Read),
+        YarrAction::Curated { name, .. } => curated_command(name).is_some_and(|cmd| cmd.mutates),
+        _ => false,
+    })
 }
 
 #[cfg(test)]

--- a/src/actions/dispatch_tests.rs
+++ b/src/actions/dispatch_tests.rs
@@ -78,3 +78,36 @@ fn shared_guard_skips_unknown_service_name() {
     validate_action_for_service(&state.service, "set_quality", "not-configured")
         .expect("guard is a no-op for unknown service names");
 }
+
+#[tokio::test]
+async fn readonly_instance_refuses_mutation_before_upstream_dispatch() {
+    use crate::{
+        app::YarrService,
+        config::{ServiceConfig, ServiceKind, YarrConfig},
+        yarr::YarrClient,
+    };
+
+    let config = YarrConfig {
+        services: vec![ServiceConfig {
+            name: "plex_prod".into(),
+            kind: ServiceKind::Plex,
+            base_url: "http://127.0.0.1:9".into(),
+            read_only: true,
+            ..ServiceConfig::default()
+        }],
+    };
+    let service = YarrService::new(YarrClient::new(&config).unwrap(), config);
+    let error = execute_service_action(
+        &service,
+        &YarrAction::ApiPost {
+            service: "plex_prod".into(),
+            path: "/library/sections/1/refresh".into(),
+            body: serde_json::json!({}),
+        },
+    )
+    .await
+    .unwrap_err();
+
+    assert!(error.to_string().contains("read-only"));
+    assert!(error.to_string().contains("plex_prod"));
+}

--- a/src/app.rs
+++ b/src/app.rs
@@ -205,6 +205,12 @@ impl YarrService {
             .map(|service| service.map(|s| s.kind))
     }
 
+    pub(crate) fn is_read_only(&self, name: &str) -> Result<bool> {
+        Ok(self
+            .find_service(name)?
+            .is_some_and(|service| service.read_only))
+    }
+
     /// Single source of truth for name/kind → service resolution. Trims and
     /// lowercases `name`, then matches a configured service by its name or kind.
     /// Returns `None` for an empty name or no match. Callers that additionally

--- a/src/app.rs
+++ b/src/app.rs
@@ -41,6 +41,8 @@ pub struct YarrService {
     codemode_slots: std::sync::Arc<tokio::sync::Semaphore>,
     codemode_queue_timeout: std::time::Duration,
     codemode_execution_timeout: std::time::Duration,
+    fleet_max_concurrent: usize,
+    fleet_instance_timeout: std::time::Duration,
 }
 
 impl YarrService {
@@ -62,7 +64,19 @@ impl YarrService {
             )),
             codemode_queue_timeout: crate::codemode::CODEMODE_QUEUE_TIMEOUT,
             codemode_execution_timeout: crate::codemode::CODEMODE_TIMEOUT,
+            fleet_max_concurrent: crate::codemode::FLEET_MAX_CONCURRENT,
+            fleet_instance_timeout: crate::codemode::FLEET_INSTANCE_TIMEOUT,
         }
+    }
+
+    pub fn with_fleet_limits(
+        mut self,
+        max_concurrent: usize,
+        instance_timeout: std::time::Duration,
+    ) -> Self {
+        self.fleet_max_concurrent = max_concurrent.max(1);
+        self.fleet_instance_timeout = instance_timeout;
+        self
     }
 
     /// Enable Code Mode `writeArtifact` by setting the artifacts root (typically

--- a/src/app/codemode.rs
+++ b/src/app/codemode.rs
@@ -35,6 +35,8 @@ static ARTIFACT_WRITE_LOCK: Mutex<()> = Mutex::new(());
 mod artifacts;
 #[path = "codemode_dispatch.rs"]
 mod dispatch;
+#[path = "codemode_fleet.rs"]
+mod fleet;
 #[path = "codemode_runtime.rs"]
 mod runtime;
 #[path = "codemode_snippets.rs"]
@@ -43,12 +45,25 @@ mod snippets;
 use artifacts::{prune_artifact_runs, write_codemode_artifact};
 use runtime::{ActiveRunMetric, ArtifactRequest, EmbedRequest, ToolRequest};
 
+#[derive(Debug, Clone, serde::Deserialize)]
+pub(crate) struct FleetMapRequest {
+    pub kind: String,
+    pub method: String,
+    #[serde(default)]
+    pub args: Value,
+}
+
 /// MCP-supplied defense-in-depth policy for every action emitted by a Code
 /// Mode script. CLI runs use no guard and retain their local-trust behavior.
 pub(crate) trait CodeModeCallGuard: Send + Sync {
     fn authorize<'a>(
         &'a self,
         action: &'a YarrAction,
+    ) -> Pin<Box<dyn Future<Output = Result<(), String>> + Send + 'a>>;
+
+    fn authorize_fleet<'a>(
+        &'a self,
+        request: &'a FleetMapRequest,
     ) -> Pin<Box<dyn Future<Output = Result<(), String>> + Send + 'a>>;
 }
 
@@ -335,3 +350,7 @@ impl YarrService {
 #[cfg(test)]
 #[path = "codemode_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "codemode_fleet_tests.rs"]
+mod fleet_tests;

--- a/src/app/codemode_dispatch.rs
+++ b/src/app/codemode_dispatch.rs
@@ -2,7 +2,7 @@
 
 use serde_json::{Map, Value};
 
-use super::CodeModeCallGuard;
+use super::{CodeModeCallGuard, FleetMapRequest};
 use crate::{
     actions::{YarrAction, execute_service_action},
     app::YarrService,
@@ -23,6 +23,19 @@ impl YarrService {
             return Err(
                 "a snippet cannot run another snippet (codemode.run is one level deep)".to_owned(),
             );
+        }
+        if id == "__fleet_map" {
+            let request: FleetMapRequest = serde_json::from_str(params_json)
+                .map_err(|error| format!("invalid fleet.map request: {error}"))?;
+            if let Some(guard) = guard.as_ref() {
+                guard.authorize_fleet(&request).await?;
+            }
+            let value = self
+                .fleet_map(&request)
+                .await
+                .map_err(|error| error.to_string())?;
+            return serde_json::to_string(&value)
+                .map_err(|error| format!("could not serialize fleet.map result: {error}"));
         }
         let params: Value = serde_json::from_str(params_json)
             .map_err(|error| format!("invalid params for `{id}`: {error}"))?;

--- a/src/app/codemode_fleet.rs
+++ b/src/app/codemode_fleet.rs
@@ -1,0 +1,161 @@
+//! Host-backed fleet fanout with bounded concurrency and isolated failures.
+
+use std::time::Instant;
+
+use anyhow::Result;
+use futures_util::{StreamExt, stream};
+use serde_json::{Value, json};
+
+use super::FleetMapRequest;
+use crate::actions::{YarrAction, execute_service_action};
+use crate::app::YarrService;
+use crate::config::ServiceKind;
+
+#[derive(Debug)]
+pub(crate) struct FleetAuthorization {
+    pub targets: Vec<String>,
+    pub action: String,
+    pub scope_action: &'static str,
+    pub destructive: bool,
+}
+
+impl YarrService {
+    pub(crate) fn fleet_targets(&self, request: &FleetMapRequest) -> Result<Vec<String>> {
+        let mut targets: Vec<String> = if request.kind == "*" {
+            if request.method != "service_status" {
+                anyhow::bail!("fleet kind `*` is supported only by fleet.status()");
+            }
+            self.services
+                .iter()
+                .map(|service| service.name.clone())
+                .collect()
+        } else {
+            let kind = request
+                .kind
+                .parse::<ServiceKind>()
+                .map_err(|_| anyhow::anyhow!("unknown fleet service kind `{}`", request.kind))?;
+            self.services
+                .iter()
+                .filter(|service| service.kind == kind)
+                .map(|service| service.name.clone())
+                .collect()
+        };
+        targets.sort();
+        Ok(targets)
+    }
+
+    pub(crate) fn fleet_authorization(
+        &self,
+        request: &FleetMapRequest,
+    ) -> Result<FleetAuthorization> {
+        let targets = self.fleet_targets(request)?;
+        let Some(first) = targets.first() else {
+            return Ok(FleetAuthorization {
+                targets,
+                action: "service_status".into(),
+                scope_action: "service_status",
+                destructive: false,
+            });
+        };
+        let action = self.fleet_action(first, request)?;
+        let destructive = match &action {
+            YarrAction::Op { service, op, .. } => {
+                self.kind_of(service)?
+                    .and_then(|kind| crate::openapi::classify_operation(kind, op))
+                    == Some(crate::openapi::OperationSafety::Destructive)
+            }
+            _ => crate::actions::action_is_destructive(action.name()),
+        };
+        Ok(FleetAuthorization {
+            targets,
+            action: request.method.clone(),
+            scope_action: action.name(),
+            destructive,
+        })
+    }
+
+    pub(crate) async fn fleet_map(&self, request: &FleetMapRequest) -> Result<Value> {
+        let targets = self.fleet_targets(request)?;
+        // Validate once before spawning. A bad kind/method is a script error;
+        // upstream failures after validation are isolated per instance.
+        for target in &targets {
+            self.fleet_action(target, request)?;
+        }
+        let timeout = self.fleet_instance_timeout;
+        let mut results = stream::iter(targets.into_iter().map(|name| {
+            let request = request.clone();
+            async move {
+                let started = Instant::now();
+                let result = match self.fleet_action(&name, &request) {
+                    Ok(action) => match tokio::time::timeout(
+                        timeout,
+                        Box::pin(execute_service_action(self, &action)),
+                    )
+                    .await
+                    {
+                        Ok(result) => result,
+                        Err(_) => Err(anyhow::anyhow!(
+                            "instance timed out after {} ms",
+                            timeout.as_millis()
+                        )),
+                    },
+                    Err(error) => Err(error),
+                };
+                match result {
+                    Ok(value) => json!({
+                        "name": name, "ok": true, "value": value,
+                        "truncated": false, "elapsed_ms": started.elapsed().as_millis(),
+                    }),
+                    Err(error) => json!({
+                        "name": name, "ok": false, "error": error.to_string(),
+                        "truncated": false, "elapsed_ms": started.elapsed().as_millis(),
+                    }),
+                }
+            }
+        }))
+        .buffer_unordered(self.fleet_max_concurrent)
+        .collect::<Vec<_>>()
+        .await;
+        results.sort_by(|left, right| left["name"].as_str().cmp(&right["name"].as_str()));
+        Ok(Value::Array(results))
+    }
+
+    fn fleet_action(&self, service_name: &str, request: &FleetMapRequest) -> Result<YarrAction> {
+        let kind = self
+            .kind_of(service_name)?
+            .ok_or_else(|| anyhow::anyhow!("unknown fleet service `{service_name}`"))?;
+        if request.method == "service_status" {
+            return Ok(YarrAction::ServiceStatus {
+                service: service_name.to_owned(),
+            });
+        }
+        if crate::openapi::is_generated(kind) {
+            if crate::openapi::classify_operation(kind, &request.method).is_none() {
+                anyhow::bail!(
+                    "operation `{}` is not available for kind {}",
+                    request.method,
+                    kind.as_str()
+                );
+            }
+            return Ok(YarrAction::Op {
+                service: service_name.to_owned(),
+                op: request.method.clone(),
+                args: request.args.clone(),
+            });
+        }
+        if !crate::codemode::catalog::service_action_names(kind).contains(&request.method.as_str())
+        {
+            anyhow::bail!(
+                "action `{}` is not available for kind {}",
+                request.method,
+                kind.as_str()
+            );
+        }
+        let mut params = request.args.as_object().cloned().ok_or_else(|| {
+            anyhow::anyhow!("fleet.map service method params must be a JSON object")
+        })?;
+        params.insert("action".into(), Value::String(request.method.clone()));
+        params.insert("service".into(), Value::String(service_name.to_owned()));
+        YarrAction::from_mcp_args(&Value::Object(params))
+    }
+}

--- a/src/app/codemode_fleet_tests.rs
+++ b/src/app/codemode_fleet_tests.rs
@@ -1,0 +1,151 @@
+use super::{FleetMapRequest, YarrService};
+use crate::config::{ServiceConfig, ServiceKind, YarrConfig};
+use crate::yarr::YarrClient;
+
+fn fleet_service() -> YarrService {
+    let config = YarrConfig {
+        services: vec![
+            ServiceConfig {
+                name: "plex_z".into(),
+                kind: ServiceKind::Plex,
+                base_url: "http://127.0.0.1:1".into(),
+                ..Default::default()
+            },
+            ServiceConfig {
+                name: "plex_a".into(),
+                kind: ServiceKind::Plex,
+                base_url: "http://127.0.0.1:2".into(),
+                ..Default::default()
+            },
+            ServiceConfig {
+                name: "sonarr".into(),
+                kind: ServiceKind::Sonarr,
+                base_url: "http://127.0.0.1:3".into(),
+                ..Default::default()
+            },
+        ],
+    };
+    YarrService::new(YarrClient::new(&config).unwrap(), config)
+        .with_fleet_limits(2, std::time::Duration::from_millis(100))
+}
+
+#[test]
+fn targets_are_filtered_and_sorted_by_configured_name() {
+    let request = FleetMapRequest {
+        kind: "plex".into(),
+        method: "service_status".into(),
+        args: serde_json::json!({}),
+    };
+    assert_eq!(
+        fleet_service().fleet_targets(&request).unwrap(),
+        vec!["plex_a", "plex_z"]
+    );
+}
+
+#[tokio::test]
+async fn individual_failures_never_reject_the_fleet_result() {
+    let request = FleetMapRequest {
+        kind: "plex".into(),
+        method: "service_status".into(),
+        args: serde_json::json!({}),
+    };
+    let result = fleet_service().fleet_map(&request).await.unwrap();
+    let rows = result.as_array().unwrap();
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0]["name"], "plex_a");
+    assert_eq!(rows[1]["name"], "plex_z");
+    assert!(rows.iter().all(|row| row["ok"] == false));
+    assert!(rows.iter().all(|row| row["error"].as_str().is_some()));
+}
+
+#[tokio::test]
+async fn twenty_way_fanout_isolates_one_dead_instance_under_ten_seconds() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let app = axum::Router::new().route(
+        "/identity",
+        axum::routing::get(|| async { axum::Json(serde_json::json!({"version": "test"})) }),
+    );
+    let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    let mut services = (0..19)
+        .map(|index| ServiceConfig {
+            name: format!("plex_{index:02}"),
+            kind: ServiceKind::Plex,
+            base_url: format!("http://{address}"),
+            token: Some("test".into()),
+            ..Default::default()
+        })
+        .collect::<Vec<_>>();
+    services.push(ServiceConfig {
+        name: "plex_dead".into(),
+        kind: ServiceKind::Plex,
+        base_url: "http://127.0.0.1:1".into(),
+        token: Some("test".into()),
+        ..Default::default()
+    });
+    let config = YarrConfig { services };
+    let service = YarrService::new(YarrClient::new(&config).unwrap(), config)
+        .with_fleet_limits(8, std::time::Duration::from_secs(2));
+    let request = FleetMapRequest {
+        kind: "plex".into(),
+        method: "service_status".into(),
+        args: serde_json::json!({}),
+    };
+
+    let started = std::time::Instant::now();
+    let result = service.fleet_map(&request).await.unwrap();
+    let rows = result.as_array().unwrap();
+    assert!(started.elapsed() < std::time::Duration::from_secs(10));
+    assert_eq!(rows.iter().filter(|row| row["ok"] == true).count(), 19);
+    assert_eq!(rows.iter().filter(|row| row["ok"] == false).count(), 1);
+    assert_eq!(rows.last().unwrap()["name"], "plex_dead");
+    server.abort();
+}
+
+#[tokio::test]
+async fn per_instance_timeout_is_reported_without_rejecting_map() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let app = axum::Router::new().route(
+        "/identity",
+        axum::routing::get(|| async {
+            tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+            axum::Json(serde_json::json!({"version": "slow"}))
+        }),
+    );
+    let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    let config = YarrConfig {
+        services: vec![ServiceConfig {
+            name: "plex_slow".into(),
+            kind: ServiceKind::Plex,
+            base_url: format!("http://{address}"),
+            token: Some("test".into()),
+            ..Default::default()
+        }],
+    };
+    let service = YarrService::new(YarrClient::new(&config).unwrap(), config)
+        .with_fleet_limits(1, std::time::Duration::from_millis(50));
+    let request = FleetMapRequest {
+        kind: "plex".into(),
+        method: "service_status".into(),
+        args: serde_json::json!({}),
+    };
+
+    let result = service.fleet_map(&request).await.unwrap();
+    assert_eq!(result[0]["ok"], false);
+    assert!(result[0]["error"].as_str().unwrap().contains("timed out"));
+    server.abort();
+}
+
+#[test]
+fn destructive_generated_fanout_exposes_all_targets_to_the_guard() {
+    let request = FleetMapRequest {
+        kind: "plex".into(),
+        method: "terminate_session".into(),
+        args: serde_json::json!({"sessionId": "x", "reason": "test"}),
+    };
+    let authorization = fleet_service().fleet_authorization(&request).unwrap();
+    assert!(authorization.destructive);
+    assert_eq!(authorization.action, "terminate_session");
+    assert_eq!(authorization.targets, vec!["plex_a", "plex_z"]);
+}

--- a/src/app/codemode_snippets.rs
+++ b/src/app/codemode_snippets.rs
@@ -11,6 +11,38 @@ use crate::{
     codemode::{self, CODEMODE_MAX_CODE_BYTES},
 };
 
+const BUILTIN_SNIPPETS: &[(&str, &str, &str)] = &[
+    (
+        "fleet_activity",
+        "Current playback sessions from every Plex instance.",
+        r#"async () => fleet.map("plex", s => s.list_sessions())"#,
+    ),
+    (
+        "fleet_health",
+        "Reachability and status across every configured instance.",
+        r#"async () => fleet.status()"#,
+    ),
+    (
+        "fleet_library_sizes",
+        "Library section inventories from every Plex instance.",
+        r#"async () => fleet.map("plex", s => s.get_sections())"#,
+    ),
+    (
+        "fleet_transcode_load",
+        "Playback sessions annotated with a per-instance transcode count.",
+        r#"async () => {
+            const rows = await fleet.map("plex", s => s.list_sessions());
+            const count = (value) => {
+                if (value == null || typeof value !== "object") return 0;
+                let total = Object.prototype.hasOwnProperty.call(value, "TranscodeSession") ? 1 : 0;
+                for (const child of Object.values(value)) total += count(child);
+                return total;
+            };
+            return rows.map(row => row.ok ? Object.assign({}, row, { transcodes: count(row.value) }) : row);
+        }"#,
+    ),
+];
+
 impl YarrService {
     fn snippet_store_root(&self) -> Result<PathBuf> {
         self.data_dir().map(Path::to_path_buf).ok_or_else(|| {
@@ -20,9 +52,29 @@ impl YarrService {
 
     pub async fn snippet_list(&self) -> Result<Value> {
         let result = (|| {
-            let dir = self.snippet_store_root()?;
-            let snippets =
-                codemode::store::list(&dir).map_err(|error| anyhow::anyhow!("{error}"))?;
+            let mut snippets = BUILTIN_SNIPPETS
+                .iter()
+                .map(|(name, description, code)| {
+                    json!({
+                        "name": name, "description": description,
+                        "bytes": code.len(), "built_in": true,
+                    })
+                })
+                .collect::<Vec<_>>();
+            if let Ok(dir) = self.snippet_store_root() {
+                snippets.extend(
+                    codemode::store::list(&dir)
+                        .map_err(|error| anyhow::anyhow!("{error}"))?
+                        .into_iter()
+                        .map(|meta| {
+                            json!({
+                                "name": meta.name, "description": meta.description,
+                                "bytes": meta.bytes, "built_in": false,
+                            })
+                        }),
+                );
+            }
+            snippets.sort_by(|left, right| left["name"].as_str().cmp(&right["name"].as_str()));
             Ok(json!({ "snippets": snippets }))
         })();
         record_snippet_operation("list", &result);
@@ -36,6 +88,7 @@ impl YarrService {
         description: Option<&str>,
     ) -> Result<Value> {
         let result = (|| {
+            reject_builtin_name(name)?;
             if code.trim().is_empty() {
                 anyhow::bail!("snippet_save requires a non-empty `code`");
             }
@@ -74,9 +127,14 @@ impl YarrService {
         input: &Value,
         guard: Option<std::sync::Arc<dyn CodeModeCallGuard>>,
     ) -> Result<Value> {
-        let dir = self.snippet_store_root()?;
-        let source =
-            codemode::store::load_source(&dir, name).map_err(|error| anyhow::anyhow!("{error}"))?;
+        let source = match builtin_source(name) {
+            Some(source) => source.to_owned(),
+            None => {
+                let dir = self.snippet_store_root()?;
+                codemode::store::load_source(&dir, name)
+                    .map_err(|error| anyhow::anyhow!("{error}"))?
+            }
+        };
         let input_json = serde_json::to_string(input).map_err(|error| {
             anyhow::anyhow!("snippet input is not serializable as JSON: {error}")
         })?;
@@ -85,6 +143,7 @@ impl YarrService {
 
     pub async fn snippet_delete(&self, name: &str) -> Result<Value> {
         let result = (|| {
+            reject_builtin_name(name)?;
             let dir = self.snippet_store_root()?;
             let existed =
                 codemode::store::delete(&dir, name).map_err(|error| anyhow::anyhow!("{error}"))?;
@@ -93,6 +152,20 @@ impl YarrService {
         record_snippet_operation("delete", &result);
         result
     }
+}
+
+fn builtin_source(name: &str) -> Option<&'static str> {
+    BUILTIN_SNIPPETS
+        .iter()
+        .find(|(builtin, _, _)| *builtin == name)
+        .map(|(_, _, source)| *source)
+}
+
+fn reject_builtin_name(name: &str) -> Result<()> {
+    if builtin_source(name).is_some() {
+        anyhow::bail!("snippet `{name}` is built in and cannot be overwritten or deleted");
+    }
+    Ok(())
 }
 
 fn record_snippet_operation(operation: &'static str, result: &Result<Value>) {

--- a/src/app/codemode_snippets_tests.rs
+++ b/src/app/codemode_snippets_tests.rs
@@ -32,9 +32,12 @@ async fn save_list_run_delete_roundtrip() {
         .snippet_save("greet", "async () => ({ hi: input.who })", Some("greets"))
         .await
         .unwrap();
-    assert_eq!(
-        service.snippet_list().await.unwrap()["snippets"][0]["name"],
-        "greet"
+    assert!(
+        service.snippet_list().await.unwrap()["snippets"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|snippet| snippet["name"] == "greet")
     );
     assert_eq!(
         service
@@ -51,7 +54,8 @@ async fn save_list_run_delete_roundtrip() {
         service.snippet_list().await.unwrap()["snippets"]
             .as_array()
             .unwrap()
-            .is_empty()
+            .iter()
+            .all(|snippet| snippet["built_in"] == true)
     );
 }
 
@@ -99,4 +103,26 @@ async fn snippets_are_disabled_without_data_dir() {
             .await
             .is_err()
     );
+}
+
+#[tokio::test]
+async fn canonical_fleet_snippets_are_available_without_a_data_dir() {
+    let service = loopback_state().service;
+    let listed = service.snippet_list().await.unwrap();
+    let names = listed["snippets"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|item| item["name"].as_str().unwrap())
+        .collect::<Vec<_>>();
+    assert!(names.contains(&"fleet_activity"));
+    assert!(names.contains(&"fleet_health"));
+    assert!(names.contains(&"fleet_library_sizes"));
+    assert!(names.contains(&"fleet_transcode_load"));
+    let health = service
+        .snippet_run("fleet_health", &serde_json::Value::Null)
+        .await
+        .unwrap();
+    assert!(health["result"].is_array());
+    assert!(service.snippet_delete("fleet_health").await.is_err());
 }

--- a/src/app/codemode_tests.rs
+++ b/src/app/codemode_tests.rs
@@ -35,6 +35,19 @@ fn multi_service(kinds: &[(&str, crate::config::ServiceKind)]) -> crate::app::Ya
 }
 
 #[tokio::test]
+async fn fleet_map_runs_through_the_host_dispatch_bridge() {
+    let output = loopback_state()
+        .service
+        .with_fleet_limits(8, std::time::Duration::from_millis(100))
+        .codemode(r#"async () => fleet.map("sonarr", s => s.service_status())"#)
+        .await
+        .unwrap();
+    assert_eq!(output["result"][0]["name"], "sonarr");
+    assert_eq!(output["result"][0]["ok"], false);
+    assert_eq!(output["result"][0]["truncated"], false);
+}
+
+#[tokio::test]
 async fn codemode_roundtrips_a_local_action() {
     let service = loopback_state().service;
     let code = r#"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -166,7 +166,10 @@ pub async fn run(cmd: Command, cfg: &YarrConfig) -> Result<()> {
             };
             crate::actions::execute_service_action(&service, &parsed).await?
         }
-        Command::Doctor { .. } | Command::Watch { .. } | Command::Setup(_) => {
+        Command::Doctor { .. }
+        | Command::Watch { .. }
+        | Command::Setup(_)
+        | Command::DiscoverPlex { .. } => {
             unreachable!("dispatched directly in main.rs::run_cli")
         }
     };

--- a/src/cli/command.rs
+++ b/src/cli/command.rs
@@ -17,6 +17,7 @@
 //! them as run modes before `parse_args` is called.
 
 use super::setup::SetupCommand;
+use std::path::PathBuf;
 
 // `Eq` is intentionally not derived: the `Curated` variant carries a
 // `serde_json::Value` (which is `PartialEq` but not `Eq`). `PartialEq` is all the
@@ -64,6 +65,14 @@ pub enum Command {
     },
     /// `yarr help` — structured JSON action reference.
     Help,
+    /// `yarr discover plex` — scaffold a reviewable Plex fleet from plex.tv.
+    DiscoverPlex {
+        owned_only: bool,
+        token_env: String,
+        output: PathBuf,
+        env_output: PathBuf,
+        diff: bool,
+    },
     /// `yarr codemode --code JS` / `--file PATH` — run a JS script that calls
     /// yarr actions. Infra, service-less; dispatched through the same
     /// `execute_service_action` path as the MCP `codemode` action.

--- a/src/cli/router.rs
+++ b/src/cli/router.rs
@@ -36,7 +36,7 @@ use infra::parse_infra_command;
 /// names (asserted in tests). `serve`/`mcp` are handled as run modes in
 /// `main.rs` but kept here to reserve the names.
 pub const INFRA_VERBS: &[&str] = &[
-    "help", "codemode", "snippet", "doctor", "watch", "setup", "serve", "mcp",
+    "help", "codemode", "snippet", "doctor", "watch", "setup", "discover", "serve", "mcp",
 ];
 
 /// True if `token` is an infra verb.

--- a/src/cli/router_infra.rs
+++ b/src/cli/router_infra.rs
@@ -12,6 +12,7 @@ pub(super) fn parse_infra_command(verb: &str, rest: &[String]) -> Result<Command
         }
         "codemode" => parse_codemode_command(rest),
         "snippet" => parse_snippet_command(rest),
+        "discover" => parse_discover_command(rest),
         "doctor" => Ok(Command::Doctor {
             json: parse_bool_flag(rest, "doctor", "--json")?,
         }),
@@ -39,6 +40,39 @@ pub(super) fn parse_infra_command(verb: &str, rest: &[String]) -> Result<Command
         )),
         other => Err(anyhow!("unknown infra command `{other}`")),
     }
+}
+
+fn parse_discover_command(rest: &[String]) -> Result<Command> {
+    let [kind, flags @ ..] = rest else {
+        return Err(anyhow!("discover requires `plex`"));
+    };
+    if kind != "plex" {
+        return Err(anyhow!("unknown discovery kind `{kind}` (expected `plex`)"));
+    }
+    let mut owned_only = true;
+    let mut token_env = "PLEX_ACCOUNT_TOKEN".to_owned();
+    let mut output = std::path::PathBuf::from("fleet.yaml");
+    let mut env_output = std::path::PathBuf::from("fleet.env");
+    let mut diff = false;
+    let mut iter = flags.iter();
+    while let Some(flag) = iter.next() {
+        match flag.as_str() {
+            "--owned-only" => owned_only = true,
+            "--include-shared" => owned_only = false,
+            "--token-env" => token_env = flag_value(&mut iter, "--token-env")?,
+            "--output" => output = flag_value(&mut iter, "--output")?.into(),
+            "--env-output" => env_output = flag_value(&mut iter, "--env-output")?.into(),
+            "--diff" => diff = true,
+            other => return Err(anyhow!("unknown discover plex flag `{other}`")),
+        }
+    }
+    Ok(Command::DiscoverPlex {
+        owned_only,
+        token_env,
+        output,
+        env_output,
+        diff,
+    })
 }
 
 fn parse_codemode_command(rest: &[String]) -> Result<Command> {

--- a/src/cli/router_infra_tests.rs
+++ b/src/cli/router_infra_tests.rs
@@ -35,3 +35,25 @@ fn snippet_infra_requires_a_name_and_valid_json_input() {
             if name == "demo" && input["ok"] == serde_json::json!(true)
     ));
 }
+
+#[test]
+fn plex_discovery_is_owned_only_and_reviewable_by_default() {
+    assert_eq!(
+        parse_infra_command("discover", &args(&["plex"])).unwrap(),
+        Command::DiscoverPlex {
+            owned_only: true,
+            token_env: "PLEX_ACCOUNT_TOKEN".into(),
+            output: "fleet.yaml".into(),
+            env_output: "fleet.env".into(),
+            diff: false,
+        }
+    );
+    assert!(matches!(
+        parse_infra_command("discover", &args(&["plex", "--include-shared", "--diff"])).unwrap(),
+        Command::DiscoverPlex {
+            owned_only: false,
+            diff: true,
+            ..
+        }
+    ));
+}

--- a/src/cli/usage.rs
+++ b/src/cli/usage.rs
@@ -33,6 +33,7 @@ fn build_usage() -> String {
     out.push_str("  yarr help                      Show JSON action reference\n");
     out.push_str("  yarr codemode --code JS|--file P  Run a JS script that calls yarr actions\n");
     out.push_str("  yarr snippet list|save|run|delete  Manage saved Code Mode snippets\n");
+    out.push_str("  yarr discover plex [--owned-only|--include-shared] [--diff]  Scaffold or audit a Plex fleet\n");
     out.push_str("  yarr doctor [--json]           Run environment pre-flight checks\n");
     out.push_str(
         "  yarr watch [--url URL] [--interval N] [--once]  Poll server health; --once exits non-zero unless healthy\n",

--- a/src/codemode.rs
+++ b/src/codemode.rs
@@ -47,6 +47,10 @@ pub use semantic::{SemanticCache, semantic_scores, tei_url};
 pub const CODEMODE_TIMEOUT: Duration = Duration::from_secs(120);
 /// Maximum number of QuickJS runtimes admitted concurrently by one service.
 pub const CODEMODE_MAX_CONCURRENT: usize = 4;
+/// Maximum upstream calls concurrently dispatched by one fleet operation.
+pub const FLEET_MAX_CONCURRENT: usize = 8;
+/// Deadline applied independently to each upstream in a fleet operation.
+pub const FLEET_INSTANCE_TIMEOUT: Duration = Duration::from_secs(8);
 /// Maximum time a Code Mode request waits for an execution slot.
 pub const CODEMODE_QUEUE_TIMEOUT: Duration = Duration::from_millis(500);
 /// QuickJS heap cap (matches lab's 64 MiB).

--- a/src/codemode.rs
+++ b/src/codemode.rs
@@ -41,8 +41,10 @@ pub use engine::{ArtifactWriter, EmbedCaller, EngineLimits, EngineOutcome, ToolC
 pub use proxy::build_preamble;
 pub use semantic::{SemanticCache, semantic_scores, tei_url};
 
-/// Wall-clock budget for a single Code Mode execution (matches lab's default).
-pub const CODEMODE_TIMEOUT: Duration = Duration::from_secs(30);
+/// Wall-clock budget for a single Code Mode execution. Fleet fanout may wait on
+/// several bounded waves of upstream requests, so this is deliberately longer
+/// than the per-request HTTP timeout.
+pub const CODEMODE_TIMEOUT: Duration = Duration::from_secs(120);
 /// Maximum number of QuickJS runtimes admitted concurrently by one service.
 pub const CODEMODE_MAX_CONCURRENT: usize = 4;
 /// Maximum time a Code Mode request waits for an execution slot.

--- a/src/codemode/catalog.rs
+++ b/src/codemode/catalog.rs
@@ -204,7 +204,7 @@ pub fn build_catalog(services: &[(String, ServiceKind)]) -> Vec<CatalogEntry> {
             // The per-service `service_status` callable is still synthesized.
             out.push(service_entry(name, "service_status"));
             for op in crate::openapi::operations_for_kind(*kind) {
-                out.push(operation_entry(name, op));
+                out.push(operation_entry(name, *kind, op));
             }
         } else {
             for action in service_action_names(*kind) {
@@ -221,7 +221,11 @@ pub fn build_catalog(services: &[(String, ServiceKind)]) -> Vec<CatalogEntry> {
 /// `write`, and DELETE ops `destructive` — metadata only, they dispatch
 /// immediately like any other write (see `docs/API.md`). The OpenAPI `tag` is
 /// surfaced as the capability for grouping.
-fn operation_entry(service: &str, op: &crate::openapi::OperationSpec) -> CatalogEntry {
+fn operation_entry(
+    service: &str,
+    kind: ServiceKind,
+    op: &crate::openapi::OperationSpec,
+) -> CatalogEntry {
     let mut required: Vec<&'static str> = op.path_params.to_vec();
     if op.has_body {
         required.push("body");
@@ -232,16 +236,17 @@ fn operation_entry(service: &str, op: &crate::openapi::OperationSpec) -> Catalog
     } else {
         op.summary
     };
+    let safety = crate::openapi::operation_safety(kind, op);
     CatalogEntry::Operation {
         path: format!("{service}.{}", op.name),
         service: service.to_string(),
         method: op.name,
-        scope: if op.method.is_read() {
+        scope: if safety == crate::openapi::OperationSafety::Read {
             CatalogScope::Read
         } else {
             CatalogScope::Write
         },
-        destructive: op.method.is_delete(),
+        destructive: safety == crate::openapi::OperationSafety::Destructive,
         capability: op.tag.to_string(),
         required_params: required,
         description,

--- a/src/codemode/catalog_tests.rs
+++ b/src/codemode/catalog_tests.rs
@@ -50,6 +50,14 @@ fn each_entry_carries_its_service() {
         .find(|e| e.path() == "sonarr.delete_series_by_id")
         .unwrap();
     assert!(del.destructive());
+    let terminate = cat
+        .iter()
+        .find(|e| e.path() == "plex.terminate_session")
+        .unwrap();
+    assert!(
+        terminate.destructive(),
+        "non-DELETE high-impact operations must advertise elicitation"
+    );
 }
 
 #[test]

--- a/src/codemode/engine_tests.rs
+++ b/src/codemode/engine_tests.rs
@@ -73,6 +73,35 @@ fn calltool_round_trips_through_on_call() {
 }
 
 #[test]
+fn fleet_inventory_and_map_capture_are_available_in_javascript() {
+    let services = vec![
+        ("plex_b".to_owned(), crate::config::ServiceKind::Plex),
+        ("sonarr".to_owned(), crate::config::ServiceKind::Sonarr),
+        ("plex_a".to_owned(), crate::config::ServiceKind::Plex),
+    ];
+    let out = run(
+        r#"async () => ({
+            names: fleet.of("plex"),
+            all: fleet.all(),
+            mapped: await fleet.map("plex", s => s.get_sessions({ limit: 2 }))
+        })"#,
+        &build_preamble(&services),
+        &limits(Duration::from_secs(5)),
+        echo_caller(),
+        no_write(),
+        no_embed(),
+        None,
+    )
+    .unwrap();
+    assert_eq!(out.result["names"], serde_json::json!(["plex_a", "plex_b"]));
+    assert_eq!(out.result["all"][0]["name"], "plex_a");
+    assert_eq!(out.result["mapped"]["echo"], "__fleet_map");
+    assert_eq!(out.result["mapped"]["params"]["kind"], "plex");
+    assert_eq!(out.result["mapped"]["params"]["method"], "get_sessions");
+    assert_eq!(out.result["mapped"]["params"]["args"]["limit"], 2);
+}
+
+#[test]
 fn console_output_is_captured() {
     let code = r#"async () => { console.log("hello", 1); console.error("boom"); return "ok"; }"#;
     let out = run(

--- a/src/codemode/proxy.rs
+++ b/src/codemode/proxy.rs
@@ -100,20 +100,6 @@ pub fn build_preamble(services: &[(String, ServiceKind)]) -> String {
     out
 }
 
-/// Global names the runtime/discovery layer owns — a configured service whose name
-/// collides with one of these does NOT get a top-level binding (it would clobber
-/// the runtime). Such a service is still fully reachable via `callTool` and, for
-/// raw HTTP, `api.<name>`.
-const RESERVED_GLOBALS: &[&str] = &[
-    "api",
-    "callTool",
-    "codemode",
-    "console",
-    "globalThis",
-    "input",
-    "writeArtifact",
-];
-
 /// Render the per-service callable namespaces. For each configured service, emit a
 /// `globalThis.<name>` object whose methods are the actions valid for that kind
 /// (`service_status` + the kind's curated commands). Each method bakes the service
@@ -122,9 +108,12 @@ const RESERVED_GLOBALS: &[&str] = &[
 fn render_service_namespaces(services: &[(String, ServiceKind)]) -> String {
     let mut out = String::new();
     for (name, kind) in services {
-        if RESERVED_GLOBALS.contains(&name.as_str()) {
-            continue;
-        }
+        assert!(
+            !crate::config::services::CODEMODE_RESERVED_GLOBALS
+                .iter()
+                .any(|reserved| reserved.eq_ignore_ascii_case(name)),
+            "configured service `{name}` collides with a reserved Code Mode global; configuration validation must run before preamble generation"
+        );
         // `{name:?}` emits a quoted, escaped JS string literal. `service` is merged
         // LAST so a script can never override the baked-in binding.
         out.push_str(&format!("globalThis[{name:?}] = {{\n"));

--- a/src/codemode/proxy.rs
+++ b/src/codemode/proxy.rs
@@ -86,6 +86,7 @@ pub fn build_preamble(services: &[(String, ServiceKind)]) -> String {
     out.push_str(&render_service_namespaces(services));
     let service_names: Vec<String> = services.iter().map(|(name, _)| name.clone()).collect();
     out.push_str(&render_api_namespace(&service_names));
+    out.push_str(&render_fleet_namespace(services));
     // Discovery: inject the per-service ACTION catalog + the per-service TYPE
     // catalog (response-shape TS interfaces), then the pure-JS search/describe
     // helpers. Types are surfaced ON DEMAND — only what the agent describes is
@@ -98,6 +99,70 @@ pub fn build_preamble(services: &[(String, ServiceKind)]) -> String {
     out.push_str(";\n");
     out.push_str(DISCOVERY_JS);
     out
+}
+
+fn render_fleet_namespace(services: &[(String, ServiceKind)]) -> String {
+    let mut inventory = services
+        .iter()
+        .map(|(name, kind)| serde_json::json!({"name": name, "kind": kind.as_str()}))
+        .collect::<Vec<_>>();
+    inventory.sort_by(|left, right| left["name"].as_str().cmp(&right["name"].as_str()));
+    let inventory = serde_json::to_string(&inventory).unwrap_or_else(|_| "[]".to_owned());
+    format!(
+        r#"
+const __yarr_fleet_services = Object.freeze({inventory});
+globalThis.fleet = Object.freeze({{
+    all: () => __yarr_fleet_services.map((service) => Object.assign({{}}, service)),
+    of: (kind) => {{
+        if (typeof kind !== "string" || kind.trim() === "") {{
+            throw new TypeError("fleet.of(kind): kind must be a non-empty string");
+        }}
+        return __yarr_fleet_services
+            .filter((service) => service.kind === kind.trim().toLowerCase())
+            .map((service) => service.name);
+    }},
+    map: async (kind, mapper) => {{
+        if (typeof kind !== "string" || kind.trim() === "") {{
+            throw new TypeError("fleet.map(kind, mapper): kind must be a non-empty string");
+        }}
+        if (typeof mapper !== "function") {{
+            throw new TypeError("fleet.map(kind, mapper): mapper must be a function");
+        }}
+        let captured = null;
+        const marker = Object.freeze({{ __yarrFleetCapture: true }});
+        const recorder = new Proxy({{}}, {{
+            get: (_target, property) => (...callArgs) => {{
+                if (typeof property !== "string" || property.trim() === "") {{
+                    throw new TypeError("fleet.map mapper selected an invalid method");
+                }}
+                if (captured !== null) {{
+                    throw new Error("fleet.map mapper must call exactly one service method");
+                }}
+                if (callArgs.length > 1) {{
+                    throw new TypeError("fleet.map service methods accept at most one params object");
+                }}
+                const args = callArgs.length === 0 || callArgs[0] == null ? {{}} : callArgs[0];
+                if (typeof args !== "object" || Array.isArray(args)) {{
+                    throw new TypeError("fleet.map service method params must be an object");
+                }}
+                captured = {{ method: property, args: args }};
+                return marker;
+            }},
+        }});
+        const mapped = await mapper(recorder);
+        if (captured === null || mapped !== marker) {{
+            throw new Error("fleet.map mapper must return exactly one service method call");
+        }}
+        return callTool("__fleet_map", {{
+            kind: kind.trim().toLowerCase(),
+            method: captured.method,
+            args: captured.args,
+        }});
+    }},
+    status: () => callTool("__fleet_map", {{ kind: "*", method: "service_status", args: {{}} }}),
+}});
+"#
+    )
 }
 
 /// Render the per-service callable namespaces. For each configured service, emit a

--- a/src/codemode/proxy_tests.rs
+++ b/src/codemode/proxy_tests.rs
@@ -99,3 +99,11 @@ fn snippet_verbs_are_not_callable_namespaces() {
     // And `input` is wired (defaults to null for non-snippet runs).
     assert!(pre.contains("globalThis.input ="));
 }
+
+#[test]
+fn fleet_global_contains_stable_inventory_and_host_backed_map() {
+    let pre = build_preamble(&services());
+    assert!(pre.contains("globalThis.fleet ="));
+    assert!(pre.contains("__yarr_fleet_services"));
+    assert!(pre.contains(r#"callTool("__fleet_map""#));
+}

--- a/src/codemode/proxy_tests.rs
+++ b/src/codemode/proxy_tests.rs
@@ -46,12 +46,11 @@ fn no_flat_tools_namespace() {
 }
 
 #[test]
-fn reserved_global_name_is_not_clobbered() {
-    // A service literally named `api` must not get a top-level binding that would
-    // overwrite the raw-API client; the client itself is still present.
-    let pre = build_preamble(&[("api".to_string(), ServiceKind::Sonarr)]);
-    assert!(!pre.contains(r#"globalThis["api"] = {"#));
-    assert!(pre.contains("globalThis.api = {};"));
+#[should_panic(expected = "collides with a reserved Code Mode global")]
+fn reserved_global_cannot_reach_preamble_generation() {
+    // Startup validation is authoritative. This assertion protects direct
+    // programmatic construction from silently hiding the configured service.
+    let _ = build_preamble(&[("api".to_string(), ServiceKind::Sonarr)]);
 }
 
 #[test]

--- a/src/codemode/truncate.rs
+++ b/src/codemode/truncate.rs
@@ -61,6 +61,11 @@ pub fn fit_response(response: &mut Value) {
         return;
     }
 
+    summarize_fleet_result(response);
+    if within_budget(response) {
+        return;
+    }
+
     // Pull logs out so we can measure the rest of the envelope on its own.
     let logs = take_array(response, "logs");
 
@@ -90,6 +95,70 @@ pub fn fit_response(response: &mut Value) {
             "[logs truncated to fit response budget — {dropped} line(s) dropped]"
         ))
     });
+}
+
+/// Preserve the shape and completeness signal of a `fleet.map` result. Each
+/// member receives an explicit `truncated` flag; values that cannot fit their
+/// fair share of the response budget are replaced with a compact summary.
+fn summarize_fleet_result(response: &mut Value) {
+    let Some(results) = response.get_mut("result").and_then(Value::as_array_mut) else {
+        return;
+    };
+    if results.is_empty()
+        || !results.iter().all(|item| {
+            item.get("name").and_then(Value::as_str).is_some()
+                && item.get("ok").and_then(Value::as_bool).is_some()
+        })
+    {
+        return;
+    }
+
+    // Leave room for the envelope, calls, logs, and JSON punctuation. This is a
+    // byte budget (like the final transport cap), not an estimated token count.
+    let per_instance_budget = RESPONSE_BUDGET
+        .saturating_sub(2 * 1024)
+        .checked_div(results.len())
+        .unwrap_or(0)
+        .max(256);
+
+    for item in results {
+        let original_len = serialized_len(item);
+        if original_len <= per_instance_budget {
+            if let Some(object) = item.as_object_mut() {
+                object.insert("truncated".into(), Value::Bool(false));
+            }
+            continue;
+        }
+
+        let Some(object) = item.as_object_mut() else {
+            continue;
+        };
+        let value = object.remove("value").unwrap_or(Value::Null);
+        let value_len = serialized_len(&value);
+        let value_type = match &value {
+            Value::Null => "null",
+            Value::Bool(_) => "boolean",
+            Value::Number(_) => "number",
+            Value::String(_) => "string",
+            Value::Array(_) => "array",
+            Value::Object(_) => "object",
+        };
+        let item_count = match &value {
+            Value::Array(items) => Some(items.len()),
+            Value::Object(fields) => Some(fields.len()),
+            _ => None,
+        };
+        let mut summary = serde_json::Map::from_iter([
+            ("type".into(), Value::String(value_type.into())),
+            ("original_bytes".into(), json!(value_len)),
+        ]);
+        if let Some(count) = item_count {
+            summary.insert("item_count".into(), json!(count));
+        }
+        object.insert("value".into(), Value::Null);
+        object.insert("truncated".into(), Value::Bool(true));
+        object.insert("summary".into(), Value::Object(summary));
+    }
 }
 
 /// True iff the compact serialization of `value` is within budget.

--- a/src/codemode/truncate_tests.rs
+++ b/src/codemode/truncate_tests.rs
@@ -126,3 +126,46 @@ fn utf8_prefix_never_splits_a_codepoint() {
         assert!(std::str::from_utf8(p.as_bytes()).is_ok());
     }
 }
+
+#[test]
+fn oversized_fleet_values_are_marked_per_instance() {
+    let huge = "x".repeat(RESPONSE_BUDGET);
+    let mut env = envelope(
+        json!([
+            {"name": "plex_01", "ok": true, "value": {"sessions": [huge]}},
+            {"name": "plex_02", "ok": true, "value": {"sessions": ["small"]}},
+        ]),
+        vec![],
+    );
+
+    fit_response(&mut env);
+
+    let results = env["result"]
+        .as_array()
+        .expect("fleet result remains an array");
+    assert_eq!(results[0]["name"], "plex_01");
+    assert_eq!(results[0]["truncated"], true);
+    assert_eq!(results[0]["value"], Value::Null);
+    assert_eq!(results[0]["summary"]["type"], "object");
+    assert!(results[0]["summary"]["original_bytes"].as_u64().unwrap() > 0);
+    assert_eq!(results[1]["name"], "plex_02");
+    assert_eq!(results[1]["truncated"], false);
+    assert_eq!(results[1]["value"]["sessions"][0], "small");
+    assert!(serialized_len(&env) <= RESPONSE_BUDGET);
+}
+
+#[test]
+fn fleet_array_summary_reports_item_count() {
+    let sessions: Vec<Value> = (0..2_000)
+        .map(|i| json!({"session": i, "title": "x".repeat(32)}))
+        .collect();
+    let mut env = envelope(
+        json!([{"name": "plex_den", "ok": true, "value": sessions}]),
+        vec![],
+    );
+
+    fit_response(&mut env);
+
+    assert_eq!(env["result"][0]["truncated"], true);
+    assert_eq!(env["result"][0]["summary"]["item_count"], 2_000);
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -30,7 +30,7 @@ pub(crate) use environment::env_value;
 pub(crate) use environment::install_plugin_env_overlay;
 use environment::{EnvOverlayGuard, load_env_overlay};
 use mcp::{env_bool, env_list, env_opt_str, env_parse, env_str};
-use services::{SERVICE_HOME_DIRNAME, load_services_from_env};
+use services::{SERVICE_HOME_DIRNAME, apply_readonly_services, load_services_from_env};
 
 /// Top-level config (maps to `config.toml` sections).
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -109,6 +109,10 @@ impl Config {
             "YARR_MCP_CODEMODE_TIMEOUT_SECS",
             &mut config.mcp.codemode_timeout_secs,
         )?;
+        env_parse(
+            "YARR_MCP_DESTRUCTIVE_FANOUT_MAX",
+            &mut config.mcp.destructive_fanout_max,
+        )?;
         env_opt_str("YARR_MCP_PUBLIC_URL", &mut config.mcp.auth.public_url);
         env_str(
             "YARR_MCP_AUTH_ADMIN_EMAIL",
@@ -186,6 +190,9 @@ impl Config {
         }
 
         load_services_from_env(&mut config.yarr)?;
+        if let Some(readonly) = env_value("YARR_FLEET_READONLY") {
+            apply_readonly_services(&mut config.yarr.services, &readonly)?;
+        }
 
         if config.mcp.static_token_scopes.is_empty() {
             anyhow::bail!("YARR_MCP_STATIC_TOKEN_SCOPES must contain at least one scope");
@@ -205,6 +212,9 @@ impl Config {
         }
         if config.mcp.codemode_queue_timeout_ms == 0 || config.mcp.codemode_timeout_secs == 0 {
             anyhow::bail!("Code Mode queue and execution timeouts must be greater than zero");
+        }
+        if config.mcp.destructive_fanout_max == 0 {
+            anyhow::bail!("YARR_MCP_DESTRUCTIVE_FANOUT_MAX must be at least 1");
         }
 
         Ok(config)

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,6 +15,7 @@ use serde::{Deserialize, Serialize};
 
 pub mod auth;
 mod environment;
+mod fleet_file;
 pub mod mcp;
 pub mod services;
 
@@ -34,6 +35,14 @@ use services::{
     SERVICE_HOME_DIRNAME, apply_readonly_services, load_services_from_env,
     validate_service_identities,
 };
+
+#[cfg(test)]
+pub(crate) use fleet_file::FleetFormat;
+pub(crate) use fleet_file::{load_fleet_file, merge_service_sources};
+
+#[cfg(test)]
+#[path = "config/fleet_file_tests.rs"]
+mod fleet_file_tests;
 
 /// Top-level config (maps to `config.toml` sections).
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -86,6 +95,12 @@ impl Config {
         }
 
         let _overlay = EnvOverlayGuard::install(load_env_overlay()?);
+
+        if let Some(path) = env_value("YARR_FLEET_FILE").filter(|path| !path.is_empty()) {
+            let fleet_services = load_fleet_file(std::path::Path::new(&path))?;
+            config.yarr.services =
+                merge_service_sources(fleet_services, std::mem::take(&mut config.yarr.services))?;
+        }
 
         // Env overrides — YARR_MCP_* for server config.
         env_str("YARR_MCP_HOST", &mut config.mcp.host);

--- a/src/config.rs
+++ b/src/config.rs
@@ -30,7 +30,10 @@ pub(crate) use environment::env_value;
 pub(crate) use environment::install_plugin_env_overlay;
 use environment::{EnvOverlayGuard, load_env_overlay};
 use mcp::{env_bool, env_list, env_opt_str, env_parse, env_str};
-use services::{SERVICE_HOME_DIRNAME, apply_readonly_services, load_services_from_env};
+use services::{
+    SERVICE_HOME_DIRNAME, apply_readonly_services, load_services_from_env,
+    validate_service_identities,
+};
 
 /// Top-level config (maps to `config.toml` sections).
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -193,6 +196,7 @@ impl Config {
         if let Some(readonly) = env_value("YARR_FLEET_READONLY") {
             apply_readonly_services(&mut config.yarr.services, &readonly)?;
         }
+        validate_service_identities(&config.yarr.services)?;
 
         if config.mcp.static_token_scopes.is_empty() {
             anyhow::bail!("YARR_MCP_STATIC_TOKEN_SCOPES must contain at least one scope");

--- a/src/config.rs
+++ b/src/config.rs
@@ -131,6 +131,14 @@ impl Config {
             "YARR_MCP_DESTRUCTIVE_FANOUT_MAX",
             &mut config.mcp.destructive_fanout_max,
         )?;
+        env_parse(
+            "YARR_FLEET_MAX_CONCURRENT",
+            &mut config.mcp.fleet_max_concurrent,
+        )?;
+        env_parse(
+            "YARR_FLEET_INSTANCE_TIMEOUT_SECS",
+            &mut config.mcp.fleet_instance_timeout_secs,
+        )?;
         env_opt_str("YARR_MCP_PUBLIC_URL", &mut config.mcp.auth.public_url);
         env_str(
             "YARR_MCP_AUTH_ADMIN_EMAIL",
@@ -234,6 +242,12 @@ impl Config {
         }
         if config.mcp.destructive_fanout_max == 0 {
             anyhow::bail!("YARR_MCP_DESTRUCTIVE_FANOUT_MAX must be at least 1");
+        }
+        if config.mcp.fleet_max_concurrent == 0 {
+            anyhow::bail!("YARR_FLEET_MAX_CONCURRENT must be at least 1");
+        }
+        if config.mcp.fleet_instance_timeout_secs == 0 {
+            anyhow::bail!("YARR_FLEET_INSTANCE_TIMEOUT_SECS must be at least 1");
         }
 
         Ok(config)

--- a/src/config/fleet_file.rs
+++ b/src/config/fleet_file.rs
@@ -1,0 +1,190 @@
+//! Additive fleet-file parsing and environment-secret resolution.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use serde::Deserialize;
+
+use super::services::{ServiceConfig, ServiceKind, validate_service_identities};
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum FleetFormat {
+    Yaml,
+    Toml,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct FleetDocument {
+    services: Vec<serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct FleetServiceEntry {
+    name: String,
+    kind: ServiceKind,
+    url: String,
+    token_env: Option<String>,
+    api_key_env: Option<String>,
+    username_env: Option<String>,
+    password_env: Option<String>,
+    client_identifier: Option<String>,
+    plex: Option<String>,
+    #[serde(default)]
+    relay_only: bool,
+}
+
+pub(crate) fn load_fleet_file(path: &Path) -> Result<Vec<ServiceConfig>> {
+    let contents = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read fleet file {}", path.display()))?;
+    let format = match path
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .map(str::to_ascii_lowercase)
+        .as_deref()
+    {
+        Some("yaml" | "yml") => FleetFormat::Yaml,
+        Some("toml") => FleetFormat::Toml,
+        _ => anyhow::bail!(
+            "fleet file {} must have a .yaml, .yml, or .toml extension",
+            path.display()
+        ),
+    };
+    parse_and_resolve(&contents, format, path)
+}
+
+pub(crate) fn parse_and_resolve(
+    contents: &str,
+    format: FleetFormat,
+    source: &Path,
+) -> Result<Vec<ServiceConfig>> {
+    let document = parse_document(contents, format)
+        .with_context(|| format!("failed to parse fleet file {}", source.display()))?;
+    let mut services = Vec::with_capacity(document.services.len());
+    for (index, raw_entry) in document.services.into_iter().enumerate() {
+        let name = raw_entry
+            .get("name")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("<unnamed>")
+            .to_owned();
+        let line = entry_line(contents, &name, index);
+        let entry: FleetServiceEntry = serde_json::from_value(raw_entry).map_err(|error| {
+            anyhow::anyhow!(
+                "{}:{line}: invalid fleet service {name:?}: {error}; credentials must use token_env, api_key_env, username_env, or password_env (inline secrets are forbidden)",
+                source.display()
+            )
+        })?;
+        services.push(entry.resolve(source, line)?);
+    }
+    services.sort_by(|left, right| left.name.cmp(&right.name));
+    validate_service_identities(&services)
+        .with_context(|| format!("invalid fleet file {}", source.display()))?;
+    Ok(services)
+}
+
+fn parse_document(contents: &str, format: FleetFormat) -> Result<FleetDocument> {
+    match format {
+        FleetFormat::Yaml => serde_yaml::from_str(contents).map_err(Into::into),
+        FleetFormat::Toml => {
+            let value: toml::Value = toml::from_str(contents)?;
+            serde_json::from_value(serde_json::to_value(value)?).map_err(Into::into)
+        }
+    }
+}
+
+impl FleetServiceEntry {
+    fn resolve(self, source: &Path, line: usize) -> Result<ServiceConfig> {
+        let name = self.name.trim().to_ascii_lowercase();
+        if name.is_empty() {
+            anyhow::bail!(
+                "{}:{line}: fleet service name must not be empty",
+                source.display()
+            );
+        }
+        let base_url = self.url.trim().to_owned();
+        if base_url.is_empty() {
+            anyhow::bail!(
+                "{}:{line}: fleet service {name:?} url must not be empty",
+                source.display()
+            );
+        }
+        Ok(ServiceConfig {
+            name,
+            kind: self.kind,
+            base_url,
+            api_key: resolve_env(&self.api_key_env, "api_key_env", source, line)?,
+            username: resolve_env(&self.username_env, "username_env", source, line)?,
+            password: resolve_env(&self.password_env, "password_env", source, line)?,
+            token: resolve_env(&self.token_env, "token_env", source, line)?,
+            read_only: false,
+            client_identifier: nonempty(self.client_identifier),
+            plex: nonempty(self.plex),
+            relay_only: self.relay_only,
+        })
+    }
+}
+
+fn resolve_env(
+    reference: &Option<String>,
+    field: &str,
+    source: &Path,
+    line: usize,
+) -> Result<Option<String>> {
+    let Some(variable) = reference.as_deref().map(str::trim) else {
+        return Ok(None);
+    };
+    if !valid_env_name(variable) {
+        anyhow::bail!(
+            "{}:{line}: {field} value {variable:?} is not a valid environment variable name",
+            source.display()
+        );
+    }
+    let value = super::env_value(variable)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "{}:{line}: {field} references unset or empty environment variable {variable}",
+                source.display()
+            )
+        })?;
+    Ok(Some(value))
+}
+
+fn valid_env_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    chars
+        .next()
+        .is_some_and(|first| first == '_' || first.is_ascii_alphabetic())
+        && chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+}
+
+fn nonempty(value: Option<String>) -> Option<String> {
+    value
+        .map(|value| value.trim().to_owned())
+        .filter(|value| !value.is_empty())
+}
+
+fn entry_line(contents: &str, name: &str, _index: usize) -> usize {
+    contents
+        .lines()
+        .enumerate()
+        .find(|(_, line)| line.contains("name") && line.contains(name))
+        .map_or(1, |(line, _)| line + 1)
+}
+
+pub(crate) fn merge_service_sources(
+    lower_precedence: Vec<ServiceConfig>,
+    higher_precedence: Vec<ServiceConfig>,
+) -> Result<Vec<ServiceConfig>> {
+    validate_service_identities(&lower_precedence)?;
+    validate_service_identities(&higher_precedence)?;
+    let mut merged = BTreeMap::<String, ServiceConfig>::new();
+    for service in lower_precedence.into_iter().chain(higher_precedence) {
+        merged.insert(service.name.to_ascii_lowercase(), service);
+    }
+    let services = merged.into_values().collect::<Vec<_>>();
+    validate_service_identities(&services)?;
+    Ok(services)
+}

--- a/src/config/fleet_file.rs
+++ b/src/config/fleet_file.rs
@@ -181,7 +181,17 @@ pub(crate) fn merge_service_sources(
     validate_service_identities(&lower_precedence)?;
     validate_service_identities(&higher_precedence)?;
     let mut merged = BTreeMap::<String, ServiceConfig>::new();
-    for service in lower_precedence.into_iter().chain(higher_precedence) {
+    for service in lower_precedence {
+        merged.insert(service.name.to_ascii_lowercase(), service);
+    }
+    for mut service in higher_precedence {
+        if let Some(lower) = merged.get(&service.name.to_ascii_lowercase()) {
+            service.client_identifier = service
+                .client_identifier
+                .or_else(|| lower.client_identifier.clone());
+            service.plex = service.plex.or_else(|| lower.plex.clone());
+            service.relay_only |= lower.relay_only;
+        }
         merged.insert(service.name.to_ascii_lowercase(), service);
     }
     let services = merged.into_values().collect::<Vec<_>>();

--- a/src/config/fleet_file_tests.rs
+++ b/src/config/fleet_file_tests.rs
@@ -95,6 +95,29 @@ fn environment_source_overrides_same_name_and_preserves_union() {
 }
 
 #[test]
+fn higher_precedence_credentials_preserve_discovery_pairing_metadata() {
+    let lower = ServiceConfig {
+        name: "tautulli_den".into(),
+        kind: ServiceKind::Tautulli,
+        base_url: "http://file".into(),
+        plex: Some("plex_den".into()),
+        ..ServiceConfig::default()
+    };
+    let higher = ServiceConfig {
+        name: "tautulli_den".into(),
+        kind: ServiceKind::Tautulli,
+        base_url: "http://environment".into(),
+        api_key: Some("secret".into()),
+        ..ServiceConfig::default()
+    };
+
+    let merged = merge_service_sources(vec![lower], vec![higher]).unwrap();
+    assert_eq!(merged[0].base_url, "http://environment");
+    assert_eq!(merged[0].api_key.as_deref(), Some("secret"));
+    assert_eq!(merged[0].plex.as_deref(), Some("plex_den"));
+}
+
+#[test]
 fn twenty_four_instance_yaml_loads_in_stable_name_order() {
     let mut yaml = String::from("services:\n");
     for index in (0..24).rev() {

--- a/src/config/fleet_file_tests.rs
+++ b/src/config/fleet_file_tests.rs
@@ -1,0 +1,113 @@
+use super::*;
+
+#[test]
+fn yaml_resolves_credential_environment_indirection() {
+    let mut env = crate::testing::TestEnv::new();
+    env.set("PLEX_DEN_TOKEN", "secret-token");
+    let yaml = r#"
+services:
+  - name: plex_den
+    kind: plex
+    url: http://10.0.0.11:32400
+    token_env: PLEX_DEN_TOKEN
+    client_identifier: machine-den
+"#;
+
+    let services =
+        fleet_file::parse_and_resolve(yaml, FleetFormat::Yaml, std::path::Path::new("fleet.yaml"))
+            .unwrap();
+
+    assert_eq!(services.len(), 1);
+    assert_eq!(services[0].name, "plex_den");
+    assert_eq!(services[0].token.as_deref(), Some("secret-token"));
+    assert_eq!(
+        services[0].client_identifier.as_deref(),
+        Some("machine-den")
+    );
+}
+
+#[test]
+fn toml_fleet_file_parses_the_same_contract() {
+    let mut env = crate::testing::TestEnv::new();
+    env.set("TAUTULLI_DEN_KEY", "secret-key");
+    let toml = r#"
+[[services]]
+name = "tautulli_den"
+kind = "tautulli"
+url = "http://10.0.0.11:8181"
+api_key_env = "TAUTULLI_DEN_KEY"
+plex = "plex_den"
+"#;
+
+    let services =
+        fleet_file::parse_and_resolve(toml, FleetFormat::Toml, std::path::Path::new("fleet.toml"))
+            .unwrap();
+
+    assert_eq!(services[0].api_key.as_deref(), Some("secret-key"));
+    assert_eq!(services[0].plex.as_deref(), Some("plex_den"));
+}
+
+#[test]
+fn inline_secret_is_rejected_with_name_source_and_line() {
+    let yaml = "services:\n  - name: plex_den\n    kind: plex\n    url: http://plex:32400\n    token: do-not-allow\n";
+    let error = fleet_file::parse_and_resolve(
+        yaml,
+        FleetFormat::Yaml,
+        std::path::Path::new("/config/fleet.yaml"),
+    )
+    .unwrap_err();
+    let message = error.to_string();
+
+    assert!(message.contains("/config/fleet.yaml:2"), "{message}");
+    assert!(message.contains("plex_den"), "{message}");
+    assert!(message.contains("token"), "{message}");
+    assert!(message.contains("token_env"), "{message}");
+}
+
+#[test]
+fn environment_source_overrides_same_name_and_preserves_union() {
+    let file = vec![
+        ServiceConfig {
+            name: "plex_den".into(),
+            kind: ServiceKind::Plex,
+            base_url: "http://file:32400".into(),
+            ..ServiceConfig::default()
+        },
+        ServiceConfig {
+            name: "plex_4k".into(),
+            kind: ServiceKind::Plex,
+            base_url: "http://4k:32400".into(),
+            ..ServiceConfig::default()
+        },
+    ];
+    let environment = vec![ServiceConfig {
+        name: "plex_den".into(),
+        kind: ServiceKind::Plex,
+        base_url: "http://environment:32400".into(),
+        ..ServiceConfig::default()
+    }];
+
+    let merged = merge_service_sources(file, environment).unwrap();
+    assert_eq!(merged.len(), 2);
+    assert_eq!(merged[0].name, "plex_4k");
+    assert_eq!(merged[1].name, "plex_den");
+    assert_eq!(merged[1].base_url, "http://environment:32400");
+}
+
+#[test]
+fn twenty_four_instance_yaml_loads_in_stable_name_order() {
+    let mut yaml = String::from("services:\n");
+    for index in (0..24).rev() {
+        yaml.push_str(&format!(
+            "  - name: plex_{index:02}\n    kind: plex\n    url: http://10.0.0.{index}:32400\n"
+        ));
+    }
+
+    let services =
+        fleet_file::parse_and_resolve(&yaml, FleetFormat::Yaml, std::path::Path::new("fleet.yaml"))
+            .unwrap();
+
+    assert_eq!(services.len(), 24);
+    assert_eq!(services.first().unwrap().name, "plex_00");
+    assert_eq!(services.last().unwrap().name, "plex_23");
+}

--- a/src/config/mcp.rs
+++ b/src/config/mcp.rs
@@ -46,6 +46,8 @@ pub struct McpConfig {
     pub codemode_queue_timeout_ms: u64,
     /// Absolute Code Mode wall-clock deadline in seconds.
     pub codemode_timeout_secs: u64,
+    /// Maximum targets allowed in one destructive fleet dispatch.
+    pub destructive_fanout_max: usize,
 }
 
 /// MCP tool-registration mode (YARR_MCP_TOOL_MODE).
@@ -137,6 +139,7 @@ impl Default for McpConfig {
             codemode_max_concurrent: crate::codemode::CODEMODE_MAX_CONCURRENT,
             codemode_queue_timeout_ms: crate::codemode::CODEMODE_QUEUE_TIMEOUT.as_millis() as u64,
             codemode_timeout_secs: crate::codemode::CODEMODE_TIMEOUT.as_secs(),
+            destructive_fanout_max: 3,
         }
     }
 }

--- a/src/config/mcp.rs
+++ b/src/config/mcp.rs
@@ -48,6 +48,10 @@ pub struct McpConfig {
     pub codemode_timeout_secs: u64,
     /// Maximum targets allowed in one destructive fleet dispatch.
     pub destructive_fanout_max: usize,
+    /// Maximum concurrently dispatched upstreams within one fleet operation.
+    pub fleet_max_concurrent: usize,
+    /// Independent per-instance fleet request deadline.
+    pub fleet_instance_timeout_secs: u64,
 }
 
 /// MCP tool-registration mode (YARR_MCP_TOOL_MODE).
@@ -140,6 +144,8 @@ impl Default for McpConfig {
             codemode_queue_timeout_ms: crate::codemode::CODEMODE_QUEUE_TIMEOUT.as_millis() as u64,
             codemode_timeout_secs: crate::codemode::CODEMODE_TIMEOUT.as_secs(),
             destructive_fanout_max: 3,
+            fleet_max_concurrent: crate::codemode::FLEET_MAX_CONCURRENT,
+            fleet_instance_timeout_secs: crate::codemode::FLEET_INSTANCE_TIMEOUT.as_secs(),
         }
     }
 }

--- a/src/config/mcp_tests.rs
+++ b/src/config/mcp_tests.rs
@@ -19,6 +19,8 @@ fn mcp_config_defaults() {
     assert_eq!(cfg.codemode_queue_timeout_ms, 500);
     assert_eq!(cfg.codemode_timeout_secs, 120);
     assert_eq!(cfg.destructive_fanout_max, 3);
+    assert_eq!(cfg.fleet_max_concurrent, 8);
+    assert_eq!(cfg.fleet_instance_timeout_secs, 8);
 }
 
 #[test]

--- a/src/config/mcp_tests.rs
+++ b/src/config/mcp_tests.rs
@@ -18,6 +18,7 @@ fn mcp_config_defaults() {
     assert_eq!(cfg.codemode_max_concurrent, 4);
     assert_eq!(cfg.codemode_queue_timeout_ms, 500);
     assert_eq!(cfg.codemode_timeout_secs, 30);
+    assert_eq!(cfg.destructive_fanout_max, 3);
 }
 
 #[test]

--- a/src/config/mcp_tests.rs
+++ b/src/config/mcp_tests.rs
@@ -17,7 +17,7 @@ fn mcp_config_defaults() {
     );
     assert_eq!(cfg.codemode_max_concurrent, 4);
     assert_eq!(cfg.codemode_queue_timeout_ms, 500);
-    assert_eq!(cfg.codemode_timeout_secs, 30);
+    assert_eq!(cfg.codemode_timeout_secs, 120);
     assert_eq!(cfg.destructive_fanout_max, 3);
 }
 

--- a/src/config/services.rs
+++ b/src/config/services.rs
@@ -30,6 +30,12 @@ pub struct ServiceConfig {
     pub token: Option<String>,
     /// Instance policy: reject every mutating action on every transport.
     pub read_only: bool,
+    /// Stable Plex machine identity used by discovery and Tautulli pairing.
+    pub client_identifier: Option<String>,
+    /// Optional configured Plex service paired with this Tautulli instance.
+    pub plex: Option<String>,
+    /// Discovery selected a bandwidth-limited Plex relay connection.
+    pub relay_only: bool,
 }
 
 impl Default for ServiceConfig {
@@ -43,6 +49,9 @@ impl Default for ServiceConfig {
             password: None,
             token: None,
             read_only: false,
+            client_identifier: None,
+            plex: None,
+            relay_only: false,
         }
     }
 }
@@ -284,11 +293,17 @@ pub(super) fn load_services_from_env(config: &mut super::YarrConfig) -> anyhow::
             password: env_optional(&format!("YARR_{env_name}_PASSWORD")),
             token: env_optional(&format!("YARR_{env_name}_TOKEN")),
             read_only: false,
+            client_identifier: None,
+            plex: None,
+            relay_only: false,
         };
         services.push(service);
     }
     if !services.is_empty() {
-        config.services = services;
+        config.services = super::fleet_file::merge_service_sources(
+            std::mem::take(&mut config.services),
+            services,
+        )?;
     }
     Ok(())
 }

--- a/src/config/services.rs
+++ b/src/config/services.rs
@@ -5,6 +5,19 @@ use serde::{Deserialize, Serialize};
 
 pub(super) const SERVICE_HOME_DIRNAME: &str = ".yarr";
 
+/// Global JavaScript bindings owned by the Code Mode runtime. Configured
+/// service names may not collide with these names because doing so would either
+/// hide the service or clobber a safety/runtime primitive.
+pub(crate) const CODEMODE_RESERVED_GLOBALS: &[&str] = &[
+    "api",
+    "callTool",
+    "codemode",
+    "console",
+    "globalThis",
+    "input",
+    "writeArtifact",
+];
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(default)]
 pub struct ServiceConfig {
@@ -303,6 +316,39 @@ pub(super) fn apply_readonly_services(
             );
         };
         service.read_only = true;
+    }
+    Ok(())
+}
+
+pub(super) fn validate_service_identities(services: &[ServiceConfig]) -> anyhow::Result<()> {
+    let mut names = std::collections::BTreeMap::<String, &str>::new();
+    let mut env_namespaces = std::collections::BTreeMap::<String, &str>::new();
+    for service in services {
+        let name = service.name.trim();
+        if name.is_empty() {
+            anyhow::bail!("configured service name must not be empty");
+        }
+        let normalized = name.to_ascii_lowercase();
+        if let Some(previous) = names.insert(normalized, name) {
+            anyhow::bail!(
+                "duplicate configured service name: {previous:?} and {name:?} differ only by case"
+            );
+        }
+        if CODEMODE_RESERVED_GLOBALS
+            .iter()
+            .any(|reserved| reserved.eq_ignore_ascii_case(name))
+        {
+            anyhow::bail!(
+                "configured service name {name:?} collides with a reserved Code Mode global; reserved names: {}",
+                CODEMODE_RESERVED_GLOBALS.join(", ")
+            );
+        }
+        let namespace = service_env_name(name);
+        if let Some(previous) = env_namespaces.insert(namespace.clone(), name) {
+            anyhow::bail!(
+                "configured service names {previous:?} and {name:?} collide in environment namespace YARR_{namespace}_*; rename one service (underscores are recommended)"
+            );
+        }
     }
     Ok(())
 }

--- a/src/config/services.rs
+++ b/src/config/services.rs
@@ -15,6 +15,7 @@ pub(crate) const CODEMODE_RESERVED_GLOBALS: &[&str] = &[
     "console",
     "globalThis",
     "input",
+    "fleet",
     "writeArtifact",
 ];
 

--- a/src/config/services.rs
+++ b/src/config/services.rs
@@ -15,6 +15,8 @@ pub struct ServiceConfig {
     pub username: Option<String>,
     pub password: Option<String>,
     pub token: Option<String>,
+    /// Instance policy: reject every mutating action on every transport.
+    pub read_only: bool,
 }
 
 impl Default for ServiceConfig {
@@ -27,6 +29,7 @@ impl Default for ServiceConfig {
             username: None,
             password: None,
             token: None,
+            read_only: false,
         }
     }
 }
@@ -267,11 +270,39 @@ pub(super) fn load_services_from_env(config: &mut super::YarrConfig) -> anyhow::
             username: env_optional(&format!("YARR_{env_name}_USERNAME")),
             password: env_optional(&format!("YARR_{env_name}_PASSWORD")),
             token: env_optional(&format!("YARR_{env_name}_TOKEN")),
+            read_only: false,
         };
         services.push(service);
     }
     if !services.is_empty() {
         config.services = services;
+    }
+    Ok(())
+}
+
+pub(super) fn apply_readonly_services(
+    services: &mut [ServiceConfig],
+    raw_names: &str,
+) -> anyhow::Result<()> {
+    for raw_name in raw_names
+        .split(',')
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+    {
+        let Some(service) = services
+            .iter_mut()
+            .find(|service| service.name.eq_ignore_ascii_case(raw_name))
+        else {
+            anyhow::bail!(
+                "YARR_FLEET_READONLY service {raw_name:?} is not configured; configured services: {}",
+                services
+                    .iter()
+                    .map(|service| service.name.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
+        };
+        service.read_only = true;
     }
     Ok(())
 }

--- a/src/config/services_tests.rs
+++ b/src/config/services_tests.rs
@@ -145,3 +145,67 @@ fn readonly_list_marks_names_case_insensitively_and_rejects_unknown_names() {
     assert!(error.to_string().contains("plex_missing"));
     assert!(error.to_string().contains("not configured"));
 }
+
+#[test]
+fn reserved_codemode_global_fails_identity_validation() {
+    let error = validate_service_identities(&[ServiceConfig {
+        name: "console".into(),
+        kind: ServiceKind::Plex,
+        base_url: "http://localhost:32400".into(),
+        ..ServiceConfig::default()
+    }])
+    .unwrap_err();
+
+    assert!(error.to_string().contains("reserved Code Mode global"));
+    for reserved in CODEMODE_RESERVED_GLOBALS {
+        assert!(error.to_string().contains(reserved), "{error}");
+    }
+}
+
+#[test]
+fn normalized_environment_namespaces_must_be_unique() {
+    let error = validate_service_identities(&[
+        ServiceConfig {
+            name: "plex-den".into(),
+            kind: ServiceKind::Plex,
+            base_url: "http://localhost:32400".into(),
+            ..ServiceConfig::default()
+        },
+        ServiceConfig {
+            name: "plex_den".into(),
+            kind: ServiceKind::Plex,
+            base_url: "http://localhost:32401".into(),
+            ..ServiceConfig::default()
+        },
+    ])
+    .unwrap_err();
+
+    assert!(error.to_string().contains("YARR_PLEX_DEN_*"));
+    assert!(error.to_string().contains("plex-den"));
+    assert!(error.to_string().contains("plex_den"));
+}
+
+#[test]
+fn configured_names_must_be_unique_case_insensitively() {
+    let error = validate_service_identities(&[
+        ServiceConfig {
+            name: "Plex_Den".into(),
+            kind: ServiceKind::Plex,
+            base_url: "http://localhost:32400".into(),
+            ..ServiceConfig::default()
+        },
+        ServiceConfig {
+            name: "plex_den".into(),
+            kind: ServiceKind::Plex,
+            base_url: "http://localhost:32401".into(),
+            ..ServiceConfig::default()
+        },
+    ])
+    .unwrap_err();
+
+    assert!(
+        error
+            .to_string()
+            .contains("duplicate configured service name")
+    );
+}

--- a/src/config/services_tests.rs
+++ b/src/config/services_tests.rs
@@ -128,3 +128,20 @@ fn load_services_bails_when_url_missing() {
     );
     assert!(msg.contains("sonarr"), "error should name the service");
 }
+
+#[test]
+fn readonly_list_marks_names_case_insensitively_and_rejects_unknown_names() {
+    let mut services = vec![ServiceConfig {
+        name: "plex_den".into(),
+        kind: ServiceKind::Plex,
+        base_url: "http://localhost:32400".into(),
+        ..ServiceConfig::default()
+    }];
+
+    apply_readonly_services(&mut services, "PLEX_DEN").unwrap();
+    assert!(services[0].read_only);
+
+    let error = apply_readonly_services(&mut services, "plex_missing").unwrap_err();
+    assert!(error.to_string().contains("plex_missing"));
+    assert!(error.to_string().contains("not configured"));
+}

--- a/src/config_tests.rs
+++ b/src/config_tests.rs
@@ -101,3 +101,47 @@ fn config_load_rejects_reserved_service_identity() {
     assert!(error.to_string().contains("reserved Code Mode global"));
     assert!(error.to_string().contains("console"));
 }
+
+#[test]
+fn config_load_merges_fleet_file_with_environment_precedence() {
+    let dir = tempfile::tempdir().unwrap();
+    let fleet_path = dir.path().join("fleet.yaml");
+    std::fs::write(
+        &fleet_path,
+        "services:\n  - name: plex_den\n    kind: plex\n    url: http://file:32400\n    token_env: PLEX_DEN_TOKEN\n  - name: plex_4k\n    kind: plex\n    url: http://4k:32400\n",
+    )
+    .unwrap();
+    let mut env = TestEnv::new();
+    env.set("YARR_HOME", dir.path());
+    env.set("HOME", dir.path());
+    env.remove("YARR_CONFIG");
+    env.set("YARR_FLEET_FILE", &fleet_path);
+    env.set("PLEX_DEN_TOKEN", "file-secret-reference");
+    env.set("YARR_SERVICES", "plex_den,sonarr");
+    env.set("YARR_PLEX_DEN_KIND", "plex");
+    env.set("YARR_PLEX_DEN_URL", "http://environment:32400");
+    env.set("YARR_PLEX_DEN_TOKEN", "environment-secret");
+    env.set("YARR_SONARR_URL", "http://sonarr:8989");
+    env.set("YARR_FLEET_READONLY", "plex_4k");
+
+    let loaded = Config::load().unwrap();
+
+    assert_eq!(loaded.yarr.services.len(), 3);
+    let den = loaded
+        .yarr
+        .services
+        .iter()
+        .find(|service| service.name == "plex_den")
+        .unwrap();
+    assert_eq!(den.base_url, "http://environment:32400");
+    assert_eq!(den.token.as_deref(), Some("environment-secret"));
+    assert!(
+        loaded
+            .yarr
+            .services
+            .iter()
+            .find(|service| service.name == "plex_4k")
+            .unwrap()
+            .read_only
+    );
+}

--- a/src/config_tests.rs
+++ b/src/config_tests.rs
@@ -85,3 +85,19 @@ fn invalid_static_token_scope_is_rejected() {
     let error = Config::load().unwrap_err();
     assert!(error.to_string().contains("yarr:admin"));
 }
+
+#[test]
+fn config_load_rejects_reserved_service_identity() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut env = TestEnv::new();
+    env.set("YARR_HOME", dir.path());
+    env.set("HOME", dir.path());
+    env.remove("YARR_CONFIG");
+    env.set("YARR_SERVICES", "console");
+    env.set("YARR_CONSOLE_KIND", "plex");
+    env.set("YARR_CONSOLE_URL", "http://localhost:32400");
+
+    let error = Config::load().unwrap_err();
+    assert!(error.to_string().contains("reserved Code Mode global"));
+    assert!(error.to_string().contains("console"));
+}

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -1,0 +1,577 @@
+//! Reviewable Plex account discovery and fleet-file scaffolding.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::io::Write as _;
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::app::YarrService;
+use crate::config::{ServiceKind, YarrConfig};
+use crate::yarr::YarrClient;
+
+const PLEX_RESOURCES_URL: &str = "https://plex.tv/api/v2/resources?includeHttps=1&includeRelay=1";
+const MAX_DISCOVERY_RESPONSE_BYTES: usize = 4 * 1024 * 1024;
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct PlexResource {
+    pub name: String,
+    pub client_identifier: String,
+    #[serde(default)]
+    pub owned: bool,
+    #[serde(default)]
+    pub provides: String,
+    pub access_token: Option<String>,
+    #[serde(default)]
+    pub connections: Vec<PlexConnection>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub(crate) struct PlexConnection {
+    pub uri: String,
+    #[serde(default)]
+    pub local: bool,
+    #[serde(default)]
+    pub relay: bool,
+    pub protocol: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct DiscoveredPlex {
+    pub name: String,
+    pub server_name: String,
+    pub client_identifier: String,
+    pub url: String,
+    pub token_env: String,
+    #[serde(skip)]
+    pub access_token: String,
+    pub relay_only: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TautulliIdentity {
+    pub name: String,
+    pub url: String,
+    pub pms_identifier: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct FleetPairing {
+    pub tautulli: String,
+    pub plex: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+pub(crate) struct PairingReport {
+    pub paired: Vec<FleetPairing>,
+    pub unpaired_plex: Vec<String>,
+    pub unpaired_tautulli: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+pub(crate) struct DriftReport {
+    pub added: Vec<String>,
+    pub removed: Vec<String>,
+    pub renamed: Vec<String>,
+    pub url_changed: Vec<String>,
+}
+
+impl DriftReport {
+    pub fn has_drift(&self) -> bool {
+        !self.added.is_empty()
+            || !self.removed.is_empty()
+            || !self.renamed.is_empty()
+            || !self.url_changed.is_empty()
+    }
+}
+
+/// Fetch the Plex account resource inventory, reconcile it by machine
+/// identifier, and either write new scaffolding or report drift without writes.
+pub async fn run_plex_discovery(
+    config: &YarrConfig,
+    owned_only: bool,
+    token_env: &str,
+    output: &Path,
+    env_output: &Path,
+    diff: bool,
+) -> Result<(serde_json::Value, bool)> {
+    let account_token = std::env::var(token_env)
+        .map_err(|_| anyhow::anyhow!("discover plex: account token env {token_env} is not set"))?;
+    if account_token.trim().is_empty() {
+        anyhow::bail!("discover plex: account token env {token_env} is empty");
+    }
+    validate_env_name(token_env)?;
+    let resources = fetch_resources(PLEX_RESOURCES_URL, &account_token).await?;
+    let discovered = discover_resources(resources, owned_only)?;
+    let tautulli = inspect_tautulli(config).await;
+    let pairing = pair_tautulli(&discovered, &tautulli)?;
+
+    if diff {
+        let previous = read_discovered_fleet(output)?;
+        let drift = diff_fleet(&discovered, &previous);
+        let has_drift = drift.has_drift();
+        return Ok((
+            serde_json::json!({
+                "drift": drift,
+                "pairing": pairing,
+                "relay_only": discovered.iter().filter(|server| server.relay_only).map(|server| &server.name).collect::<Vec<_>>(),
+            }),
+            has_drift,
+        ));
+    }
+
+    if output.exists() || env_output.exists() {
+        anyhow::bail!(
+            "discover plex refuses to overwrite reviewable fleet files; {} or {} already exists (use --diff)",
+            output.display(),
+            env_output.display()
+        );
+    }
+    write_discovery_files(output, env_output, &discovered, &tautulli, &pairing)?;
+    Ok((
+        serde_json::json!({
+            "fleet_file": output,
+            "env_file": env_output,
+            "servers": discovered.len(),
+            "pairing": pairing,
+            "relay_only": discovered.iter().filter(|server| server.relay_only).map(|server| &server.name).collect::<Vec<_>>(),
+            "review_required": true,
+        }),
+        false,
+    ))
+}
+
+pub(crate) fn parse_resources(payload: &[u8]) -> Result<Vec<PlexResource>> {
+    serde_json::from_slice(payload).map_err(Into::into)
+}
+
+async fn fetch_resources(endpoint: &str, token: &str) -> Result<Vec<PlexResource>> {
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .connect_timeout(std::time::Duration::from_secs(10))
+        .redirect(reqwest::redirect::Policy::none())
+        .build()?;
+    let response = client
+        .get(endpoint)
+        .header(reqwest::header::ACCEPT, "application/json")
+        .header("X-Plex-Token", token)
+        .header("X-Plex-Client-Identifier", "yarr-plex-discovery-v1")
+        .header("X-Plex-Product", "yarr")
+        .send()
+        .await
+        .context("discover plex: plex.tv resource request failed")?;
+    let status = response.status();
+    if !status.is_success() {
+        anyhow::bail!("discover plex: plex.tv returned HTTP {}", status.as_u16());
+    }
+    if response
+        .content_length()
+        .is_some_and(|length| length > MAX_DISCOVERY_RESPONSE_BYTES as u64)
+    {
+        anyhow::bail!("discover plex: plex.tv resource response exceeds 4 MiB");
+    }
+    let bytes = response.bytes().await?;
+    if bytes.len() > MAX_DISCOVERY_RESPONSE_BYTES {
+        anyhow::bail!("discover plex: plex.tv resource response exceeds 4 MiB");
+    }
+    parse_resources(&bytes).context("discover plex: unexpected plex.tv resource response shape")
+}
+
+pub(crate) fn discover_resources(
+    resources: Vec<PlexResource>,
+    owned_only: bool,
+) -> Result<Vec<DiscoveredPlex>> {
+    let mut candidates = resources
+        .into_iter()
+        .filter(|resource| {
+            resource
+                .provides
+                .split(',')
+                .any(|provided| provided.trim() == "server")
+        })
+        .filter(|resource| !owned_only || resource.owned)
+        .collect::<Vec<_>>();
+    candidates.sort_by(|left, right| left.client_identifier.cmp(&right.client_identifier));
+
+    let mut slug_counts = BTreeMap::<String, usize>::new();
+    for resource in &candidates {
+        *slug_counts.entry(slug(&resource.name)).or_default() += 1;
+    }
+
+    let mut discovered = Vec::with_capacity(candidates.len());
+    for resource in candidates {
+        let base = slug(&resource.name);
+        let name = if slug_counts[&base] > 1 {
+            format!("plex_{base}_{}", short_hash(&resource.client_identifier))
+        } else {
+            format!("plex_{base}")
+        };
+        let (url, relay_only) = select_connection(&resource).ok_or_else(|| {
+            anyhow::anyhow!(
+                "Plex server {:?} ({}) has no local, direct HTTPS, or relay connection",
+                resource.name,
+                resource.client_identifier
+            )
+        })?;
+        let access_token = resource.access_token.ok_or_else(|| {
+            anyhow::anyhow!(
+                "Plex server {:?} ({}) did not provide a per-resource accessToken",
+                resource.name,
+                resource.client_identifier
+            )
+        })?;
+        discovered.push(DiscoveredPlex {
+            token_env: format!("{}_TOKEN", name.to_ascii_uppercase()),
+            name,
+            server_name: resource.name,
+            client_identifier: resource.client_identifier,
+            url,
+            access_token,
+            relay_only,
+        });
+    }
+    discovered.sort_by(|left, right| left.name.cmp(&right.name));
+    Ok(discovered)
+}
+
+pub(crate) fn pair_tautulli(
+    plex: &[DiscoveredPlex],
+    tautulli: &[TautulliIdentity],
+) -> Result<PairingReport> {
+    let by_identifier = plex
+        .iter()
+        .map(|server| (server.client_identifier.as_str(), server.name.as_str()))
+        .collect::<BTreeMap<_, _>>();
+    let mut paired_plex = BTreeSet::new();
+    let mut paired = Vec::new();
+    let mut unpaired_tautulli = Vec::new();
+    for instance in tautulli {
+        let Some(identifier) = instance.pms_identifier.as_deref() else {
+            unpaired_tautulli.push(instance.name.clone());
+            continue;
+        };
+        let Some(plex_name) = by_identifier.get(identifier) else {
+            unpaired_tautulli.push(instance.name.clone());
+            continue;
+        };
+        if !paired_plex.insert((*plex_name).to_owned()) {
+            anyhow::bail!(
+                "multiple Tautulli instances report Plex identifier {identifier}; pairing must be one-to-one"
+            );
+        }
+        paired.push(FleetPairing {
+            tautulli: instance.name.clone(),
+            plex: (*plex_name).to_owned(),
+        });
+    }
+    paired.sort_by(|left, right| left.tautulli.cmp(&right.tautulli));
+    unpaired_tautulli.sort();
+    let unpaired_plex = plex
+        .iter()
+        .filter(|server| !paired_plex.contains(&server.name))
+        .map(|server| server.name.clone())
+        .collect();
+    Ok(PairingReport {
+        paired,
+        unpaired_plex,
+        unpaired_tautulli,
+    })
+}
+
+pub(crate) fn diff_fleet(current: &[DiscoveredPlex], previous: &[DiscoveredPlex]) -> DriftReport {
+    let current_by_id = current
+        .iter()
+        .map(|item| (item.client_identifier.as_str(), item))
+        .collect::<BTreeMap<_, _>>();
+    let previous_by_id = previous
+        .iter()
+        .map(|item| (item.client_identifier.as_str(), item))
+        .collect::<BTreeMap<_, _>>();
+    let mut report = DriftReport::default();
+    for (identifier, item) in &current_by_id {
+        match previous_by_id.get(identifier) {
+            None => report.added.push(item.name.clone()),
+            Some(old) => {
+                if old.name != item.name {
+                    report
+                        .renamed
+                        .push(format!("{} -> {}", old.name, item.name));
+                }
+                if old.url != item.url {
+                    report
+                        .url_changed
+                        .push(format!("{}: {} -> {}", item.name, old.url, item.url));
+                }
+            }
+        }
+    }
+    for (identifier, item) in previous_by_id {
+        if !current_by_id.contains_key(identifier) {
+            report.removed.push(item.name.clone());
+        }
+    }
+    report.added.sort();
+    report.removed.sort();
+    report.renamed.sort();
+    report.url_changed.sort();
+    report
+}
+
+fn slug(name: &str) -> String {
+    let mut out = String::new();
+    let mut separator = false;
+    for character in name.chars().flat_map(char::to_lowercase) {
+        if character.is_ascii_alphanumeric() {
+            out.push(character);
+            separator = false;
+        } else if !out.is_empty() && !separator {
+            out.push('_');
+            separator = true;
+        }
+    }
+    while out.ends_with('_') {
+        out.pop();
+    }
+    if out.is_empty() { "server".into() } else { out }
+}
+
+fn short_hash(identifier: &str) -> String {
+    let digest = Sha256::digest(identifier.as_bytes());
+    digest[..4]
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+fn select_connection(resource: &PlexResource) -> Option<(String, bool)> {
+    let mut connections = resource.connections.iter().collect::<Vec<_>>();
+    connections.sort_by(|left, right| left.uri.cmp(&right.uri));
+    if let Some(connection) = connections.iter().find(|connection| connection.local) {
+        return Some((connection.uri.clone(), false));
+    }
+    if let Some(connection) = connections.iter().find(|connection| {
+        !is_relay(connection)
+            && (connection.protocol.as_deref() == Some("https")
+                || connection.uri.starts_with("https://"))
+    }) {
+        return Some((connection.uri.clone(), false));
+    }
+    connections
+        .iter()
+        .find(|connection| is_relay(connection))
+        .map(|connection| (connection.uri.clone(), true))
+}
+
+fn is_relay(connection: &PlexConnection) -> bool {
+    connection.relay || connection.uri.contains("relay.plex.direct")
+}
+
+async fn inspect_tautulli(config: &YarrConfig) -> Vec<TautulliIdentity> {
+    let client = match YarrClient::new(config) {
+        Ok(client) => client,
+        Err(_) => return Vec::new(),
+    };
+    let service = YarrService::new(client, config.clone());
+    let mut identities = Vec::new();
+    for instance in config
+        .services
+        .iter()
+        .filter(|instance| instance.kind == ServiceKind::Tautulli)
+    {
+        let pms_identifier = match service.service_status(&instance.name).await {
+            Ok(value) => find_string_field(&value, "pms_identifier"),
+            Err(_) => None,
+        };
+        identities.push(TautulliIdentity {
+            name: instance.name.clone(),
+            url: instance.base_url.clone(),
+            pms_identifier,
+        });
+    }
+    identities.sort_by(|left, right| left.name.cmp(&right.name));
+    identities
+}
+
+fn find_string_field(value: &serde_json::Value, field: &str) -> Option<String> {
+    match value {
+        serde_json::Value::Object(object) => object
+            .get(field)
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_owned)
+            .or_else(|| {
+                object
+                    .values()
+                    .find_map(|child| find_string_field(child, field))
+            }),
+        serde_json::Value::Array(items) => items
+            .iter()
+            .find_map(|child| find_string_field(child, field)),
+        _ => None,
+    }
+}
+
+#[derive(Serialize)]
+struct FleetDocumentOut {
+    services: Vec<FleetEntryOut>,
+}
+
+#[derive(Serialize)]
+struct FleetEntryOut {
+    name: String,
+    kind: ServiceKind,
+    url: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    token_env: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    client_identifier: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    plex: Option<String>,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    relay_only: bool,
+}
+
+fn write_discovery_files(
+    output: &Path,
+    env_output: &Path,
+    plex: &[DiscoveredPlex],
+    tautulli: &[TautulliIdentity],
+    pairing: &PairingReport,
+) -> Result<()> {
+    match output.extension().and_then(|extension| extension.to_str()) {
+        Some("yaml" | "yml") => {}
+        _ => anyhow::bail!("discover plex --output must use a .yaml or .yml extension"),
+    }
+    for path in [output, env_output] {
+        if let Some(parent) = path.parent()
+            && !parent.as_os_str().is_empty()
+        {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("could not create {}", parent.display()))?;
+        }
+    }
+
+    let paired_by_tautulli = pairing
+        .paired
+        .iter()
+        .map(|pair| (pair.tautulli.as_str(), pair.plex.as_str()))
+        .collect::<BTreeMap<_, _>>();
+    let mut services = plex
+        .iter()
+        .map(|server| FleetEntryOut {
+            name: server.name.clone(),
+            kind: ServiceKind::Plex,
+            url: server.url.clone(),
+            token_env: Some(server.token_env.clone()),
+            client_identifier: Some(server.client_identifier.clone()),
+            plex: None,
+            relay_only: server.relay_only,
+        })
+        .collect::<Vec<_>>();
+    services.extend(tautulli.iter().filter_map(|instance| {
+        paired_by_tautulli
+            .get(instance.name.as_str())
+            .map(|plex_name| FleetEntryOut {
+                name: instance.name.clone(),
+                kind: ServiceKind::Tautulli,
+                url: instance.url.clone(),
+                token_env: None,
+                client_identifier: None,
+                plex: Some((*plex_name).to_owned()),
+                relay_only: false,
+            })
+    }));
+    services.sort_by(|left, right| left.name.cmp(&right.name));
+    let yaml = serde_yaml::to_string(&FleetDocumentOut { services })?;
+    create_new_file(output, yaml.as_bytes(), false)?;
+
+    let mut env =
+        String::from("# Generated by yarr discover plex; contains per-server credentials.\n");
+    for server in plex {
+        if server.access_token.contains(['\r', '\n']) {
+            anyhow::bail!("Plex returned an invalid token for {}", server.name);
+        }
+        env.push_str(&server.token_env);
+        env.push('=');
+        env.push_str(&server.access_token);
+        env.push('\n');
+    }
+    if let Err(error) = create_new_file(env_output, env.as_bytes(), true) {
+        let _ = std::fs::remove_file(output);
+        return Err(error);
+    }
+    Ok(())
+}
+
+fn create_new_file(path: &Path, contents: &[u8], private: bool) -> Result<()> {
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    if private {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options
+        .open(path)
+        .with_context(|| format!("refusing to overwrite {}", path.display()))?;
+    file.write_all(contents)?;
+    file.sync_all()?;
+    Ok(())
+}
+
+fn read_discovered_fleet(path: &Path) -> Result<Vec<DiscoveredPlex>> {
+    let contents = std::fs::read_to_string(path)
+        .with_context(|| format!("discover plex --diff could not read {}", path.display()))?;
+    let document: serde_json::Value = serde_yaml::from_str(&contents)
+        .with_context(|| format!("discover plex --diff could not parse {}", path.display()))?;
+    let services = document
+        .get("services")
+        .and_then(serde_json::Value::as_array)
+        .ok_or_else(|| anyhow::anyhow!("{} has no services array", path.display()))?;
+    let mut result = Vec::new();
+    for entry in services {
+        if entry.get("kind").and_then(serde_json::Value::as_str) != Some("plex") {
+            continue;
+        }
+        let field = |name: &str| {
+            entry
+                .get(name)
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_owned)
+                .ok_or_else(|| anyhow::anyhow!("{} Plex entry is missing {name}", path.display()))
+        };
+        let name = field("name")?;
+        result.push(DiscoveredPlex {
+            server_name: name.clone(),
+            name,
+            client_identifier: field("client_identifier")?,
+            url: field("url")?,
+            token_env: field("token_env")?,
+            access_token: String::new(),
+            relay_only: entry
+                .get("relay_only")
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(false),
+        });
+    }
+    result.sort_by(|left, right| left.name.cmp(&right.name));
+    Ok(result)
+}
+
+fn validate_env_name(name: &str) -> Result<()> {
+    let mut chars = name.chars();
+    if !chars
+        .next()
+        .is_some_and(|first| first == '_' || first.is_ascii_alphabetic())
+        || !chars.all(|character| character == '_' || character.is_ascii_alphanumeric())
+    {
+        anyhow::bail!("discover plex --token-env must be a valid environment variable name");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[path = "discovery_tests.rs"]
+mod tests;

--- a/src/discovery_tests.rs
+++ b/src/discovery_tests.rs
@@ -1,0 +1,145 @@
+use super::*;
+
+fn payload() -> Vec<PlexResource> {
+    parse_resources(
+        br#"[
+          {"name":"Den","clientIdentifier":"aaa","owned":true,"provides":"server",
+           "accessToken":"tok-a","connections":[
+             {"uri":"https://relay.plex.direct/a","local":false,"relay":true,"protocol":"https"},
+             {"uri":"https://direct.example:32400","local":false,"relay":false,"protocol":"https"},
+             {"uri":"http://10.0.0.11:32400","local":true,"relay":false,"protocol":"http"}]},
+          {"name":"Shared","clientIdentifier":"bbb","owned":false,"provides":"server,player",
+           "accessToken":"tok-b","connections":[{"uri":"https://relay.plex.direct/b","relay":true,"protocol":"https"}]},
+          {"name":"TV","clientIdentifier":"ccc","owned":true,"provides":"player",
+           "accessToken":"tok-c","connections":[]}
+        ]"#,
+    )
+    .unwrap()
+}
+
+#[test]
+fn filters_non_servers_and_shared_by_default_and_prefers_local() {
+    let found = discover_resources(payload(), true).unwrap();
+    assert_eq!(found.len(), 1);
+    assert_eq!(found[0].name, "plex_den");
+    assert_eq!(found[0].url, "http://10.0.0.11:32400");
+    assert_eq!(found[0].token_env, "PLEX_DEN_TOKEN");
+    assert!(!found[0].relay_only);
+}
+
+#[test]
+fn shared_opt_in_and_relay_only_are_explicit() {
+    let found = discover_resources(payload(), false).unwrap();
+    let shared = found
+        .iter()
+        .find(|item| item.server_name == "Shared")
+        .unwrap();
+    assert_eq!(shared.url, "https://relay.plex.direct/b");
+    assert!(shared.relay_only);
+}
+
+#[test]
+fn colliding_slugs_receive_stable_identifier_hashes() {
+    let resources = parse_resources(
+        br#"[
+          {"name":"4K Room","clientIdentifier":"identifier-a","owned":true,"provides":"server","accessToken":"a","connections":[{"uri":"http://a","local":true}]},
+          {"name":"4k-room","clientIdentifier":"identifier-b","owned":true,"provides":"server","accessToken":"b","connections":[{"uri":"http://b","local":true}]}
+        ]"#,
+    ).unwrap();
+    let first = discover_resources(resources.clone(), true).unwrap();
+    let second = discover_resources(resources.into_iter().rev().collect(), true).unwrap();
+    assert_eq!(first, second);
+    assert!(
+        first
+            .iter()
+            .all(|item| item.name.starts_with("plex_4k_room_"))
+    );
+    assert_ne!(first[0].name, first[1].name);
+}
+
+#[test]
+fn pairs_tautulli_by_machine_identifier_and_reports_both_sides() {
+    let plex = discover_resources(payload(), false).unwrap();
+    let tautulli = vec![
+        TautulliIdentity {
+            name: "tautulli_den".into(),
+            url: "http://t1".into(),
+            pms_identifier: Some("aaa".into()),
+        },
+        TautulliIdentity {
+            name: "tautulli_orphan".into(),
+            url: "http://t2".into(),
+            pms_identifier: Some("missing".into()),
+        },
+    ];
+    let report = pair_tautulli(&plex, &tautulli).unwrap();
+    assert_eq!(
+        report.paired,
+        vec![FleetPairing {
+            tautulli: "tautulli_den".into(),
+            plex: "plex_den".into()
+        }]
+    );
+    assert_eq!(report.unpaired_plex, vec!["plex_shared"]);
+    assert_eq!(report.unpaired_tautulli, vec!["tautulli_orphan"]);
+}
+
+#[test]
+fn drift_is_pinned_by_identifier_not_name() {
+    let previous = vec![item("plex_old", "Old", "aaa", "http://old")];
+    let current = vec![
+        item("plex_new", "New", "aaa", "http://new"),
+        item("plex_added", "Added", "bbb", "http://added"),
+    ];
+    let report = diff_fleet(&current, &previous);
+    assert_eq!(report.added, vec!["plex_added"]);
+    assert!(report.removed.is_empty());
+    assert_eq!(report.renamed, vec!["plex_old -> plex_new"]);
+    assert_eq!(
+        report.url_changed,
+        vec!["plex_new: http://old -> http://new"]
+    );
+}
+
+fn item(name: &str, server_name: &str, id: &str, url: &str) -> DiscoveredPlex {
+    DiscoveredPlex {
+        name: name.into(),
+        server_name: server_name.into(),
+        client_identifier: id.into(),
+        url: url.into(),
+        token_env: format!("{}_TOKEN", name.to_ascii_uppercase()),
+        access_token: "token".into(),
+        relay_only: false,
+    }
+}
+
+#[test]
+fn writes_secret_free_yaml_and_private_env_file() {
+    let directory = tempfile::tempdir().unwrap();
+    let fleet_path = directory.path().join("fleet.yaml");
+    let env_path = directory.path().join("fleet.env");
+    let plex = discover_resources(payload(), true).unwrap();
+    let pairing = PairingReport::default();
+
+    write_discovery_files(&fleet_path, &env_path, &plex, &[], &pairing).unwrap();
+
+    let fleet = std::fs::read_to_string(&fleet_path).unwrap();
+    let env = std::fs::read_to_string(&env_path).unwrap();
+    assert!(fleet.contains("token_env: PLEX_DEN_TOKEN"));
+    assert!(fleet.contains("client_identifier: aaa"));
+    assert!(!fleet.contains("tok-a"));
+    assert!(env.contains("PLEX_DEN_TOKEN=tok-a"));
+    assert_eq!(
+        diff_fleet(&plex, &read_discovered_fleet(&fleet_path).unwrap()),
+        DriftReport::default()
+    );
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        assert_eq!(
+            std::fs::metadata(env_path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ mod capability;
 mod cli;
 mod codemode;
 mod config;
+mod discovery;
 pub(crate) mod logging;
 mod mcp;
 pub mod models;
@@ -50,6 +51,7 @@ pub use config::{
     AuthConfig, Config, McpConfig, ServiceConfig, ServiceKind, YarrConfig,
     acquire_oauth_instance_lock, resolve_data_dir,
 };
+pub use discovery::run_plex_discovery;
 /// Initialise dual logging for the binary: pretty colored output on stderr plus
 /// a JSON-lines file at `{data_dir}/logs/{service}.log` (non-blocking and
 /// rotated at 10 MiB with three retained backups).

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,7 @@ use yarr::{
     AppState, AuthPolicy, AuthPolicyKind, Command, Config, READ_SCOPE, RunMode, WRITE_SCOPE,
     YarrClient, YarrService, acquire_oauth_instance_lock, apply_plugin_options, cli_usage,
     init_logging, parse_args_configured, resolve_auth_policy_kind, resolve_data_dir, rmcp_server,
-    router, run_cli_command, run_doctor, run_setup, run_watch,
+    router, run_cli_command, run_doctor, run_plex_discovery, run_setup, run_watch,
 };
 
 fn main() -> Result<()> {
@@ -166,6 +166,28 @@ async fn run_cli(config: Config) -> Result<()> {
             run_watch(&base, interval, once).await
         }
         Some(Command::Setup(command)) => run_setup(&config, command).await,
+        Some(Command::DiscoverPlex {
+            owned_only,
+            token_env,
+            output,
+            env_output,
+            diff,
+        }) => {
+            let (report, has_drift) = run_plex_discovery(
+                &config.yarr,
+                owned_only,
+                &token_env,
+                &output,
+                &env_output,
+                diff,
+            )
+            .await?;
+            println!("{}", serde_json::to_string_pretty(&report)?);
+            if has_drift {
+                std::process::exit(2);
+            }
+            Ok(())
+        }
         Some(cmd) => run_cli_command(cmd, &config.yarr).await,
         None => {
             eprintln!("Unknown command. Run `yarr --help` for usage.");

--- a/src/main.rs
+++ b/src/main.rs
@@ -133,6 +133,10 @@ async fn serve_stdio_mcp(config: Config) -> Result<()> {
             config.mcp.codemode_max_concurrent,
             Duration::from_millis(config.mcp.codemode_queue_timeout_ms),
             Duration::from_secs(config.mcp.codemode_timeout_secs),
+        )
+        .with_fleet_limits(
+            config.mcp.fleet_max_concurrent,
+            Duration::from_secs(config.mcp.fleet_instance_timeout_secs),
         );
     // Enable Code Mode `writeArtifact` under the data dir (best-effort).
     if let Ok(dir) = resolve_data_dir() {
@@ -205,6 +209,10 @@ async fn build_state(config: Config) -> Result<AppState> {
             config.mcp.codemode_max_concurrent,
             Duration::from_millis(config.mcp.codemode_queue_timeout_ms),
             Duration::from_secs(config.mcp.codemode_timeout_secs),
+        )
+        .with_fleet_limits(
+            config.mcp.fleet_max_concurrent,
+            Duration::from_secs(config.mcp.fleet_instance_timeout_secs),
         );
     // Enable Code Mode `writeArtifact` under the data dir (best-effort).
     if let Ok(dir) = resolve_data_dir() {

--- a/src/mcp/elicit.rs
+++ b/src/mcp/elicit.rs
@@ -65,11 +65,47 @@ enum ElicitOutcome {
 }
 
 /// The elicitation prompt shown to the user before a destructive delete.
-pub(crate) fn confirm_message(action: &str, service: &str) -> String {
+pub(crate) fn confirm_message(action: &str, services: &[String]) -> String {
+    let mut names = services.to_vec();
+    names.sort();
+    names.dedup();
+    if names.len() == 1 {
+        return format!(
+            "Confirm destructive action '{action}' on service '{}'. This operation has high \
+             impact or permanently deletes data and cannot be undone. Approve to proceed.",
+            names[0]
+        );
+    }
     format!(
-        "Confirm destructive action '{action}' on service '{service}'. This permanently \
-         deletes data and cannot be undone. Approve to proceed."
+        "Confirm destructive fleet action '{action}' on {} instances: {}. This operation has \
+         high impact or permanently deletes data and cannot be undone. Approve once to dispatch \
+         to every named instance.",
+        names.len(),
+        names.join(", ")
     )
+}
+
+pub(crate) fn validate_destructive_targets(
+    services: &[String],
+    maximum: usize,
+) -> Result<Vec<String>, String> {
+    let mut names = services
+        .iter()
+        .map(|name| name.trim().to_ascii_lowercase())
+        .filter(|name| !name.is_empty())
+        .collect::<Vec<_>>();
+    names.sort();
+    names.dedup();
+    if names.is_empty() {
+        return Err("destructive action has no target instances".to_owned());
+    }
+    if names.len() > maximum {
+        return Err(format!(
+            "destructive fleet action targets {} instances but the configured maximum is {maximum}; target explicitly in groups of at most {maximum}",
+            names.len()
+        ));
+    }
+    Ok(names)
 }
 
 /// Pure decision: map a normalized [`ElicitOutcome`] to a [`DeleteGate`]. Fully
@@ -106,14 +142,18 @@ fn normalize(result: Result<Option<DeleteConfirmation>, ElicitationError>) -> El
 pub(crate) async fn gate_destructive(
     peer: &Peer<RoleServer>,
     action: &str,
-    service: &str,
+    services: &[String],
+    maximum: usize,
 ) -> DeleteGate {
+    let Ok(services) = validate_destructive_targets(services, maximum) else {
+        return DeleteGate::Declined;
+    };
     if peer.supported_elicitation_modes().is_empty() {
         return DeleteGate::Declined;
     }
     let result = peer
         .elicit_with_timeout::<DeleteConfirmation>(
-            confirm_message(action, service),
+            confirm_message(action, &services),
             Some(ELICIT_TIMEOUT),
         )
         .await;

--- a/src/mcp/elicit_tests.rs
+++ b/src/mcp/elicit_tests.rs
@@ -12,10 +12,35 @@ use super::*;
 
 #[test]
 fn confirm_message_names_action_and_service() {
-    let msg = confirm_message("delete", "sonarr");
+    let msg = confirm_message("delete", &["sonarr".to_owned()]);
     assert!(msg.contains("delete"));
     assert!(msg.contains("sonarr"));
     assert!(msg.contains("cannot be undone"));
+}
+
+#[test]
+fn fleet_confirmation_is_single_sorted_prompt_naming_every_instance() {
+    let msg = confirm_message(
+        "terminate_session",
+        &["plex_den".to_owned(), "plex_4k".to_owned()],
+    );
+    assert!(msg.contains("2 instances"), "{msg}");
+    assert!(msg.contains("plex_4k, plex_den"), "{msg}");
+}
+
+#[test]
+fn destructive_target_cap_fails_closed_before_prompting() {
+    let error = validate_destructive_targets(
+        &[
+            "plex_a".to_owned(),
+            "plex_b".to_owned(),
+            "plex_c".to_owned(),
+        ],
+        2,
+    )
+    .unwrap_err();
+    assert!(error.contains("maximum is 2"));
+    assert!(error.contains("target explicitly"));
 }
 
 // ── normalize: rmcp Ok result → ElicitOutcome (Err arms not constructible) ───────

--- a/src/mcp/rmcp_server.rs
+++ b/src/mcp/rmcp_server.rs
@@ -134,7 +134,13 @@ impl ServerHandler for YarrRmcpServer {
         // `is_destructive_op_call`.
         if (crate::actions::action_is_destructive(&action)
             || (action == "op" && is_destructive_op_call(&self.state, &tool_name, &arguments)))
-            && elicit::gate_destructive(&peer, &action, &tool_name).await
+            && elicit::gate_destructive(
+                &peer,
+                &action,
+                std::slice::from_ref(&tool_name),
+                self.state.config.destructive_fanout_max,
+            )
+            .await
                 == elicit::DeleteGate::Declined
         {
             tracing::info!(

--- a/src/mcp/rmcp_server_definitions.rs
+++ b/src/mcp/rmcp_server_definitions.rs
@@ -84,12 +84,10 @@ pub(super) fn tool_result_from_json(value: Value) -> Result<CallToolResult, Erro
     Ok(CallToolResult::success(vec![ContentBlock::text(text)]))
 }
 
-/// Whether `arguments` dispatches a generated DELETE operation via the `op`
-/// action (e.g. `{"action": "op", "op": "delete_series_by_id"}` against the
-/// `sonarr` tool in `flat` mode). `action_is_destructive` has no notion of
-/// `op`'s underlying HTTP method, so this is checked separately — otherwise a
-/// generated DELETE op would dispatch through `call_tool` with no elicitation
-/// prompt at all.
+/// Whether `arguments` dispatches a generated operation whose reviewed safety
+/// classification requires elicitation. DELETE is always destructive; the
+/// explicit safety table also covers high-impact POST/PUT operations such as
+/// Plex session termination and library scans.
 pub(super) fn is_destructive_op_call(state: &AppState, tool_name: &str, arguments: &Value) -> bool {
     let Some(op_name) = arguments.get("op").and_then(Value::as_str) else {
         return false;
@@ -97,7 +95,8 @@ pub(super) fn is_destructive_op_call(state: &AppState, tool_name: &str, argument
     let Ok(Some(kind)) = state.service.kind_of(tool_name) else {
         return false;
     };
-    crate::openapi::find_operation(kind, op_name).is_some_and(|spec| spec.method.is_delete())
+    crate::openapi::classify_operation(kind, op_name)
+        == Some(crate::openapi::OperationSafety::Destructive)
 }
 
 /// Result returned when a destructive action is declined at the elicitation

--- a/src/mcp/rmcp_server_errors_tests.rs
+++ b/src/mcp/rmcp_server_errors_tests.rs
@@ -175,6 +175,21 @@ fn destructive_op_call_flags_generated_delete_ops() {
 }
 
 #[test]
+fn destructive_op_call_flags_non_delete_high_impact_ops() {
+    let state = plex_only_state();
+    assert!(is_destructive_op_call(
+        &state,
+        "plex_den",
+        &json!({ "op": "terminate_session" })
+    ));
+    assert!(is_destructive_op_call(
+        &state,
+        "plex_den",
+        &json!({ "op": "scan" })
+    ));
+}
+
+#[test]
 fn destructive_op_call_ignores_non_delete_ops() {
     let state = sonarr_only_state();
     assert!(!is_destructive_op_call(

--- a/src/mcp/rmcp_server_tests.rs
+++ b/src/mcp/rmcp_server_tests.rs
@@ -33,6 +33,24 @@ fn sonarr_only_state() -> AppState {
     }
 }
 
+fn plex_only_state() -> AppState {
+    let config = YarrConfig {
+        services: vec![ServiceConfig {
+            name: "plex_den".into(),
+            kind: ServiceKind::Plex,
+            base_url: "http://localhost:32400".into(),
+            token: Some("test".into()),
+            ..ServiceConfig::default()
+        }],
+    };
+    let client = YarrClient::new(&config).expect("client builds");
+    AppState {
+        config: McpConfig::default(),
+        auth_policy: AuthPolicy::LoopbackDev,
+        service: YarrService::new(client, config),
+    }
+}
+
 fn scopes(s: &[&str]) -> Vec<String> {
     s.iter().map(|x| x.to_string()).collect()
 }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -7,7 +7,7 @@ use rmcp::{RoleServer, service::Peer};
 use serde_json::{Map, Value};
 
 use crate::actions::{YarrAction, execute_service_action, required_scope_for_action};
-use crate::app::codemode::CodeModeCallGuard;
+use crate::app::codemode::{CodeModeCallGuard, FleetMapRequest};
 use crate::server::AppState;
 
 use super::schemas::YARR_TOOL_NAME;
@@ -146,6 +146,57 @@ impl CodeModeCallGuard for McpCodeModeGuard {
                 return Err(format!(
                     "destructive inner Code Mode action `{}` was not confirmed; nothing changed",
                     action.name()
+                ));
+            }
+            Ok(())
+        })
+    }
+
+    fn authorize_fleet<'a>(
+        &'a self,
+        request: &'a FleetMapRequest,
+    ) -> std::pin::Pin<Box<dyn Future<Output = Result<(), String>> + Send + 'a>> {
+        Box::pin(async move {
+            let authorization = self
+                .state
+                .service
+                .fleet_authorization(request)
+                .map_err(|error| error.to_string())?;
+            if let (Some(auth), Some(required)) = (
+                self.auth.as_ref(),
+                required_scope_for_action(authorization.scope_action),
+            ) && !crate::actions::scopes_satisfy(&auth.scopes, required)
+            {
+                return Err(format!(
+                    "forbidden fleet action `{}`: requires scope {required}",
+                    authorization.action
+                ));
+            }
+            if !authorization.destructive || authorization.targets.is_empty() {
+                return Ok(());
+            }
+            let targets = super::elicit::validate_destructive_targets(
+                &authorization.targets,
+                self.state.config.destructive_fanout_max,
+            )?;
+            if self.peer.supported_elicitation_modes().is_empty() {
+                return Err(format!(
+                    "destructive fleet action `{}` requires an elicitation-capable MCP client; nothing changed",
+                    authorization.action
+                ));
+            }
+            if super::elicit::gate_destructive(
+                &self.peer,
+                &authorization.action,
+                &targets,
+                self.state.config.destructive_fanout_max,
+            )
+            .await
+                == super::elicit::DeleteGate::Declined
+            {
+                return Err(format!(
+                    "destructive fleet action `{}` was not confirmed; nothing changed",
+                    authorization.action
                 ));
             }
             Ok(())

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -134,7 +134,13 @@ impl CodeModeCallGuard for McpCodeModeGuard {
                     action.name()
                 ));
             }
-            if super::elicit::gate_destructive(&self.peer, action.name(), service_name).await
+            if super::elicit::gate_destructive(
+                &self.peer,
+                action.name(),
+                &[service_name.to_owned()],
+                self.state.config.destructive_fanout_max,
+            )
+            .await
                 == super::elicit::DeleteGate::Declined
             {
                 return Err(format!(
@@ -161,18 +167,20 @@ fn destructive_inner_call<'a>(state: &AppState, action: &'a YarrAction) -> (bool
             .unwrap_or(YARR_TOOL_NAME),
         _ => YARR_TOOL_NAME,
     };
-    let generated_delete = match action {
-        YarrAction::Op { service, op, .. } => state
-            .service
-            .kind_of(service)
-            .ok()
-            .flatten()
-            .and_then(|kind| crate::openapi::find_operation(kind, op))
-            .is_some_and(|spec| spec.method.is_delete()),
+    let generated_destructive = match action {
+        YarrAction::Op { service, op, .. } => {
+            state
+                .service
+                .kind_of(service)
+                .ok()
+                .flatten()
+                .and_then(|kind| crate::openapi::classify_operation(kind, op))
+                == Some(crate::openapi::OperationSafety::Destructive)
+        }
         _ => false,
     };
     (
-        crate::actions::action_is_destructive(action.name()) || generated_delete,
+        crate::actions::action_is_destructive(action.name()) || generated_destructive,
         service,
     )
 }

--- a/src/mcp/tools_tests.rs
+++ b/src/mcp/tools_tests.rs
@@ -1,6 +1,40 @@
 use crate::testing::loopback_state;
 use serde_json::json;
 
+#[test]
+fn inner_codemode_guard_classifies_plex_terminate_as_destructive() {
+    use crate::{
+        actions::YarrAction,
+        app::YarrService,
+        config::{McpConfig, ServiceConfig, ServiceKind, YarrConfig},
+        server::{AppState, AuthPolicy},
+        yarr::YarrClient,
+    };
+    let config = YarrConfig {
+        services: vec![ServiceConfig {
+            name: "plex_den".into(),
+            kind: ServiceKind::Plex,
+            base_url: "http://localhost:32400".into(),
+            ..ServiceConfig::default()
+        }],
+    };
+    let state = AppState {
+        config: McpConfig::default(),
+        auth_policy: AuthPolicy::LoopbackDev,
+        service: YarrService::new(YarrClient::new(&config).unwrap(), config),
+    };
+    let action = YarrAction::Op {
+        service: "plex_den".into(),
+        op: "terminate_session".into(),
+        args: json!({}),
+    };
+
+    assert_eq!(
+        super::destructive_inner_call(&state, &action),
+        (true, "plex_den")
+    );
+}
+
 #[tokio::test]
 async fn yarr_tool_dispatches_codemode() {
     // The single `yarr` tool takes only `code` and runs it as the codemode action.

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -20,10 +20,17 @@ use crate::config::ServiceKind;
 // Generated tables (one module per spec-backed service). Each provides
 // `pub static OPERATIONS: &[OperationSpec]` and `pub static TYPES: &[TypeDef]`.
 pub mod generated;
+mod safety;
+
+pub use safety::{OperationSafety, classify_operation, operation_safety, validate_write_inventory};
 
 #[cfg(test)]
 #[path = "openapi_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "openapi/safety_tests.rs"]
+mod safety_tests;
 
 /// HTTP method for a generated upstream operation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/openapi/safety.rs
+++ b/src/openapi/safety.rs
@@ -1,0 +1,237 @@
+//! Reviewed safety classification for generated OpenAPI operations.
+//!
+//! HTTP DELETE remains an unconditional destructive trigger. The table below
+//! adds non-DELETE operations whose blast radius warrants the same MCP
+//! elicitation gate. Every other non-GET operation is a normal mutation. The
+//! reviewed write counts deliberately fail when regenerated specs add a write,
+//! forcing the new operation through review before generated docs and CI pass.
+
+use crate::config::ServiceKind;
+
+use super::OperationSpec;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OperationSafety {
+    Read,
+    Mutating,
+    Destructive,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct SafetyRow {
+    kind: ServiceKind,
+    operation: &'static str,
+}
+
+const HIGH_IMPACT_ROWS: &[SafetyRow] = &[
+    // Plex: stream termination, metadata/library-wide changes, and operations
+    // that can start expensive work across an entire server.
+    SafetyRow {
+        kind: ServiceKind::Plex,
+        operation: "terminate_session",
+    },
+    SafetyRow {
+        kind: ServiceKind::Plex,
+        operation: "edit_metadata_item",
+    },
+    SafetyRow {
+        kind: ServiceKind::Plex,
+        operation: "refresh_section",
+    },
+    SafetyRow {
+        kind: ServiceKind::Plex,
+        operation: "refresh_sections_metadata",
+    },
+    SafetyRow {
+        kind: ServiceKind::Plex,
+        operation: "scan",
+    },
+    SafetyRow {
+        kind: ServiceKind::Plex,
+        operation: "add_section",
+    },
+    SafetyRow {
+        kind: ServiceKind::Plex,
+        operation: "edit_section",
+    },
+    SafetyRow {
+        kind: ServiceKind::Plex,
+        operation: "empty_trash",
+    },
+    SafetyRow {
+        kind: ServiceKind::Plex,
+        operation: "clean_bundles",
+    },
+    SafetyRow {
+        kind: ServiceKind::Plex,
+        operation: "optimize_database",
+    },
+    // Arr command bodies can request library-wide scans/imports. Bulk editors,
+    // restore, restart, and shutdown likewise have fleet-scale blast radius.
+    SafetyRow {
+        kind: ServiceKind::Sonarr,
+        operation: "post_command",
+    },
+    SafetyRow {
+        kind: ServiceKind::Sonarr,
+        operation: "post_system_backup_restore_by_id",
+    },
+    SafetyRow {
+        kind: ServiceKind::Sonarr,
+        operation: "post_system_backup_restore_upload",
+    },
+    SafetyRow {
+        kind: ServiceKind::Sonarr,
+        operation: "post_system_restart",
+    },
+    SafetyRow {
+        kind: ServiceKind::Sonarr,
+        operation: "post_system_shutdown",
+    },
+    SafetyRow {
+        kind: ServiceKind::Sonarr,
+        operation: "put_series_editor",
+    },
+    SafetyRow {
+        kind: ServiceKind::Radarr,
+        operation: "post_command",
+    },
+    SafetyRow {
+        kind: ServiceKind::Radarr,
+        operation: "post_system_backup_restore_by_id",
+    },
+    SafetyRow {
+        kind: ServiceKind::Radarr,
+        operation: "post_system_backup_restore_upload",
+    },
+    SafetyRow {
+        kind: ServiceKind::Radarr,
+        operation: "post_system_restart",
+    },
+    SafetyRow {
+        kind: ServiceKind::Radarr,
+        operation: "post_system_shutdown",
+    },
+    SafetyRow {
+        kind: ServiceKind::Radarr,
+        operation: "put_movie_editor",
+    },
+    // Overseerr administrative job controls and full Plex synchronization.
+    SafetyRow {
+        kind: ServiceKind::Overseerr,
+        operation: "post_settings_jobs_cancel_by_job_id",
+    },
+    SafetyRow {
+        kind: ServiceKind::Overseerr,
+        operation: "post_settings_jobs_run_by_job_id",
+    },
+    SafetyRow {
+        kind: ServiceKind::Overseerr,
+        operation: "post_settings_jobs_schedule_by_job_id",
+    },
+    SafetyRow {
+        kind: ServiceKind::Overseerr,
+        operation: "post_settings_plex_sync",
+    },
+    // Jellyfin server lifecycle, library-wide work, restore, and remote session
+    // controls are high impact even though the API models them as POST.
+    SafetyRow {
+        kind: ServiceKind::Jellyfin,
+        operation: "refresh_library",
+    },
+    SafetyRow {
+        kind: ServiceKind::Jellyfin,
+        operation: "restart_application",
+    },
+    SafetyRow {
+        kind: ServiceKind::Jellyfin,
+        operation: "shutdown_application",
+    },
+    SafetyRow {
+        kind: ServiceKind::Jellyfin,
+        operation: "start_restore_backup",
+    },
+    SafetyRow {
+        kind: ServiceKind::Jellyfin,
+        operation: "start_task",
+    },
+    SafetyRow {
+        kind: ServiceKind::Jellyfin,
+        operation: "send_full_general_command",
+    },
+    SafetyRow {
+        kind: ServiceKind::Jellyfin,
+        operation: "send_general_command",
+    },
+    SafetyRow {
+        kind: ServiceKind::Jellyfin,
+        operation: "send_playstate_command",
+    },
+    SafetyRow {
+        kind: ServiceKind::Jellyfin,
+        operation: "send_system_command",
+    },
+    SafetyRow {
+        kind: ServiceKind::Jellyfin,
+        operation: "sync_play_stop",
+    },
+];
+
+// These upstream APIs incorrectly model side-effecting calls as GET.
+const MUTATING_GET_ROWS: &[SafetyRow] = &[
+    SafetyRow {
+        kind: ServiceKind::Plex,
+        operation: "add_subtitles",
+    },
+    SafetyRow {
+        kind: ServiceKind::Plex,
+        operation: "start_transcode_session",
+    },
+];
+
+const REVIEWED_WRITE_COUNTS: &[(ServiceKind, usize)] = &[
+    (ServiceKind::Sonarr, 113),
+    (ServiceKind::Radarr, 112),
+    (ServiceKind::Prowlarr, 59),
+    (ServiceKind::Overseerr, 71),
+    (ServiceKind::Jellyfin, 160),
+    (ServiceKind::Plex, 124), // 122 non-GET operations + two mutating GETs.
+];
+
+pub fn operation_safety(kind: ServiceKind, spec: &OperationSpec) -> OperationSafety {
+    if spec.method.is_delete()
+        || HIGH_IMPACT_ROWS
+            .iter()
+            .any(|row| row.kind == kind && row.operation == spec.name)
+    {
+        OperationSafety::Destructive
+    } else if !spec.method.is_read()
+        || MUTATING_GET_ROWS
+            .iter()
+            .any(|row| row.kind == kind && row.operation == spec.name)
+    {
+        OperationSafety::Mutating
+    } else {
+        OperationSafety::Read
+    }
+}
+
+pub fn classify_operation(kind: ServiceKind, operation: &str) -> Option<OperationSafety> {
+    super::find_operation(kind, operation).map(|spec| operation_safety(kind, spec))
+}
+
+pub fn validate_write_inventory() -> Result<(), String> {
+    for &(kind, reviewed_count) in REVIEWED_WRITE_COUNTS {
+        let actual_count = super::operations_for_kind(kind)
+            .iter()
+            .filter(|spec| operation_safety(kind, spec) != OperationSafety::Read)
+            .count();
+        if actual_count != reviewed_count {
+            return Err(format!(
+                "{} generated write inventory changed: reviewed {reviewed_count}, found {actual_count}; classify and audit the new operation before regenerating tool docs",
+                kind.as_str()
+            ));
+        }
+    }
+    Ok(())
+}

--- a/src/openapi/safety_tests.rs
+++ b/src/openapi/safety_tests.rs
@@ -1,0 +1,78 @@
+use super::{OperationSafety, ServiceKind, classify_operation, validate_write_inventory};
+
+#[test]
+fn plex_non_delete_high_impact_operations_are_destructive() {
+    for operation in [
+        "terminate_session",
+        "edit_metadata_item",
+        "refresh_section",
+        "scan",
+        "add_section",
+        "edit_section",
+    ] {
+        assert_eq!(
+            classify_operation(ServiceKind::Plex, operation),
+            Some(OperationSafety::Destructive),
+            "plex.{operation} must require elicitation"
+        );
+    }
+}
+
+#[test]
+fn delete_remains_an_additional_destructive_trigger() {
+    assert_eq!(
+        classify_operation(ServiceKind::Plex, "stop_all_refreshes"),
+        Some(OperationSafety::Destructive)
+    );
+    assert_eq!(
+        classify_operation(ServiceKind::Sonarr, "delete_series_by_id"),
+        Some(OperationSafety::Destructive)
+    );
+}
+
+#[test]
+fn audited_equivalent_operations_are_destructive() {
+    for (kind, operation) in [
+        (ServiceKind::Sonarr, "post_system_restart"),
+        (ServiceKind::Sonarr, "post_system_shutdown"),
+        (ServiceKind::Radarr, "post_system_restart"),
+        (ServiceKind::Radarr, "post_system_shutdown"),
+        (ServiceKind::Overseerr, "post_settings_jobs_run_by_job_id"),
+        (ServiceKind::Jellyfin, "restart_application"),
+        (ServiceKind::Jellyfin, "shutdown_application"),
+        (ServiceKind::Jellyfin, "send_playstate_command"),
+    ] {
+        assert_eq!(
+            classify_operation(kind, operation),
+            Some(OperationSafety::Destructive),
+            "{}.{} must require elicitation",
+            kind.as_str(),
+            operation
+        );
+    }
+}
+
+#[test]
+fn ordinary_writes_are_mutating_but_not_destructive() {
+    assert_eq!(
+        classify_operation(ServiceKind::Sonarr, "put_episode_by_id"),
+        Some(OperationSafety::Mutating)
+    );
+    assert_eq!(
+        classify_operation(ServiceKind::Plex, "set_rating"),
+        Some(OperationSafety::Mutating)
+    );
+}
+
+#[test]
+fn reads_are_classified_read_only() {
+    assert_eq!(
+        classify_operation(ServiceKind::Plex, "get_sessions"),
+        Some(OperationSafety::Read)
+    );
+}
+
+#[test]
+fn every_current_generated_write_matches_the_reviewed_inventory() {
+    validate_write_inventory().expect("generated write inventory must be explicitly reviewed");
+}

--- a/tests/tool_dispatch.rs
+++ b/tests/tool_dispatch.rs
@@ -260,14 +260,19 @@ async fn codemode_requires_code_param() {
 
 #[tokio::test]
 async fn snippet_list_is_a_routed_action() {
-    // The loopback stub has no data dir, so snippet_list routes to the handler and
-    // errors with a data-dir message (proving it's recognized, not "unknown action").
+    // Built-in fleet snippets remain available without a writable data dir.
     let state = loopback_state();
-    let err =
+    let listed =
         execute_tool_without_peer_for_test(&state, "sonarr", json!({ "action": "snippet_list" }))
             .await
-            .expect_err("snippet_list without a data dir should error");
-    assert!(err.to_string().contains("data dir"), "got: {err}");
+            .expect("snippet_list should expose built-ins");
+    assert!(
+        listed["snippets"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|snippet| snippet["name"] == "fleet_health" && snippet["built_in"] == true)
+    );
 }
 
 #[tokio::test]

--- a/xtask/src/tool_docs.rs
+++ b/xtask/src/tool_docs.rs
@@ -15,6 +15,7 @@ use endpoints::{
 const OUTPUT: &str = "docs/TOOLS_ACTIONS_ENDPOINTS.md";
 
 pub fn run(args: &[String]) -> Result<()> {
+    yarr::openapi::validate_write_inventory().map_err(anyhow::Error::msg)?;
     let check = args.iter().any(|arg| arg == "--check");
     let doc = render();
     let path = Path::new(OUTPUT);
@@ -199,6 +200,31 @@ client elicitation for DELETEs; clients without elicitation support fail closed.
     out.push_str(
         "\nThe generator omits an operation only when its OpenAPI serialization cannot be represented losslessly. Omitted rows are not callable through `op`; use a reviewed generic passthrough only when the service path allowlist permits it.\n\n",
     );
+    out.push_str(
+        "### Generated-operation safety coverage\n\nEvery generated operation is classified below. `destructive (elicited)` includes every DELETE plus explicitly audited high-impact non-DELETE operations. `cargo xtask tool-docs --check` fails when the reviewed write inventory changes.\n\n| Operation | Method | Safety |\n|---|---|---|\n",
+    );
+    for kind in ServiceKind::ALL
+        .iter()
+        .copied()
+        .filter(|kind| yarr::openapi::is_generated(*kind))
+    {
+        for operation in yarr::openapi::operations_for_kind(kind) {
+            let safety = match yarr::openapi::operation_safety(kind, operation) {
+                yarr::openapi::OperationSafety::Read => "read",
+                yarr::openapi::OperationSafety::Mutating => "mutating",
+                yarr::openapi::OperationSafety::Destructive => "destructive (elicited)",
+            };
+            let _ = writeln!(
+                out,
+                "| `{}.{}` | `{}` | {} |",
+                kind.as_str(),
+                operation.name,
+                operation.method.as_str(),
+                safety
+            );
+        }
+    }
+    out.push('\n');
 }
 
 fn render_capabilities(out: &mut String) {

--- a/xtask/src/tool_docs/render_tests.rs
+++ b/xtask/src/tool_docs/render_tests.rs
@@ -13,3 +13,12 @@ fn small_render_helpers_are_stable() {
     assert_eq!(yes_no(true), "yes");
     assert_eq!(yes_no(false), "no");
 }
+
+#[test]
+fn generated_operation_report_includes_reviewed_safety_classification() {
+    let rendered = render();
+    assert!(rendered.contains("`plex.terminate_session`"));
+    assert!(rendered.contains("destructive (elicited)"));
+    assert!(rendered.contains("`sonarr.get_series`"));
+    assert!(rendered.contains("read"));
+}


### PR DESCRIPTION
PR 6 of 7 in the yarr fleet-support series. Depends on #110.

## Summary
- expose fleet.of, fleet.all, fleet.map, and fleet.status without adding MCP tool schemas
- capture one service method in JavaScript and execute host-backed fanout with configurable concurrency and per-instance deadlines
- isolate upstream failures and return stable name-sorted ok/value or ok/error rows with explicit truncation state
- authorize destructive fanout once over the aggregate target set, enforce the hard cap before dispatch, and preserve per-instance read-only policy
- ship immutable fleet_activity, fleet_health, fleet_library_sizes, and fleet_transcode_load snippets

## Verification
A 20-instance test returns 19 successes plus one dead-host error in under ten seconds. Additional tests cover stable inventory, host-bridge dispatch, ordering, timeout isolation, destructive classification, and built-in snippets. Full Rust, parity, generated-doc, formatting, Clippy, and documentation-link gates pass.

## Stacking note
This fork-based PR targets upstream main and temporarily contains #106-#110. Review the isolated change as codex/fleet-05-plex-discovery..codex/fleet-06-fanout.