### PR TITLE
fix(docker): match builder to Rust 1.97.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Pin the container builder to Rust 1.97.1 and enforce parity with the repository toolchain.
 - Keep the configurable Compose env file optional so local and validation deployments do not require a host-specific file.
 
 ### Changed

--- a/config/Dockerfile
+++ b/config/Dockerfile
@@ -8,10 +8,10 @@
 # =============================================================================
 
 # ── Stage 1: Builder ──────────────────────────────────────────────────────────
-# Builder uses Rust 1.97 (>= the declared MSRV of 1.90). The multi-platform
-# manifest digest was resolved from Docker Hub on 2026-07-16; Dependabot should
-# propose deliberate digest refreshes.
-FROM rust:1.97-slim-bookworm@sha256:6d220bf85c74e842a79da63997af8d2e74455c0b8847d8bb3a5888572334991d AS builder
+# Builder matches the exact toolchain declared in rust-toolchain.toml. The
+# multi-platform manifest digest was resolved from Docker Hub on 2026-08-14;
+# Dependabot should propose deliberate digest refreshes.
+FROM rust:1.97.1-slim-bookworm@sha256:2775a09d208ff0d7c1f50490c45b62db929e87ba1dcbc3f2132ac71a704bcdd3 AS builder
 
 WORKDIR /app
 

--- a/tests/template_invariants.rs
+++ b/tests/template_invariants.rs
@@ -31,6 +31,21 @@ fn json(path: &str) -> Value {
 }
 
 #[test]
+fn docker_builder_matches_pinned_rust_toolchain() {
+    let toolchain = read("rust-toolchain.toml");
+    let channel = toolchain
+        .lines()
+        .find_map(|line| line.trim().strip_prefix("channel = \"")?.strip_suffix('"'))
+        .expect("rust-toolchain.toml should declare a quoted channel");
+    let dockerfile = read("config/Dockerfile");
+
+    assert!(
+        dockerfile.contains(&format!("FROM rust:{channel}-slim-bookworm@sha256:")),
+        "config/Dockerfile builder must use the exact pinned Rust toolchain {channel}"
+    );
+}
+
+#[test]
 fn agent_memory_files_are_claude_symlinks() {
     for path in ["AGENTS.md", "GEMINI.md"] {
         let target = fs::read_link(path).unwrap_or_else(|err| panic!("{path}: {err}"));


### PR DESCRIPTION
## Summary
- pin the Docker builder to the repository's Rust 1.97.1 toolchain
- add an invariant preventing Docker/toolchain drift
- document the pipeline fix

## Root cause
The nightly Docker Publish workflow resolved `rust:1.97-slim-bookworm` to rustc 1.97.0 after the repository MSRV moved to 1.97.1, so Cargo rejected the build before the image could be scanned or promoted.

## Verification
- `cargo fmt --check`
- `cargo test --locked --test template_invariants`
- `bash scripts/check-coupled-files.sh origin/main WORKTREE`
- `git diff --check`
- `docker build --progress=plain --target builder -f config/Dockerfile -t yarr-pipeline-fix:builder .`

Closes #86