### PR TITLE
fix(compose): keep selected env file optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Keep the configurable Compose env file optional so local and validation deployments do not require a host-specific file.
+
 ### Changed
 
 - Allow Compose deployments to select the service env file with `YARR_ENV_FILE`.

--- a/docker-compose.common.yml
+++ b/docker-compose.common.yml
@@ -22,7 +22,7 @@ services:
         compress: "true"
     env_file:
       - path: ${YARR_ENV_FILE:-${HOME}/.yarr/.env}
-        required: true
+        required: false
     environment:
       YARR_MCP_HOST: 0.0.0.0
       YARR_MCP_ALLOWED_HOSTS: "yarr.dinglebear.ai,yarr.tootie.tv,localhost,127.0.0.1"


### PR DESCRIPTION
## Summary

- keep the configurable YARR_ENV_FILE path optional
- restore local and production Compose validation when the host-specific env file is absent
- document the correction in CHANGELOG.md

## Validation

- docker compose config for local and production files
- scripts/test-template-features.sh: 12 passed, 0 failed
- git diff --check