### PR TITLE
chore(kache): pin kache 0.15.1

### DIFF
--- a/.github/actions/setup-rust-kache/action.yml
+++ b/.github/actions/setup-rust-kache/action.yml
@@ -121,7 +121,7 @@ runs:
           fi
         done
 
-    # Pinned exactly. The private fleet and hosted CI share the 0.13.0 S3
+    # Pinned exactly. The private fleet and hosted CI share the 0.15.1 S3
     # object layout and daemon protocol. Floating this version could split cache
     # epochs or layouts without an obvious workflow failure. Bump deliberately,
     # never via tag drift.
@@ -129,7 +129,7 @@ runs:
       if: inputs.enable-cache == 'true' && runner.os == 'Linux'
       shell: bash
       env:
-        KACHE_VERSION: "0.13.0"
+        KACHE_VERSION: "0.15.1"
       run: |
         set -euo pipefail
         # Reuse any already-installed binary at the pinned version. Persistent


### PR DESCRIPTION
Bumps the CI kache pin to **0.15.1**.

### Verified against the 0.15.1 binary before bumping

| Risk from the 0.14/0.15 notes | Result |
|---|---|
| 0.15.0 stops auto-started daemons inheriting `KACHE_S3_*` | Unaffected — the remote is written into `[cache.remote]` in `config.toml`, which is what the upgrade note prescribes |
| 0.15.0 versioned the report JSON schema | Unaffected — `kache-gate.sh` already reads `.summary.*`; ran its real jq pipeline against 0.15.1 output |
| CI-written config keys rejected | `local_store`, `daemon_idle_timeout_secs`, `prefetch_max_bytes`, `local_max_size` all accepted, no unknown-key warnings |

### Notes

- The cache-key schema reaches **v27**, so pre-0.14 entries cold-miss and are eligible for reclamation.
- Runner images ship no systemd `kache.service`, so the action owns the daemon and client/daemon versions always match — no version-split risk.