### PR TITLE
fix(compose): make env and bindings configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,9 @@
 #   cp .env.example .env
 #   # Edit .env — fill in real values
 #   # .env is in .gitignore; never commit it
+#
+# Compose-only override (set in your shell or the project-level .env):
+# YARR_ENV_FILE=${HOME}/.yarr/.env
 # =============================================================================
 
 # ── Media automation services ────────────────────────────────────────────────

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Allow Compose deployments to select the service env file with `YARR_ENV_FILE`.
+- Bind the production MCP port only to DOOKIE's Tailscale and LAN addresses instead of every host interface.
+
 ## [2.2.2](https://github.com/dinglebear-ai/yarr/compare/v2.2.1...v2.2.2) (2026-07-29)
 
 

--- a/docker-compose.common.yml
+++ b/docker-compose.common.yml
@@ -21,14 +21,15 @@ services:
         max-file: "3"
         compress: "true"
     env_file:
-      - path: .env
+      - path: ${YARR_ENV_FILE:-${HOME}/.yarr/.env}
         required: true
     environment:
       YARR_MCP_HOST: 0.0.0.0
       YARR_MCP_ALLOWED_HOSTS: "yarr.dinglebear.ai,yarr.tootie.tv,localhost,127.0.0.1"
       YARR_MCP_ALLOWED_ORIGINS: "https://yarr.dinglebear.ai,https://yarr.tootie.tv"
     ports:
-      - "${YARR_MCP_HOST_PORT:-40070}:40070/tcp"
+      - "100.88.16.79:${YARR_MCP_HOST_PORT:-40070}:40070/tcp"
+      - "10.1.0.6:${YARR_MCP_HOST_PORT:-40070}:40070/tcp"
     volumes:
       - ${HOME}/.yarr:/data
     # cap_drop:


### PR DESCRIPTION
## Summary

- allow the Compose env-file path to be selected through YARR_ENV_FILE
- default the env file to HOME/.yarr/.env
- bind the production MCP port to DOOKIE's Tailscale and LAN addresses
- document the override in .env.example and CHANGELOG.md

## Validation

- both addresses are assigned on DOOKIE
- docker compose config --no-interpolate --quiet
- cargo fmt --all -- --check on the original change head
- git diff --check
