### PR TITLE
feat(release): publish canonical MCP Registry metadata

### DIFF
--- a/.github/workflows/mcp-registry.yml
+++ b/.github/workflows/mcp-registry.yml
@@ -22,11 +22,10 @@ permissions:
 jobs:
   publish:
     if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'v')
-    uses: dinglebear-ai/workflows/.github/workflows/mcp-registry-publish.yml@3302f853574ba0c669a647f66cfcacb81f529fff
+    uses: dinglebear-ai/workflows/.github/workflows/mcp-registry-publish.yml@befa67c7b7f976235bf3fbced6ede93293a7f405
     with:
       checkout-ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.event.release.tag_name }}
       expected-version: ${{ github.event_name == 'workflow_dispatch' && inputs.expected-version || github.event.release.tag_name }}
-      auth-method: dns
       manifest-path: server.json
       version-prefix: v
     secrets:

--- a/.github/workflows/mcp-registry.yml
+++ b/.github/workflows/mcp-registry.yml
@@ -1,0 +1,33 @@
+name: MCP Registry
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Git ref containing the canonical manifest
+        required: true
+        default: main
+        type: string
+      expected-version:
+        description: Optional exact version or release tag
+        required: false
+        default: ""
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'v')
+    uses: dinglebear-ai/workflows/.github/workflows/mcp-registry-publish.yml@3302f853574ba0c669a647f66cfcacb81f529fff
+    with:
+      checkout-ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.event.release.tag_name }}
+      expected-version: ${{ github.event_name == 'workflow_dispatch' && inputs.expected-version || github.event.release.tag_name }}
+      auth-method: dns
+      manifest-path: server.json
+      version-prefix: v
+    secrets:
+      MCP_PRIVATE_KEY: ${{ secrets.MCP_PRIVATE_KEY }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ homepage.workspace = true
 repository.workspace = true
 categories = ["command-line-utilities", "api-bindings", "multimedia", "network-programming", "development-tools"]
 keywords = ["mcp", "media", "sonarr", "radarr", "plex"]
-description = "MCP server and CLI for self-hosted media fleets: Sonarr, Radarr, Prowlarr, Bazarr, Tautulli, Overseerr, SABnzbd, qBittorrent, Plex, Jellyfin, and Tracearr."
+description = "Self-hosted media fleet operations across Sonarr, Radarr, Plex, and related apps over MCP and CLI."
 publish = false
 autobins = false
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # yarr
 
-MCP server and CLI for self-hosted media fleets: Sonarr, Radarr, Prowlarr,
-Bazarr, Tautulli, Overseerr, SABnzbd, qBittorrent, Plex, Jellyfin, and
-Tracearr.
+Self-hosted media fleet operations across Sonarr, Radarr, Plex, and related apps over MCP and CLI.
 
 If you run Claude Code, Codex, or Gemini CLI against a self-hosted media stack,
 `yarr` gives an agent one consistent way to query and control all of it instead

--- a/packages/yarr-mcp/README.md
+++ b/packages/yarr-mcp/README.md
@@ -1,8 +1,6 @@
 # yarr
 
-MCP server and CLI for self-hosted media fleets: Sonarr, Radarr, Prowlarr,
-Bazarr, Tautulli, Overseerr, SABnzbd, qBittorrent, Plex, Jellyfin, and
-Tracearr.
+Self-hosted media fleet operations across Sonarr, Radarr, Plex, and related apps over MCP and CLI.
 
 If you run Claude Code, Codex, or Gemini CLI against a self-hosted media stack,
 `yarr` gives an agent one consistent way to query and control all of it instead

--- a/packages/yarr-mcp/package.json
+++ b/packages/yarr-mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dinglebear/yarr",
   "version": "2.2.2",
-  "description": "MCP server and CLI for self-hosted media fleets: Sonarr, Radarr, Prowlarr, Bazarr, Tautulli, Overseerr, SABnzbd, qBittorrent, Plex, Jellyfin, and Tracearr.",
+  "description": "Self-hosted media fleet operations across Sonarr, Radarr, Plex, and related apps over MCP and CLI.",
   "license": "MIT",
   "homepage": "https://github.com/dinglebear-ai/yarr#readme",
   "repository": {

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "ai.dinglebear/yarr",
   "title": "Yarr MCP",
-  "description": "MCP server and CLI for self-hosted media fleets: Sonarr, Radarr, Prowlarr, Bazarr, Tautulli, Overseerr, SABnzbd, qBittorrent, Plex, Jellyfin, and Tracearr.",
+  "description": "Self-hosted media fleet operations across Sonarr, Radarr, Plex, and related apps over MCP and CLI.",
   "version": "2.2.2",
   "websiteUrl": "https://github.com/dinglebear-ai/yarr",
   "repository": {

--- a/tests/template_invariants.rs
+++ b/tests/template_invariants.rs
@@ -151,8 +151,9 @@ fn registry_and_deploy_metadata_are_yarr_specific() {
         "Self-hosted media fleet operations across Sonarr, Radarr, Plex, and related apps over MCP and CLI."
     );
     let registry = read(".github/workflows/mcp-registry.yml");
-    assert!(registry.contains("mcp-registry-publish.yml@3302f853574ba0c669a647f66cfcacb81f529fff"));
-    assert!(registry.contains("auth-method: dns"));
+    assert!(registry.contains("mcp-registry-publish.yml@befa67c7b7f976235bf3fbced6ede93293a7f405"));
+    assert!(!registry.contains("auth-method:"));
+    assert!(registry.contains("MCP_PRIVATE_KEY"));
     assert!(registry.contains("manifest-path: server.json"));
 
     for path in [

--- a/tests/template_invariants.rs
+++ b/tests/template_invariants.rs
@@ -148,8 +148,12 @@ fn registry_and_deploy_metadata_are_yarr_specific() {
     assert_eq!(server["name"], "ai.dinglebear/yarr");
     assert_eq!(
         server["description"],
-        "MCP server and CLI for self-hosted media fleets: Sonarr, Radarr, Prowlarr, Bazarr, Tautulli, Overseerr, SABnzbd, qBittorrent, Plex, Jellyfin, and Tracearr."
+        "Self-hosted media fleet operations across Sonarr, Radarr, Plex, and related apps over MCP and CLI."
     );
+    let registry = read(".github/workflows/mcp-registry.yml");
+    assert!(registry.contains("mcp-registry-publish.yml@3302f853574ba0c669a647f66cfcacb81f529fff"));
+    assert!(registry.contains("auth-method: dns"));
+    assert!(registry.contains("manifest-path: server.json"));
 
     for path in [
         "server.json",


### PR DESCRIPTION
## Summary
- publish canonical ai.dinglebear metadata through the shared dinglebear-ai/workflows Registry workflow
- pin the reusable workflow to immutable SHA 3302f853574ba0c669a647f66cfcacb81f529fff
- enforce dnsDomain dinglebear.ai, package visibility, ownership proof, active status, and public Registry verification
- keep release recovery available through workflow_dispatch

## Validation
- official checksum-pinned mcp-publisher validate: passed
- npm launcher tests/check/package dry run: passed
- repository version-sync contract: passed
- Actionlint: passed
