### PR TITLE
fix(ci): remove leaked internal identifiers from setup-rust-kache

### DIFF
--- a/.github/actions/setup-rust-kache/action.yml
+++ b/.github/actions/setup-rust-kache/action.yml
@@ -29,9 +29,15 @@ inputs:
     required: false
     default: ""
   s3-endpoint:
-    description: S3-compatible endpoint used when credentials are supplied.
+    description: >-
+      S3-compatible endpoint used when credentials are supplied. Intentionally
+      has NO default: this repository is public, and a real endpoint hostname
+      here would publish internal infrastructure. Every caller that supplies
+      credentials also passes ${{ vars.KACHE_S3_ENDPOINT }}, so the value lives
+      in org variables, not in source. An empty value means callers fall back
+      to local-only caching.
     required: false
-    default: "https://s3.tootie.tv"
+    default: ""
   s3-bucket:
     description: S3 bucket containing the shared cache.
     required: false
@@ -224,12 +230,12 @@ runs:
         [cache.remote]
         type = "s3"
         bucket = "kache"
-        endpoint = "http://10.1.0.2:9000"
+        endpoint = "http://192.0.2.2:9000"
         region = "us-east-1"
         prefix = "rust"
         profile = "kache"
         TOML
-          echo "kache remote: s3://kache/rust via Tootie MinIO"
+          echo "kache remote: s3://kache/rust via Nashost MinIO"
         else
           cat > "$config_file" <<TOML
         [cache]


### PR DESCRIPTION
This repository is public (`gh api repos/dinglebear-ai/yarr --jq .private` -> `false`).
Three internal identifiers were committed in
`.github/actions/setup-rust-kache/action.yml`.

## What was leaked, and by which PR

Attributed with `git log -S '<string>' -- <file>`, not guessed.

| line | content | introduced by |
|---|---|---|
| 34 | `default: "https://s3.tootie.tv"` | [#119](https://github.com/dinglebear-ai/yarr/pull/119) `CI audit: dependabot watcher, docker-publish gating, cache + MSRV fixes` (`83bc8d1`) |
| 227 | `endpoint = "http://10.1.0.2:9000"` | [#105](https://github.com/dinglebear-ai/yarr/pull/105) `fix(ci): preserve existing Kache config` (`33904cd`) |
| 232 | `echo "kache remote: s3://kache/rust via Tootie MinIO"` | [#105](https://github.com/dinglebear-ai/yarr/pull/105) |

## Why the `s3-endpoint` default is safe to drop

The input is consumed in exactly one place — the branch guarded by
`[ -n "$KACHE_S3_ACCESS_KEY" ] && [ -n "$KACHE_S3_SECRET_KEY" ]`. Only one
caller supplies those keys, and it passes the endpoint explicitly:

```
.github/workflows/release.yml:107   s3-access-key: ${{ secrets.KACHE_S3_ACCESS_KEY }}
.github/workflows/release.yml:108   s3-secret-key: ${{ secrets.KACHE_S3_SECRET_KEY }}
.github/workflows/release.yml:109   s3-endpoint:   ${{ vars.KACHE_S3_ENDPOINT }}
```

The other four call sites (`ci.yml` x3, `msrv.yml`) pass no `s3-*` inputs at
all, so the credential branch is never entered and the default is never read.
The org variable `KACHE_S3_ENDPOINT` exists and is scoped to this repository,
so the real value is already supplied out of band.

## Why the `10.1.0.2` block is dead, with evidence

Three branches can write `~/.config/kache/config.toml`, in order:

1. an existing config is present -> leave it alone;
2. S3 credentials were supplied -> write `$KACHE_S3_ENDPOINT`;
3. `~/.aws/credentials` contains a `[kache]` profile -> write the hardcoded endpoint.

Branch 3 requires a runner with **no** existing kache config **and** a host
`[kache]` AWS profile. That combination does not occur on this fleet. Every
self-hosted job in recent runs takes branch 1:

```
$ gh run view 31059612087 --log | grep 'existing kache config present'
Clippy          ... existing kache config present - leaving it alone
Repo Contracts  ... existing kache config present - leaving it alone
Test            ... existing kache config present - leaving it alone
```

Sweeping the last 8 runs of this repo for the branch-3 marker
(`kache remote: s3://kache/rust via Tootie MinIO`) returns **zero** hits.
The same sweep on `cortex` also returns zero. Meanwhile the hosted path on
`axon` prints branch 2 resolving through the org variable
(`kache remote: s3://kache/rust via https://s3.tootie.tv`), confirming the
live path is branch 2, not branch 3.

`soma` `main` already carries `192.0.2.2` / `"Nashost MinIO"` in this exact
block (scrubbed in soma#325, merged, CI green afterwards), and `axon` `main`
carries it too. This change makes yarr match.

**Stated tradeoff:** this is a scrub of a code path that is dead today, not of
a live endpoint. If a runner ever did hit branch 3, it would now point at a
documentation address; kache fails open, so the result would be an uncached
(slow, green) build rather than a failure. That is the same tradeoff soma and
axon already accepted. Nothing that runs today loses its cache.

## Verification

- `actionlint` clean in every repo touched.
- `yaml.safe_load` parses the action; `s3-endpoint.default` is now `""`.
- Re-read the file back from the pushed remote branch and grepped it: no
  `tootie`, no `10.1.0.2` left under `.github/`.

## Gates

`lefthook.yml` in this repo declares no `pre-push` hook, so the push ran no
local gates. The change touches only `.github/` YAML and comments and cannot
affect compilation; CI on this PR is the gate.

## Not changed

- `KACHE_VERSION` is untouched (still `0.13.0`).
