### PR TITLE
ci: pin Kache v0.15.1

### DIFF
--- a/.github/actions/setup-rust-kache/action.yml
+++ b/.github/actions/setup-rust-kache/action.yml
@@ -121,7 +121,7 @@ runs:
           fi
         done
 
-    # Pinned exactly. The private fleet and hosted CI share the 0.13.0 S3
+    # Pinned exactly. The private fleet and hosted CI share the 0.15.1 S3
     # object layout and daemon protocol. Floating this version could split cache
     # epochs or layouts without an obvious workflow failure. Bump deliberately,
     # never via tag drift.
@@ -129,7 +129,7 @@ runs:
       if: inputs.enable-cache == 'true' && runner.os == 'Linux'
       shell: bash
       env:
-        KACHE_VERSION: "0.13.0"
+        KACHE_VERSION: "0.15.1"
       run: |
         set -euo pipefail
         # Reuse any already-installed binary at the pinned version. Persistent


### PR DESCRIPTION
Bumps the pinned `KACHE_VERSION` in `setup-rust-kache` to **0.15.1**.

kache 0.15.1 is the current fleet version — the mise global pin is `github:kunobi-ninja/kache = "0.15.1"`, the host binary reports 0.15.1, and upstream [v0.15.1](https://github.com/kunobi-ninja/kache/releases/tag/v0.15.1) was released 2026-08-24.

The action's own comment is why this lands fleet-wide at once: the private fleet and hosted CI must share one S3 object layout and daemon protocol, and a mixed fleet splits cache epochs without an obvious workflow failure. Companion PRs go up in the other Rust repos using this action.

Version-only change — the comment line and the `KACHE_VERSION` env var. No other edits.