### PR TITLE
ci: pin Kache v0.13.0

### DIFF
--- a/.github/actions/setup-rust-kache/action.yml
+++ b/.github/actions/setup-rust-kache/action.yml
@@ -94,7 +94,7 @@ runs:
           fi
         done
 
-    # Pinned exactly. The private fleet and hosted CI share the 0.12.0 S3
+    # Pinned exactly. The private fleet and hosted CI share the 0.13.0 S3
     # object layout and daemon protocol. Floating this version could split cache
     # epochs or layouts without an obvious workflow failure. Bump deliberately,
     # never via tag drift.
@@ -102,7 +102,7 @@ runs:
       if: inputs.enable-cache == 'true' && runner.os == 'Linux'
       shell: bash
       env:
-        KACHE_VERSION: "0.12.0"
+        KACHE_VERSION: "0.13.0"
       run: |
         set -euo pipefail
         # Reuse any already-installed binary at the pinned version. Persistent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* **ci:** pin the shared Rust cache action to upstream Kache 0.13.0 so hosted and self-hosted jobs use the same daemon protocol and S3 cache epoch
 * **deps:** pin `rmcp` to an exact `=3.0.0-beta.2` (was a caret `"2.1.0"` that had already drifted to `2.2.0` in the lockfile). `ServerHandler::call_tool`/`read_resource`/`get_prompt` now return the `CallToolResponse`/`ReadResourceResponse`/`GetPromptResponse` wrappers, and `StreamableHttpServerConfig::with_stateful_mode` is now `with_legacy_session_mode`; both are behaviour-preserving. The elicitation API is unchanged, so destructive-delete gating stays fail-closed
 
 ### Removed


### PR DESCRIPTION
## Summary

- pin the shared Rust cache action to upstream Kache v0.13.0
- keep hosted and self-hosted jobs on the same daemon protocol and S3 cache epoch
- preserve the existing MinIO credential detection, config ownership, fallback, and cache-gate behavior

## Verification

- composite action YAML parsed and validated
- `scripts/kache-gate-selftest.sh` passed against Kache v0.13.0
- `git diff --check`

Upstream v0.13.0 includes the speculative-prefetch controls merged in kunobi-ninja/kache#649.