### PR TITLE
fix(release): give xtask a literal version so release-please can walk the workspace

### DIFF
--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -13,7 +13,13 @@
 
 [package]
 name = "xtask"
-version.workspace = true
+# Literal, NOT version.workspace = true. release-please's Rust updater walks
+# every workspace member and rewrites `package.version` in place; an inherited
+# version has no literal value to write, so the whole run dies with
+# "value at path package.version is not tagged". This crate is publish = false
+# and nothing consumes its version, so a literal that release-please maintains
+# is the cheapest way to keep the workspace walkable.
+version = "2.2.2"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION
## The failure
release-please has failed on **every** main push since at least 2026-08-04:

```
❯ Fetching xtask/Cargo.toml from branch main
##[error]release-please failed: value at path package.version is not tagged
```

Consequence: no release PR has been opened despite releasable commits landing. This predates the CI-audit work — run on `f7cfe033` (Aug 4) failed identically.

## Cause
`release-type: rust` makes release-please walk every `[workspace] members` entry and rewrite `package.version` in place. `xtask/Cargo.toml` declared `version.workspace = true`, and an **inherited** version has no literal value to rewrite, so the run aborts.

This is the known upstream limitation with Cargo workspace inheritance — the same one axon's `CLAUDE.md` documents (`googleapis/release-please` cannot handle `version.workspace = true`), which is why axon removed `.` from release-please management entirely.

## Fix
Pin `xtask` to a literal `2.2.2` and let release-please maintain it from here. This is safe because xtask:
- is `publish = false` (private automation crate)
- is **not** referenced by `scripts/check-version-sync.sh` or `scripts/bump-version.sh`
- has a version nothing consumes

`check-version-sync.sh` still reports **all 5 tracked files at v2.2.2** — xtask is not one of them, so the version contract is unaffected.

## What this does not fix, and how you'll know
The root package also declares `version.workspace = true`. In the failing log, member `.` produced only a warning (`⚠ member . declared but did not find Cargo.toml`) and execution continued — xtask was the hard failure. So this should be sufficient, but **it is unverified until the next release-please run on main**, because there is no dry-run mode for this action.

If `.` then fails the same way, the next step is axon's precedent: drop `.` from `release-please-config.json` / `.release-please-manifest.json` and bump the root manually.

## Unrelated observation
The audit merge `83bc8d1` landed with a non-conventional squash subject (`CI audit: …`), which release-please logs as `unexpected token ' ' at 1:3`. That's cosmetic next to the fatal error above — it just means that commit contributes nothing to the changelog. This repo squashes using the **PR title** when a PR has multiple commits, so conventional PR titles matter here.